### PR TITLE
fix(community): resolve CI FAIL in Sannai v2.9 (11.12 table/interest-garden)

### DIFF
--- a/docs/resolver/hermes-memory-os-optimization-roadmap.md
+++ b/docs/resolver/hermes-memory-os-optimization-roadmap.md
@@ -819,6 +819,28 @@ Sannai: 流萤～今天的蝴蝶停在叶子上好久
 | Mailbox direct letter | ✅ 信已写入 `/agents/hermes/inbox/` |
 | Family-room message | ✅ 消息已发布到 family-room 消息目录 |
 
+#### 11.12.7 工程复审：CI 修复与实现落差记录（2026-07-29，代码复审）
+
+> **审查注**：11.12/11.12.6 落地时 GitHub CI 处于 FAIL 状态（`write_surface_check`
+> 8 处未分类写入 + 一条 `partner_create` 测试断言过期），11.12.6 的"全部通路连通"
+> 描述的是功能手测，不代表 CI 绿。本节记录 CI 修复与复审中发现的实现落差——能安全修的
+> 已修（CI 红、字符编码、测试覆盖），涉及生产部署契约的改动只记录、不重构。
+
+| # | 发现 | 状态 | 处理 |
+|---|---|---|---|
+| 1 | CI FAIL：`community_table.py`/`community_partner_runtime.py`/`community_partner_reply.py` 新增 8 处写入未在 `write_surface_check.py` 登记 | 已修复 | 登记为 `community_table_bounded_shared_surface`/`community_partner_private_notes_log`/`community_partner_private_replies_log` 等；`sannai__{pid}.jsonl` 直写单独标注见 #6 |
+| 2 | CI FAIL：`test_create_partner_requires_real_partner_profile_config` 断言旧错误文案 | 已修复 | embedded_mode 分支加入后错误文案改为「...in non-embedded mode」以区分两种失败模式（embedded 缺 `backend_info` vs. 非 embedded 缺 `partner_config_path`），测试断言同步更新 |
+| 3 | `community_table.py`、`community_interest_garden.py`、`scripts/community_partner_reply.py`、`scripts/community_monitor.py` 多处 `open()`/`write_text()`/`read_text()` 处理中文内容未显式声明 `encoding="utf-8"` | 已修复 | 全部显式加 `encoding="utf-8"`，与项目既有约定一致；本机（Windows，默认 locale 已是 UTF-8）与 CI（Linux）均无法构造出反事实 FAIL，判定同 BO 记录的"无法反事实"类修复——纯 portability 加固，非行为回归 |
+| 4 | **实现落差**：11.12.1/11.12.3 描述的 `community_table.py`/`community_interest_garden.py` 是纯 stdlib、零相对导入的模块，但零调用方、零测试；真正跑在 cron 上的是 `scripts/community_partner_reply.py`，它内联重写了同一逻辑而非 import 这两个模块（连同 `community_partner_runtime.py`——11.11.3 记录的"唯一净新增模块"，同样零调用方、零测试） | 仅记录，不重构 | 三个模块与实际线上路径完全脱节；改 import 会改变 `community_partner_reply.py` 的部署契约（当前自包含、无 PYTHONPATH 依赖，模块级代码在 import 时即执行生产 config/roster 读取），本次复审不具备验证宿主环境的条件，不动。后续收口二选一：(a) cron 脚本改为 import 三个模块并验证部署契约；(b) 明确废弃三个模块并删除 |
+| 5 | 因 #4，两份 `_extract_topics()` 已分叉：模块版覆盖 声音/草/树/虫/河/幻想，脚本版覆盖 是不是/风/雪，关键词集合不再一致 | 仅记录 | 跟随 #4 一并处理 |
+| 6 | 因 #4，`community_table.py::write_to_table()` 的"每人每小时 ≤5 条"限流（11.12.1 文档承诺的约束）只存在于未被调用的模块里；实际写入路径 `scripts/community_partner_reply.py::_write_table()` 完全没有限流。同一脚本对 `community/shared/sannai__{pid}.jsonl` 直接 `open().write()`，绕开了 `community_shared.py::write_shared_memory()` 的 `actor=="sannai"` 门控——两条路径通向同一文件，一条有治理一条没有 | 仅记录 | 该脚本零测试覆盖、模块级代码 import 时即执行（读取生产 config/roster、可 `sys.exit`），本次复审无法在沙箱内安全验证补丁；写入路径本身已在 write_surface_check 登记为 `community_shared_projection_cron_direct_ungoverned_duplicate` 以保留可见性，收口留给 #4 |
+| 7 | `community_snapshot.py::build_community_snapshot()` 新增的 `unread_partner_replies`/`partner_reply_breakdown` 用 `count(replies.jsonl 行数) − cursor(state.json，实为 sannai_says.jsonl 的读取游标)` 计算"未读回复"——两个计数器语义无关（cursor 从不追踪 replies 被谁读过），该字段当前恒近似 0 或无意义 | 仅记录 | grep 全仓库确认当前无任何消费者读取这两个字段，尚未造成误导；真正修复需要新增"回复已读游标"，属功能缺口而非 bug，不在本次范围内新增 |
+
+新增测试：`tests/plugins/memory/test_memory_os_community_table_and_interest_garden.py`
+（`write_to_table`/`read_table`/`get_unread_shares`/`update_interests`/`get_interests_summary`
+的中文内容往返 + 限流边界），补齐 #4 中两个此前零覆盖模块（`community_table.py`、
+`community_interest_garden.py`）的基础测试。
+
 ---
 
 ## 12. 发布与部署强制流程

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -913,6 +913,67 @@ BC 评审 15 项至此全部完成（P0×3 → BD，P1×4 → BE，P2×3 → BF�
 
 ---
 
+## BP — 复审 Sannai v2.9 提交（11.12 窗台/一起看/兴趣花园）：CI 修复 + 落差记录（2026-07-29）
+
+- **触发**：用户要求同步 GitHub 最新提交并审查 `docs/resolver/hermes-memory-os-optimization-roadmap.md`
+  的最新 Sannai 提交（`0897e5b` "11.12 小院子的新角落"、`609bc40` "社区通路全部测试通过"）。
+  同步后本地 GitHub Actions `Memory-OS CI` 对这两个提交均为 FAIL。
+- **根因**（两项 CI FAIL）：
+  1. `write_surface_check`：新增的 `community_table.py`、`community_partner_runtime.py`
+     （11.11.3 记录的"唯一净新增模块"，本次复审确认零调用方零测试）、
+     `scripts/community_partner_reply.py` 共新增 8 处直接文件写入
+     （`open(..., "a")` / `atomic_json_replace_call`），未在 `ALLOWED_WRITE_SURFACES`
+     登记，`unclassified_count` 从 0 变为 8。
+  2. `partner_create.py::create_partner()` 的 embedded_mode 分支加入后，非 embedded 分支的
+     错误文案从 `"partner profile config required"` 改为
+     `"partner profile config required in non-embedded mode"`（用于区分 embedded 缺
+     `backend_info` 与非 embedded 缺 `partner_config_path` 两种失败），但
+     `test_create_partner_requires_real_partner_profile_config` 断言未同步更新——文案改动
+     合理，测试是陈旧的。
+- **修复**：
+  1. 8 处写入按既有先例逐一登记分类（`community_partner_private_runtime_state`/
+     `_notes_log`/`_replies_log`、`community_table_bounded_shared_surface`），其中
+     `scripts/community_partner_reply.py` 对 `sannai__{pid}.jsonl` 的直写单独标注为
+     `community_shared_projection_cron_direct_ungoverned_duplicate`（见下方落差 #4/#6）。
+  2. 测试断言同步为新文案。
+  3. 顺带修复：`community_table.py`、`community_interest_garden.py`、
+     `scripts/community_partner_reply.py`、`scripts/community_monitor.py` 中处理中文内容的
+     `open()`/`write_text()`/`read_text()` 调用普遍缺失显式 `encoding="utf-8"`（依赖 locale
+     默认编码），与项目既有约定不一致，全部补齐。
+- **反事实覆盖**：CI 修复两项均有直接反事实——revert 8 处分类登记 → `write_surface_check`
+  确定性 FAIL（`unclassified_count=8`）；revert 测试文案 → 确定性 FAIL（旧文案 assertion）；
+  均已用 `git stash` 实测验证 revert→FAIL、restore→PASS。`encoding="utf-8"` 修复本身
+  **无法**构造反事实——本机（Windows）与 CI（Linux）的 `locale.getpreferredencoding(False)`
+  均已是 UTF-8，revert 后新增的往返测试仍然 PASS（已用 `git stash` 实测确认），判定同 BO
+  记录的"无法反事实"类修复，纯 portability 加固，非行为回归。
+- **实现落差记录**（仅记录，未改动，详见路线图 11.12.7）：`community_table.py`/
+  `community_interest_garden.py`/`community_partner_runtime.py` 三个模块零调用方、零测试，
+  实际跑在 cron 上的 `scripts/community_partner_reply.py` 是内联重写的独立副本——
+  `_extract_topics()` 关键词集合已分叉；11.12.1 文档承诺的"每人每小时 ≤5 条"限流只存在于
+  未被调用的 `community_table.py` 里，脚本的 `_write_table()` 无限流；脚本对
+  `sannai__{pid}.jsonl` 的直写绕开了 `community_shared.write_shared_memory()` 的
+  `actor=="sannai"` 门控。三处均未改动——`scripts/community_partner_reply.py` 是零测试覆盖、
+  模块级代码 import 时即执行生产 config/roster 读取的自包含 cron 脚本，本次复审不具备验证
+  该部署契约改动的宿主环境条件，属于"不动，只记录"。另确认 `community_snapshot.py` 新增的
+  `unread_partner_replies`/`partner_reply_breakdown` 用两个语义无关的计数器相减（回复行数 −
+  sannai_says.jsonl 读取游标），当前无消费者读取，尚未造成误导，未修——真正修复需要新增
+  "回复已读游标"，属功能缺口而非 bug。
+- **测试数量变化**：新增 5 个测试（`tests/plugins/memory/test_memory_os_community_table_and_interest_garden.py`，
+  覆盖此前零测试的 `community_table.py`/`community_interest_garden.py` 往返 + 限流边界）。
+  全量本地（Windows）**3039 passed / 3 failed / 13 skipped**——3 个 FAIL 均为既有环境伪影：
+  2 个是 BK/BM 记录的 `test_memory_os_pytest_policy.py` skip-count 断言（经 stash 对照验证
+  revert 后同样失败，与本次改动无关）；1 个是
+  `test_execution_gate_runner_serializes_parallel_sidecar_updates`，全量套件下因并发资源
+  争用（复审期间本机同时在跑 Edit 工具调用）偶发 FAIL，单独重跑与 stash 对照均 100% PASS，
+  非本次改动引入的回归。import cycle（173 modules / 0 cycle）、write surface
+  （163/163，`unclassified_count=0`）、static hygiene、public checkout probe（PASS）、
+  `git diff --check` 全过。
+- **结论**：两项 CI FAIL 已修复；顺带加固字符编码一致性并为两个此前零覆盖模块补测试；
+  三处实现落差（模块脱节、限流缺失、治理门控被绕开）与一处语义存疑指标已如实记入路线图
+  11.12.7，留待后续按记录中的两个方案之一收口，本次不重构生产部署契约。
+
+---
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -929,6 +990,14 @@ BJ 待办的"9 项 Windows 本地 pre-existing 测试失败诊断"已由 BK 完�
 3. `shell_alias_no_env()` 的 22 条 CLI 探针命令并行执行（`ThreadPoolExecutor`）对同一
    `HERMES_HOME` 文件/SQLite 状态的一般性并发风险——无实测复现、无并发单测覆盖，记录为已知
    残留风险（BM 记录，`review_reply` 使用假 token 探针本身已确认安全）。
+4. BP 记录的 Track A 实现落差——`community_partner_runtime.py`/`community_table.py`/
+   `community_interest_garden.py` 与实际线上路径（`scripts/community_partner_reply.py`）
+   脱节，导致限流约束缺失、shared 写入门控被绕开、`_extract_topics` 关键词分叉；收口需二选一
+   （改脚本 import 模块并验证部署契约 / 明确废弃模块并删除），本次未做判断，留给下次接触
+   Track A 代码时处理（路线图 11.12.7 记录）。
+5. BP 记录的 `community_snapshot.py::unread_partner_replies`/`partner_reply_breakdown`
+   语义缺口——用两个无关计数器相减，当前无消费者读取，未修；若未来有 UI/digest 要消费这两个
+   字段，须先补"回复已读游标"再接入，不能直接信任现有数值。
 
 ---
 
@@ -1016,3 +1085,15 @@ BJ 待办的"9 项 Windows 本地 pre-existing 测试失败诊断"已由 BK 完�
   并把 `slo_checks` 附在断言消息里；未改 `DEFAULT_SLO`/`run_benchmark()` 生产语义。
   无新增/删除测试，全量 3035 passed / 2 failed（同 BK/BM 既有 Windows `%TEMP%` 环境伪影，
   经 stash 对照验证与本次改动无关）/ 13 skipped，静态门全过。
+- `609bc40..（BP，本节）`：复审 Sannai v2.9 提交（11.12 窗台/一起看/兴趣花园）——修复两项
+  GitHub CI FAIL（`write_surface_check` 新增 8 处写入未登记；`partner_create` 测试断言旧
+  错误文案）；顺带补齐 4 个文件缺失的 `encoding="utf-8"`（无法反事实，纯 portability）；
+  新增 5 个测试覆盖此前零测试的 `community_table.py`/`community_interest_garden.py`；
+  记录（不重构）3 处实现落差——`community_partner_runtime.py`/`community_table.py`/
+  `community_interest_garden.py` 零调用方、实际 cron 路径是内联重写副本，导致限流约束缺失、
+  shared 写入门控被绕开、`_extract_topics` 关键词分叉——写入路线图 11.12.7；另确认
+  `community_snapshot.py` 新增的 `unread_partner_replies` 字段计算语义无关的两个计数器，
+  当前无消费者，未修。全量本地（Windows）3032→**3039 passed** / 3 failed（2 个同 BK/BM
+  既有 skip-count 环境伪影 + 1 个全量套件下资源争用偶发 FAIL、隔离重跑 100% PASS，均经
+  stash 对照验证与本次改动无关）/ 13 skipped，静态门全过（import cycle 173/0、write
+  surface 163/163、static hygiene、public checkout probe、git diff --check）。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -968,9 +968,19 @@ BC 评审 15 项至此全部完成（P0×3 → BD，P1×4 → BE，P2×3 → BF�
   非本次改动引入的回归。import cycle（173 modules / 0 cycle）、write surface
   （163/163，`unclassified_count=0`）、static hygiene、public checkout probe（PASS）、
   `git diff --check` 全过。
-- **结论**：两项 CI FAIL 已修复；顺带加固字符编码一致性并为两个此前零覆盖模块补测试；
-  三处实现落差（模块脱节、限流缺失、治理门控被绕开）与一处语义存疑指标已如实记入路线图
-  11.12.7，留待后续按记录中的两个方案之一收口，本次不重构生产部署契约。
+- **附加发现（推送后从真实 GHA 复现，非本地可预见）**：分支推送后 push 事件触发的 CI 独立
+  报了第三个 FAIL——`Reject whitespace errors in pushed range` 步骤，因为这是全新分支，
+  `PUSH_BEFORE_SHA` 为全零，工作流回退为对空树 diff，暴露了 `community_partner_runtime.py`
+  中原 Sannai 提交自带的 6 处行尾空白（非本次改动引入）——与 BL.1 记录的"新分支空树 fallback
+  暴露历史文件尾随空白"同一根因。本地 `git diff --check` 此前只查未提交 diff（对 HEAD），未
+  复现此路径；改用 `git diff --check "$(git hash-object -t tree /dev/null)" HEAD` 精确复现
+  CI 命令后确认全仓库只有这 6 处，逐一清理（纯空白，`ast.parse`/`import` 验证无语义变化）。
+  同一提交下 pull_request 触发的 CI（正确对 `main` 做 diff）已先于此发现独立跑 PASS，验证了
+  两项核心修复在真实 Linux CI 上有效。
+- **结论**：两项 CI FAIL（write surface、测试断言）+ 一项推送后发现的 CI FAIL（行尾空白）
+  已修复；顺带加固字符编码一致性并为两个此前零覆盖模块补测试；三处实现落差（模块脱节、
+  限流缺失、治理门控被绕开）与一处语义存疑指标已如实记入路线图 11.12.7，留待后续按记录中的
+  两个方案之一收口，本次不重构生产部署契约。
 
 ---
 
@@ -1085,9 +1095,10 @@ BJ 待办的"9 项 Windows 本地 pre-existing 测试失败诊断"已由 BK 完�
   并把 `slo_checks` 附在断言消息里；未改 `DEFAULT_SLO`/`run_benchmark()` 生产语义。
   无新增/删除测试，全量 3035 passed / 2 failed（同 BK/BM 既有 Windows `%TEMP%` 环境伪影，
   经 stash 对照验证与本次改动无关）/ 13 skipped，静态门全过。
-- `609bc40..（BP，本节）`：复审 Sannai v2.9 提交（11.12 窗台/一起看/兴趣花园）——修复两项
+- `609bc40..（BP，本节）`：复审 Sannai v2.9 提交（11.12 窗台/一起看/兴趣花园）——修复三项
   GitHub CI FAIL（`write_surface_check` 新增 8 处写入未登记；`partner_create` 测试断言旧
-  错误文案）；顺带补齐 4 个文件缺失的 `encoding="utf-8"`（无法反事实，纯 portability）；
+  错误文案；推送后从真实 GHA 复现的 `community_partner_runtime.py` 6 处行尾空白，新分支
+  空树 fallback 触发，同 BL.1 根因）；顺带补齐 4 个文件缺失的 `encoding="utf-8"`（无法反事实，纯 portability）；
   新增 5 个测试覆盖此前零测试的 `community_table.py`/`community_interest_garden.py`；
   记录（不重构）3 处实现落差——`community_partner_runtime.py`/`community_table.py`/
   `community_interest_garden.py` 零调用方、实际 cron 路径是内联重写副本，导致限流约束缺失、

--- a/plugins/memory/memory_os/community_interest_garden.py
+++ b/plugins/memory/memory_os/community_interest_garden.py
@@ -123,7 +123,7 @@ def update_interests(
 
     state["known_interests"] = interests
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state, ensure_ascii=False, indent=2))
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
     return interests
 
 

--- a/plugins/memory/memory_os/community_partner_runtime.py
+++ b/plugins/memory/memory_os/community_partner_runtime.py
@@ -114,7 +114,7 @@ def _append_note(partner_dir: Path, text: str) -> None:
     if not text.strip():
         return
     text = text.strip()[:_MAX_NOTE_CHARS]
-    
+
     # Read existing notes to check total size
     notes_path = partner_dir / "notes.jsonl"
     existing_lines: list[str] = []
@@ -130,14 +130,14 @@ def _append_note(partner_dir: Path, text: str) -> None:
         except OSError:
             existing_lines = []
             total_chars = 0
-    
+
     # Trim from front if over limit
     while total_chars + len(text) > _MAX_NOTE_TOTAL and existing_lines:
         removed = existing_lines.pop(0)
         total_chars -= len(removed)
     if total_chars + len(text) > _MAX_NOTE_TOTAL:
         return  # note too large even after trim; discard
-    
+
     entry = json.dumps(
         {
             "ts": datetime.now(timezone.utc).isoformat(),
@@ -161,7 +161,7 @@ def _build_prompt(
     notes_section = ""
     if recent_notes:
         notes_section = "\n你最近的笔记（回忆）：\n" + "\n".join(f"- {n}" for n in recent_notes[-5:])
-    
+
     prompt = f"""{soul_md}
 
 {notes_section}
@@ -181,13 +181,13 @@ def run_once(
     model_call: Callable[[str], str] | None = None,
 ) -> dict[str, Any]:
     """Run one tick of the partner runtime for all embedded partners.
-    
+
     Args:
         memory_os_root: Path to Memory-OS root directory.
         model_call: Callable that takes a prompt string and returns the
             model's response text.  If None, no model call is made
             (dry-run / test mode).
-    
+
     Returns:
         A dict with keys:
             - "partners_checked": int

--- a/plugins/memory/memory_os/community_table.py
+++ b/plugins/memory/memory_os/community_table.py
@@ -132,7 +132,7 @@ def write_to_table(
     if share_url:
         entry["share_url"] = str(share_url)[:1000]
 
-    with open(table_path, "a") as f:
+    with open(table_path, "a", encoding="utf-8") as f:
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
     return entry

--- a/scripts/community_monitor.py
+++ b/scripts/community_monitor.py
@@ -43,7 +43,7 @@ def build_track_a_report(community_root: Path) -> dict:
 
     # Parse active partners
     current: dict[str, dict] = {}
-    for line in roster_path.read_text().splitlines():
+    for line in roster_path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
         try:
@@ -78,7 +78,7 @@ def build_track_a_report(community_root: Path) -> dict:
         # Count replies
         reply_lines: list[str] = []
         if replies_path.exists():
-            reply_lines = [l for l in replies_path.read_text().splitlines() if l.strip()]
+            reply_lines = [l for l in replies_path.read_text(encoding="utf-8").splitlines() if l.strip()]
         total_replies = len(reply_lines)
         total_replies_all += total_replies
 
@@ -97,13 +97,13 @@ def build_track_a_report(community_root: Path) -> dict:
         # Count notes
         note_count = 0
         if notes_path.exists():
-            note_count = len([l for l in notes_path.read_text().splitlines() if l.strip()])
+            note_count = len([l for l in notes_path.read_text(encoding="utf-8").splitlines() if l.strip()])
         total_notes += note_count
 
         # Count error records
         error_count = 0
         if error_path.exists():
-            error_count = len([l for l in error_path.read_text().splitlines() if l.strip()])
+            error_count = len([l for l in error_path.read_text(encoding="utf-8").splitlines() if l.strip()])
         total_errors += error_count
 
         # Read state
@@ -111,7 +111,7 @@ def build_track_a_report(community_root: Path) -> dict:
         cursor = 0
         if state_path.exists():
             try:
-                st = json.loads(state_path.read_text())
+                st = json.loads(state_path.read_text(encoding="utf-8"))
                 mood = st.get("mood", "unknown")
                 cursor = int(st.get("cursor", 0))
             except (json.JSONDecodeError, OSError, ValueError):
@@ -122,7 +122,7 @@ def build_track_a_report(community_root: Path) -> dict:
         state_obj = {}
         if state_path.exists():
             try:
-                state_obj = json.loads(state_path.read_text())
+                state_obj = json.loads(state_path.read_text(encoding="utf-8"))
                 skip_count = int(state_obj.get("skip_count", state_obj.get("budget_skips", 0)))
             except (json.JSONDecodeError, OSError, ValueError):
                 pass
@@ -157,7 +157,7 @@ def build_track_a_report(community_root: Path) -> dict:
         if latest:
             cron_last_run = datetime.fromtimestamp(latest[0], tz=timezone.utc).isoformat()
             try:
-                cron_output = json.loads(latest[1].read_text())
+                cron_output = json.loads(latest[1].read_text(encoding="utf-8"))
                 if cron_output.get("errors"):
                     cron_healthy = False
                     cron_errors = len(cron_output.get("errors"))

--- a/scripts/community_partner_reply.py
+++ b/scripts/community_partner_reply.py
@@ -42,7 +42,7 @@ def _update_interests(state_path: Path, text: str):
         state = {"known_interests": []}
     else:
         try:
-            state = json.loads(state_path.read_text())
+            state = json.loads(state_path.read_text(encoding="utf-8"))
         except:
             state = {"known_interests": []}
     interests = state.get("known_interests", [])
@@ -63,13 +63,13 @@ def _update_interests(state_path: Path, text: str):
     interests.sort(key=lambda e: e.get("count", 0), reverse=True)
     state["known_interests"] = interests[:20]
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2))
+    state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
 
 def _get_interests_summary(state_path: Path) -> str:
     if not state_path.exists():
         return ""
     try:
-        state = json.loads(state_path.read_text())
+        state = json.loads(state_path.read_text(encoding="utf-8"))
     except:
         return ""
     interests = state.get("known_interests", [])
@@ -90,7 +90,7 @@ def _write_table(text: str, actor: str, actor_name: str, share_type: str = "note
         "ts": _ts(), "actor": actor, "actor_name": actor_name,
         "text": str(text)[:500], "share_type": share_type,
     }, ensure_ascii=False)
-    with open(table_path, "a") as f:
+    with open(table_path, "a", encoding="utf-8") as f:
         f.write(entry + "\n")
 
 # ── 读配置 ──────────────────────────────────────────────────────
@@ -107,7 +107,7 @@ if not roster_path.exists():
     sys.exit(1)
 
 partners = []
-for line in roster_path.read_text().splitlines():
+for line in roster_path.read_text(encoding="utf-8").splitlines():
     line = line.strip()
     if not line:
         continue
@@ -127,7 +127,7 @@ says_path = MOS_ROOT / "community" / "shared" / "sannai_says.jsonl"
 says_data: list[dict] = []
 if says_path.exists():
     says_data = [
-        json.loads(line) for line in says_path.read_text().splitlines()
+        json.loads(line) for line in says_path.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.isspace()
     ]
 
@@ -148,7 +148,7 @@ for partner in partners:
     cursor = 0
     if state_path.exists():
         try:
-            state_data = json.loads(state_path.read_text())
+            state_data = json.loads(state_path.read_text(encoding="utf-8"))
             cursor = int(state_data.get("cursor", 0))
         except (json.JSONDecodeError, ValueError, OSError):
             cursor = 0
@@ -162,13 +162,13 @@ for partner in partners:
 
     # 读 soul
     soul_path = partner_dir / "SOUL.md"
-    soul_text = soul_path.read_text() if soul_path.exists() else ""
+    soul_text = soul_path.read_text(encoding="utf-8") if soul_path.exists() else ""
 
     # 读最近 notes + interests
     notes_path = partner_dir / "notes.jsonl"
     recent_notes = []
     if notes_path.exists():
-        for line in notes_path.read_text().splitlines():
+        for line in notes_path.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -242,7 +242,7 @@ for partner in partners:
         "reply_to_ts": last_msg.get("ts", ""),
         "text": clean_reply,
     }, ensure_ascii=False)
-    with open(partner_dir / "replies.jsonl", "a") as f:
+    with open(partner_dir / "replies.jsonl", "a", encoding="utf-8") as f:
         f.write(reply_entry + "\n")
     result["replies_written"] += 1
 
@@ -259,11 +259,11 @@ for partner in partners:
     }, ensure_ascii=False)
     shared_path = MOS_ROOT / "community" / "shared" / f"sannai__{pid}.jsonl"
     shared_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(shared_path, "a") as f:
+    with open(shared_path, "a", encoding="utf-8") as f:
         f.write(shared_entry + "\n")
 
     # 写 notes
-    with open(notes_path, "a") as f:
+    with open(notes_path, "a", encoding="utf-8") as f:
         f.write(json.dumps({"ts": _ts(), "text": clean_reply[:300]}, ensure_ascii=False) + "\n")
 
     # 更新兴趣花园（从回复中提取话题）
@@ -280,7 +280,7 @@ for partner in partners:
         "topic_interest": [],
     }
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(json.dumps(new_state, ensure_ascii=False, indent=2))
+    state_path.write_text(json.dumps(new_state, ensure_ascii=False, indent=2), encoding="utf-8")
 
 # Only output when there's something to report
 has_activity = (result.get("replies_written", 0) > 0 or

--- a/scripts/memory_os_write_surface_check.py
+++ b/scripts/memory_os_write_surface_check.py
@@ -188,6 +188,17 @@ ALLOWED_WRITE_SURFACES: dict[str, str] = {
     "plugins/memory/memory_os/cognitive_loop.py::CognitiveLoopRunner._community_cycle::atomic_json_replace_call::cursor_path": "community_trigger_dedup_projection_state",
     "plugins/memory/memory_os/execution_gate.py::_write_gate_index::atomic_json_replace_call::_gate_index_path(roots)": "execution_gate_projection_index",
     "plugins/memory/memory_os/partner_create.py::create_partner::atomic_json_replace_call::memory_dir / 'state.json'": "community_partner_private_runtime_state",
+    "plugins/memory/memory_os/community_partner_runtime.py::_save_partner_state::atomic_json_replace_call::partner_dir / 'memory' / 'state.json'": "community_partner_private_runtime_state",
+    "plugins/memory/memory_os/community_partner_runtime.py::_append_note::open_a::notes_path": "community_partner_private_notes_log",
+    "plugins/memory/memory_os/community_partner_runtime.py::run_once::open_a::replies_path": "community_partner_private_replies_log",
+    "plugins/memory/memory_os/community_table.py::write_to_table::open_a::table_path": "community_table_bounded_shared_surface",
+    "scripts/community_partner_reply.py::_write_table::open_a::table_path": "community_table_bounded_shared_surface",
+    "scripts/community_partner_reply.py::<module>::open_a::partner_dir / 'replies.jsonl'": "community_partner_private_replies_log",
+    # NOTE: writes the same sannai__{pid}.jsonl target as community_shared.py's
+    # write_shared_memory(), but bypasses its actor=="sannai" gate entirely —
+    # a direct, ungoverned duplicate write path. See roadmap 11.12 amendment.
+    "scripts/community_partner_reply.py::<module>::open_a::shared_path": "community_shared_projection_cron_direct_ungoverned_duplicate",
+    "scripts/community_partner_reply.py::<module>::open_a::notes_path": "community_partner_private_notes_log",
     "plugins/memory/memory_os/runtime.py::MemoryOSRuntime._write_state::atomic_json_replace_call::self._state_path": "memory_os_runtime_projection_state",
     "plugins/memory/memory_os/runtime.py::MemoryOSRuntime._write_heartbeat_error_fallback::atomic_json_replace_call::self.store.roots.memory_os_root / 'runtime' / 'heartbeat_error_fallback.json'": "runtime_error_fallback_projection",
     "plugins/memory/memory_os/session_mirror.py::SessionMirror._write_state::atomic_json_replace_call::self.state_path": "session_mirror_projection_state",

--- a/tests/plugins/memory/test_memory_os_community_hardening.py
+++ b/tests/plugins/memory/test_memory_os_community_hardening.py
@@ -145,7 +145,7 @@ def test_create_partner_requires_real_partner_profile_config(tmp_path: Path) -> 
     root = _community_root(tmp_path)
     result = _create_partner_api(root, "P", "kind", partner_id="p-01", actor="sannai")
     assert result.status == "fail"
-    assert result.errors == ["partner profile config required"]
+    assert result.errors == ["partner profile config required in non-embedded mode"]
 
 
 def test_partner_creation_fails_closed_on_invalid_budget(tmp_path: Path) -> None:

--- a/tests/plugins/memory/test_memory_os_community_table_and_interest_garden.py
+++ b/tests/plugins/memory/test_memory_os_community_table_and_interest_garden.py
@@ -1,0 +1,74 @@
+"""Tests for the community table (窗台) and interest garden (兴趣花园).
+
+Covers write_to_table/read_table and update_interests/get_interests_summary
+round-tripping Chinese content — both modules were added with zero test
+coverage and their writes did not specify an explicit encoding.
+"""
+
+from pathlib import Path
+
+from plugins.memory.memory_os.community_table import write_to_table, read_table, get_unread_shares
+from plugins.memory.memory_os.community_interest_garden import (
+    update_interests,
+    get_interests_summary,
+)
+
+
+class TestCommunityTable:
+    def test_write_and_read_round_trips_chinese_text(self, tmp_path: Path) -> None:
+        write_to_table(tmp_path, actor="sannai", actor_name="三奶", text="今天蝴蝶停在叶子上好久")
+        entries = read_table(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["actor_name"] == "三奶"
+        assert entries[0]["text"] == "今天蝴蝶停在叶子上好久"
+
+        raw = (tmp_path / "shared" / "table.jsonl").read_text(encoding="utf-8")
+        assert "三奶" in raw
+        assert "蝴蝶" in raw
+
+    def test_share_type_and_unread_shares(self, tmp_path: Path) -> None:
+        write_to_table(
+            tmp_path,
+            actor="partner-df1c2405",
+            actor_name="流萤",
+            text="看到一朵形状奇怪的云",
+            share_type="share",
+            share_url="https://example.com/cloud.jpg",
+        )
+        shares = get_unread_shares(tmp_path, last_seen_ts="1970-01-01T00:00:00+00:00")
+        assert len(shares) == 1
+        assert shares[0]["actor_name"] == "流萤"
+
+    def test_rate_limit_blocks_sixth_entry_in_one_hour(self, tmp_path: Path) -> None:
+        for i in range(5):
+            write_to_table(tmp_path, actor="sannai", actor_name="三奶", text=f"note {i}")
+        try:
+            write_to_table(tmp_path, actor="sannai", actor_name="三奶", text="note 5")
+            raised = False
+        except RuntimeError:
+            raised = True
+        assert raised
+
+
+class TestInterestGarden:
+    def test_update_interests_round_trips_chinese_topics(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        update_interests(state_path, text="今天看到月亮和云，还有一只蜗牛")
+        interests = update_interests(state_path, text="又看到月亮了")
+
+        topics = {entry["topic"] for entry in interests}
+        assert "月亮" in topics
+        assert "云" in topics
+        assert "蜗牛" in topics
+
+        moon_entry = next(entry for entry in interests if entry["topic"] == "月亮")
+        assert moon_entry["count"] == 2
+
+        raw = state_path.read_text(encoding="utf-8")
+        assert "月亮" in raw
+
+    def test_get_interests_summary_natural_language(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        update_interests(state_path, text="月亮")
+        summary = get_interests_summary(state_path)
+        assert summary == "最近喜欢聊月亮"


### PR DESCRIPTION
## Summary
Reviewed the latest Sannai commits (`0897e5b`, `609bc40`) to `docs/resolver/hermes-memory-os-optimization-roadmap.md` per request. GitHub Actions CI was red on both. Fixes two CI failures, hardens character encoding, adds missing test coverage, and documents (without restructuring) three implementation gaps found during review.

## CI fixes
- **`write_surface_check` FAIL** (`unclassified_count` 0→8): `community_partner_runtime.py`, `community_table.py`, and `scripts/community_partner_reply.py` added 8 direct file writes never registered in `ALLOWED_WRITE_SURFACES`. Classified each following existing precedent. The cron script's direct write to `sannai__{pid}.jsonl` is labeled `*_cron_direct_ungoverned_duplicate` since it bypasses `community_shared.write_shared_memory()`'s actor gate — flagged, not silently normalized.
- **Stale test assertion**: `test_create_partner_requires_real_partner_profile_config` asserted the pre-embedded-mode error message. The message was intentionally changed to disambiguate embedded vs. non-embedded failures; test updated to match.

## Also fixed
- `community_table.py`, `community_interest_garden.py`, `scripts/community_partner_reply.py`, `scripts/community_monitor.py`: several `open()`/`write_text()`/`read_text()` calls on Chinese content were missing explicit `encoding="utf-8"`, relying on locale default instead (inconsistent with the rest of the codebase). No counterfactual test exists for this — both this Windows box and Linux CI already default to UTF-8 — documented as portability hardening, not a behavior fix.
- Added `tests/plugins/memory/test_memory_os_community_table_and_interest_garden.py` (5 tests), covering `write_to_table`/`read_table`/`get_unread_shares` and `update_interests`/`get_interests_summary`, which had zero prior coverage.

## Documented, not fixed (see roadmap 11.12.7)
- `community_partner_runtime.py`, `community_table.py`, `community_interest_garden.py` have **zero importers**. The live cron path (`scripts/community_partner_reply.py`) is a self-contained inline duplicate whose `_extract_topics()` keyword list has already diverged, whose table writes have no rate limit (unlike the documented ≤5/hour constraint enforced only in the unused module), and which bypasses the shared-memory actor gate (above). Restructuring the cron script's import/deployment contract can't be verified from this environment (self-contained by design, executes at import against real production paths), so this is recorded for a follow-up rather than fixed here.
- `community_snapshot.py`'s new `unread_partner_replies`/`partner_reply_breakdown` fields diff two semantically unrelated counters (reply count vs. an unrelated read cursor). Currently unconsumed anywhere, so not yet misleading — left as-is; a real fix needs a reply-read pointer that doesn't exist yet (a feature gap, not a bug).

## Verification
Full local suite: 3032 → **3039 passed** / 3 failed / 13 skipped. All 3 failures are pre-existing and unrelated — verified via `git stash` (revert my changes, re-run, same failures):
- 2× known Windows `%TEMP%` skip-count artifacts (documented in the stabilization checklist's BK section)
- 1× `test_execution_gate_runner_serializes_parallel_sidecar_updates`, a resource-contention flake under full-suite load (100% pass in isolation and under stash)

Static gates all pass: import cycle (173 modules / 0 cycles), write surface (163/163, `unclassified_count=0`), static hygiene, public checkout probe, `git diff --check`.

Stabilization checklist updated per project process (section BP).