### PR TITLE
fix(memory-os): close 28 findings from invariant-sliced project review

### DIFF
--- a/docs/resolver/hermes-memory-os-optimization-roadmap.md
+++ b/docs/resolver/hermes-memory-os-optimization-roadmap.md
@@ -448,16 +448,20 @@ observation_days >= configured_gate
 | R4 状态机 | 非法状态结构上不可写、旧行可读 | 重写 append-only 历史 |
 | R5 认知伙伴 | Owner 反馈与自然质量门满足 | 自动身份/关系写入、强制表达 |
 | R6 性能 | 行为等价且真实资源改善 | 少跑检查、stale cache 伪装加速 |
-| R7 社区 | 伙伴持续运行、真实回复、自然 shared/overlay/scheduler evidence | 用 transport/pairing 冒充关系 live |
+| R7 社区（已迁出，见 §11） | 伙伴持续运行、真实回复、自然 shared/overlay/scheduler evidence | 用 transport/pairing 冒充关系 live |
 
 ---
 
 ## 14. 当前优先级
 
-1. **观察窗（14天）**：流萤 cron 自然运行，记录预算违规、error_record、健康安静时刻。
-2. **社区快照**：定期执行 `build_community_snapshot()` 和 `community_monitor.py` 检查社区状态。
-3. **Sannai 主动管理**：有想法时写纸条给流萤，让自然回路的频率保持。
-4. **社区报纸**：在不忙的时候探索报纸功能，与 Hermes 叔叔聊。
+> **原 1–4 项已迁出（2026-07-29）**：以下四项均属于 Sannai Community（流萤 Track A）功能，
+> 已随 §11 记录的 `community.py` 等模块与 `scripts/community_monitor.py`、
+> `scripts/community_partner_reply.py`、`scripts/deploy_community.py` 一并迁出本仓库，独立为
+> [sannai-community](https://github.com/btnalit/sannai-community)：原「观察窗（14天）：流萤
+> cron 自然运行，记录预算违规、error_record、健康安静时刻」、原「社区快照：定期执行
+> `build_community_snapshot()` 和 `community_monitor.py` 检查社区状态」（两函数均已随迁出删除，
+> 本仓库不再提供）、原「Sannai 主动管理：有想法时写纸条给流萤」、原「社区报纸：探索报纸功能」。
+> 本仓库当前没有可执行的社区相关优先级；后续社区侧当前优先级请见该仓库。
 
 ---
 

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1088,6 +1088,13 @@ BC 评审 15 项至此全部完成（P0×3 → BD，P1×4 → BE，P2×3 → BF�
   4. **cron 注册表漂移（真实安装缺失）**：`ACTIVE_CLOSURE_CRON_KEYS` 与 dashboard 的
      core/optional 名单是 `MEMORY_OS_CRON_SPECS` 的手抄副本，`clearance_cycle` 从未被加入，
      全新 active-closure 安装**根本不会创建该 cron**。改为从注册表推导 + 显式声明有意排除。
+     **`clearance_cycle` 本次仍不安装，但改为按名字显式排除并写明理由（延后启用）**：本次同
+     一批改动修好了 `append_terminal(detail=...)`，使 `sweep_unavailable_open_proposals_on_flag_flip`
+     （会**撤销**未决提案，就在 `clearance_cycle.py` 内）从"每次必抛 TypeError"变为真正可执行；
+     若同时创建该 cron，等于让两条从未真正跑过的路径在 3.200 上同时上线，出问题无法归因。
+     dashboard 侧同步标为 OPTIONAL（否则会对"我们故意不装的任务"永久报 missing_core WARN），
+     并加了一条测试锁死两者一致性。**启用方式：删掉排除集里那一行即可**；漂移防护不受影响，
+     新注册的 spec 仍不可能被静默漏掉。本次的关键区别是——遗漏必须是一个**决定**，而不是意外。
   5. **StateOverlay section 注册表六处重复**：改为从 `StateOverlay` dataclass 字段推导
      （`OVERLAY_SECTION_FIELDS`），标签/子集在 import 时断言穷尽；另发现并消除了第 7 处
      未被记录的内联副本。序列化输出键序逐字不变。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1059,6 +1059,91 @@ BC 评审 15 项至此全部完成（P0×3 → BD，P1×4 → BE，P2×3 → BF�
   sannai-community README 一并携带）；`deploy_community.py` 未移植到新仓库（其模块清单混合
   核心文件，按旧仓库安装布局硬编码路径，移植等于重写一个未经验证的部署脚本，超出本次范围）。
 
+## BR — 全项目审查（6 轮不变量切片）与整体修复（2026-07-30）
+
+- **触发**：对 `47bbc13` 之后的整个项目做代码审查。首轮只覆盖了最后一次提交的 diff，遂按
+  **不变量**（而非目录）重新切片，补做 5 轮横切审查：ExecutionGate 覆盖、无声失败/
+  error_record、OwnerGate/ResolverGate 授权、治理 import 拓扑 + substrate 权威、
+  手工维护的并行注册表。共 28 项发现，按文件所有权分 8 个互不重叠的包修复。
+- **共同根因**：绝大多数发现是同一形状——**检查通过 ≠ 不变量成立**。`write_surface_check`
+  在仓库内保证 `unclassified_count=0`，但写入面可以留在主机上；`import_cycle_check` 查环
+  不查方向；多个测试断言的是自己手工维护的列表而非从单一真相源推导，列表漂移时照样绿。
+- **已修（按严重度）**：
+  1. **所有者授权绕过（安全，已实测复现）**：`owner_actions.py` 的 `_surface_action_token_map`
+     从当前实时状态重算令牌，使 `require_recorded_digest=True` 对 `revoke_crystallized`/
+     `demote_crystallized` 失效——仅凭一条 crystallized 记录的 `id` 即可离线算出
+     `oa_<sha256(...)[:14]>` 并撤销该记录，全程无摘要投递。修复期间另发现**更严重的变体**：
+     即使存在已记录摘要（生产常态，`binding == "latest_recorded_digest"`），伪造仍然成功——
+     只按 `digest_not_found` 收口会在真实生产状态下留洞。改为按风险类**默认拒绝**（动作类型
+     与目标类型都必须低风险），并删除 `token_match` 回退中重复的 `_surface_action_token_map`
+     二次查找（否则刚被拒绝的令牌会被重新放行）。`apply_proposal`/`proposal` 经评估保留为
+     digest-optional（已需 owner 批准 + OpsGate would_allow + 3 种受限 kind + 40 bit 提案 id
+     后缀，且不在 CLAUDE.md 的 OwnerGate 永久边界清单内）。
+  2. **ExecutionGate 许可证泄漏 ×2**：`runtime.py` heartbeat 中途抛异常则 envelope 永久悬空
+     （已复现：1 条 permit、0 条 completion）；`cognitive_loop.py` 三条 lane 委托模块零异常
+     保护。均按同文件既有正确范式（`spontaneous_expression_delivery`）在两个分支都收口。
+  3. **substrate 自称权威**：`substrates/router.py` 仅凭 fact 自报的 `authority_class` 授予
+     一级权威，不校验 `provider == "local_artifact"`。改为结构性校验并将伪造 fact 排除出
+     返回集（检测遥测仍从未过滤的 `raw_facts` 计算，避免"丢掉内容就丢掉告警"）。
+  4. **cron 注册表漂移（真实安装缺失）**：`ACTIVE_CLOSURE_CRON_KEYS` 与 dashboard 的
+     core/optional 名单是 `MEMORY_OS_CRON_SPECS` 的手抄副本，`clearance_cycle` 从未被加入，
+     全新 active-closure 安装**根本不会创建该 cron**。改为从注册表推导 + 显式声明有意排除。
+  5. **StateOverlay section 注册表六处重复**：改为从 `StateOverlay` dataclass 字段推导
+     （`OVERLAY_SECTION_FIELDS`），标签/子集在 import 时断言穷尽；另发现并消除了第 7 处
+     未被记录的内联副本。序列化输出键序逐字不变。
+  6. **错误可见性**：`index.py` 构造 error_record 后丢弃不写（唯一一处）→ 改为经
+     `append_audit` 落盘；`clearance_cycle.py` 追加缺字段记录且 `status` 恒为 `ok` → 改用
+     `build_error_record` 并区分"部分失败/整批失败"；`session_mirror.py` 两处静默
+     `except: continue` → 记录并经 `doctor()` 暴露。
+  7. **community 主机侧退役**：`47bbc13` 只移除了仓库、没有反向操作，`_copy_tree` 是纯增量，
+     已部署主机上的模块/数据目录/`deploy_community.py` 会永久残留。按
+     `legacy_right_brain_retirement.py` 范式新增 `scripts/memory_os_community_retirement.py`
+     （幂等、归档而非删除、dry-run 证明零写入、两阶段提交 + SHA256 完整性校验 + 写锁），
+     并把 `community_monitor.py`/`community_partner_reply.py` 加入
+     `RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES`（否则残留 cron 落入 `external_unmanaged` 而对
+     monitor 完全不可见）。**未在任何主机执行**，是否执行由 owner 决定。
+  8. **公开文档漂移**：路线图 §14「当前优先级」仍以现在时指示运维执行
+     `build_community_snapshot()` 与 `community_monitor.py`（均已删除），§13 仍把 R7 社区
+     列为在跑阶段——已改为迁出说明并保留原文，指向 sannai-community。
+  9. **pytest 版本漂移（红→绿）**：`test_memory_os_pytest_policy.py` 两处断言把随 pytest
+     版本变化的 `skip_count` 当作不变量（8.4.2/Windows 下单个 module-level skip 计为 2）。
+     改为断言真正的不变量（collect 阶段 skip 全部被判为 unknown、`status=fail`、returncode
+     非 0），而非附带计数。这两个失败是 BQ 记录的既有伪影，本节将其真正修复。
+- **交接期间自查发现的两个额外问题**（3 个 agent 因额度中断，由主会话接手完成）：
+  - `append_terminal(detail=...)` 根本不接受 `detail` 参数（`permanent_promotion.py:485-495`），
+    旧代码每次 sweep 都抛 `TypeError`，被宽 `except` 吞掉并写入畸形记录，函数还返回硬编码
+    `status: "ok"`——即 `sweep_unavailable_open_proposals_on_flag_flip` **从未成功清扫过任何
+    提案**。这是"无声失败"不变量的教科书式印证。
+  - 包切分本身引入一处跨包回归：`test_memory_os_plugin_install.py` 里硬编码 `== 19` 与 19 个
+    job 名字面量（cron 注册表的第 4、5 份副本）属于 F 包白名单，而改变数量的是 E1 包，E1
+    无权修它。**教训：按文件所有权切包时，行为变更与其测试可能不在同一个包里。**
+- **反事实覆盖**：每项修复均有"撤销修复即失败"的测试并经实际验证（本轮统一改用仓库外文件
+  复制回退，不用 `git stash`——8 个 agent 共享同一 worktree 时 stash 栈跨 worktree 共享，
+  裸 `pop` 可能恢复他人暂存内容）。关键新增：envelope 账本在错误路径上必须有 completion
+  记录（旧测试只断言 audit 与 heartbeat_state，从不读 `execution_gate_envelopes.jsonl`）；
+  伪造 fact 必须被排除出 `facts`（旧测试只断言违规标志位翻转）；新增 cron spec 未分类必须
+  测试失败；error_record 发射组件必须全部登记（从源码推导 30 个发射者）。
+- **测试与静态门**：全量本地（Windows）2968 passed / **2 failed** → **3023 passed / 0 failed**
+  / 13 skipped（+55，563s），**本仓库首次全绿**。静态门全过：import cycle 0 环、write surface
+  `unclassified_count=0`、static hygiene、public checkout probe `--strict`（exit 0）、
+  `git diff --check`。
+- **未做的事（明确记录，非遗漏）**：
+  - `oa_` 令牌密钥化（纵深防御）未实施：需向 `_action_token` 贯穿 `roots`（约 45 处，单点
+    遗漏会导致 digest cron 与 gateway **静默**产生不一致令牌）、令牌格式被 4 个白名单外文件的
+    正则锁定、且失败策略需要 `error_registry` 错误码与 monitor 字段。已实测的攻击面已由第 1
+    项完全关闭；未做半迁移。
+  - monitor 11 个组件的 snapshot 采集未接线（这些组件根本没有 snapshot payload，接线属于对
+    大型生产 monitor 的采集改造且无法离线验证）。改为把缺口**显式化且可测**：新增
+    `component_coverage.unaggregated_components`，并用从源码推导发射者清单的测试防止新增
+    发射者继续静默扩大盲区。
+  - `_configured_mailbox_root` 在 `signal_collectors.py` 与 `plugins/modules/messaging/mailbox.py`
+    逐字重复：合并需要从 portable module 反向 import memory_os 核心，越过模块边界，故有意
+    接受重复并在此登记。
+  - `error_registry.py` 零注册错误码（所有 code 经 `unregistered_error_code(...)` 落到
+    `production_severity="unknown"`）；`candidate_aggregation.py` 三处
+    `start_resolver_auto_approve_envelope` 后的写入无异常保护（与第 2 项同类，白名单外未修）。
+  - 主机侧：未触碰 hermes-media / hermes-feiniu。
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -1187,3 +1272,15 @@ sannai-community 仓库 README。）
   （有意减少 71，对应 6 个整体迁出的测试文件 + 2 个混合文件定向裁剪，非回归）/ 2 failed（同
   BK/BM/BO/BP 既有 skip-count 环境伪影）/ 13 skipped，静态门全过（import cycle 165/0、write
   surface 151/151、static hygiene、public checkout probe --strict、git diff --check）。
+- `47bbc13..（BR，本节）`：全项目审查改按**不变量**切片（ExecutionGate / 无声失败 /
+  OwnerGate 授权 / import 拓扑 + substrate 权威 / 并行注册表），28 项发现分 8 个文件互斥包
+  修复。最重一项为**已实测复现的所有者授权绕过**——`oa_` 是无密钥确定性哈希，仅凭记录 id
+  即可离线伪造 revoke/demote 并绕过 `require_recorded_digest`（且在"已存在摘要"的生产常态下
+  同样成立），改为按风险类默认拒绝；另修 ExecutionGate 许可证泄漏 ×2、substrate 自称权威、
+  cron 注册表漂移（`clearance_cycle` 从未被安装）、StateOverlay 六处 section 副本、4 处错误
+  可见性缺口、community 主机退役机制 + 公开文档漂移。顺带查实
+  `sweep_unavailable_open_proposals_on_flag_flip` 因 `append_terminal(detail=...)` 参数不存在
+  而**从未成功清扫过**。全量本地（Windows）2968 passed / 2 failed → **3023 passed / 0 failed**
+  / 13 skipped（+55），**首次全绿**；静态门全过（import cycle 0 环、write surface
+  unclassified 0、static hygiene、public checkout probe --strict exit 0、git diff --check）。
+  `oa_` 密钥化、monitor 11 组件采集接线、主机侧退役执行均**有意未做**并在 BR 节登记原因。

--- a/plugins/memory/memory_os/clearance_cycle.py
+++ b/plugins/memory/memory_os/clearance_cycle.py
@@ -19,6 +19,7 @@ from .clearance_receipts import (
     read_clearance_receipts,
     write_clearance_receipt,
 )
+from .jsonl_io import build_error_record
 
 
 # ── E4: Rejudge queue ──────────────────────────────────────────────────────
@@ -260,11 +261,25 @@ def run_clearance_cycle(
             report["judged"] += 1
             report["verdict_distribution"][verdict] += 1
         except Exception as exc:
-            report["error_records"].append({
-                "record_id": record_id,
-                "error_code": type(exc).__name__,
-                "error_summary": str(exc)[:200],
-            })
+            report["error_records"].append(
+                build_error_record(
+                    component="clearance_cycle",
+                    operation="run_clearance_cycle_judge_item",
+                    error_code=type(exc).__name__,
+                    severity="error",
+                    recoverable=True,
+                    details={"record_id": record_id, "error_summary": str(exc)[:200]},
+                )
+            )
+
+    # Total-failure gate: a single bad record is expected/recoverable noise
+    # (it stays unjudged and is retried next cycle), so it must not flip the
+    # cron exit code (memory_os_clearance_cycle_helper.py maps status=="ok"
+    # to exit 0). But if EVERY attempted item in the batch errored, nothing
+    # useful was accomplished this cycle and that must be visible as a
+    # real failure, not silently reported "ok".
+    if batch and len(report["error_records"]) == len(batch):
+        report["status"] = "error"
 
     return report
 
@@ -723,31 +738,45 @@ def sweep_unavailable_open_proposals_on_flag_flip(store: Any) -> dict[str, Any]:
     swept_count = 0
     swept_ids: list[str] = []
     error_records: list[dict[str, Any]] = []
+    eligible_count = 0
 
     for state in service.proposals._states().values():
         if state.get("status") not in {"open", "deciding"}:
             continue
         clearance = state.get("clearance")
         if isinstance(clearance, dict) and clearance.get("status") == "unavailable":
+            eligible_count += 1
             proposal_id = str(state.get("proposal_id") or "")
             try:
                 service.proposals.append_terminal(
                     proposal_id,
                     status="revoked",
                     reason="v2e_flag_flip",
-                    detail="swept on v2e flag flip — no clearance receipt available",
                 )
                 swept_count += 1
                 if proposal_id:
                     swept_ids.append(proposal_id)
             except Exception as exc:
-                error_records.append({
-                    "proposal_id": proposal_id,
-                    "error_code": type(exc).__name__,
-                })
+                error_records.append(
+                    build_error_record(
+                        component="clearance_cycle",
+                        operation="sweep_unavailable_open_proposals_on_flag_flip",
+                        error_code=type(exc).__name__,
+                        severity="error",
+                        recoverable=True,
+                        details={"proposal_id": proposal_id},
+                    )
+                )
+
+    # Same total-vs-partial-failure discrimination as run_clearance_cycle:
+    # one proposal failing to sweep is recoverable (it stays open, unswept,
+    # and can be retried on the next flag-flip pass), but if every eligible
+    # proposal failed, the sweep accomplished nothing and that must not be
+    # reported as "ok".
+    status = "error" if eligible_count and len(error_records) == eligible_count else "ok"
 
     return {
-        "status": "ok",
+        "status": status,
         "swept_count": swept_count,
         "swept_proposal_ids": swept_ids,
         "error_records": error_records,

--- a/plugins/memory/memory_os/cognitive_loop.py
+++ b/plugins/memory/memory_os/cognitive_loop.py
@@ -607,11 +607,23 @@ class CognitiveLoopRunner:
             scope=scope,
             boundary=dict(BOUNDARIES),
         )
-        result = GroundTruthMinerModule(self.hermes_home, profile=self.profile).run_once(
-            store=self.store,
-            execution_envelope_id=str(permit.get("execution_gate_envelope_id") or ""),
-            expected_scope=scope,
-        )
+        envelope_id = str(permit.get("execution_gate_envelope_id") or "")
+        try:
+            result = GroundTruthMinerModule(self.hermes_home, profile=self.profile).run_once(
+                store=self.store,
+                execution_envelope_id=envelope_id,
+                expected_scope=scope,
+            )
+        except Exception as exc:
+            complete_execution_gate_envelope(
+                self.store,
+                envelope_id=envelope_id,
+                lane_id=REVERSIBLE_LABELS_LANE_ID,
+                execution_status="error",
+                postcheck=dict(BOUNDARIES),
+                result_summary={"error_type": type(exc).__name__, "message": str(exc)[:200]},
+            )
+            raise
         context["ground_truth_miner_result"] = result
         return result
 
@@ -1214,13 +1226,25 @@ class CognitiveLoopRunner:
             scope=scope,
             boundary=dict(BOUNDARIES),
         )
-        result = collect_and_project_signals(
-            self.store,
-            host_capabilities=capabilities,
-            trigger_type="cognitive_loop",
-            execution_envelope_id=str(permit.get("execution_gate_envelope_id") or ""),
-            expected_scope=scope,
-        )
+        envelope_id = str(permit.get("execution_gate_envelope_id") or "")
+        try:
+            result = collect_and_project_signals(
+                self.store,
+                host_capabilities=capabilities,
+                trigger_type="cognitive_loop",
+                execution_envelope_id=envelope_id,
+                expected_scope=scope,
+            )
+        except Exception as exc:
+            complete_execution_gate_envelope(
+                self.store,
+                envelope_id=envelope_id,
+                lane_id="memory_projection_collect",
+                execution_status="error",
+                postcheck=dict(BOUNDARIES),
+                result_summary={"error_type": type(exc).__name__, "message": str(exc)[:200]},
+            )
+            raise
         context["memory_projection_result"] = result
         return result
 
@@ -1238,13 +1262,25 @@ class CognitiveLoopRunner:
             scope=scope,
             boundary=dict(BOUNDARIES),
         )
-        result = run_left_brain_advisor(
-            self.store,
-            write=True,
-            trigger_type="cognitive_loop",
-            execution_envelope_id=str(permit.get("execution_gate_envelope_id") or ""),
-            expected_scope=scope,
-        )
+        envelope_id = str(permit.get("execution_gate_envelope_id") or "")
+        try:
+            result = run_left_brain_advisor(
+                self.store,
+                write=True,
+                trigger_type="cognitive_loop",
+                execution_envelope_id=envelope_id,
+                expected_scope=scope,
+            )
+        except Exception as exc:
+            complete_execution_gate_envelope(
+                self.store,
+                envelope_id=envelope_id,
+                lane_id="left_brain_advisor_report",
+                execution_status="error",
+                postcheck=dict(BOUNDARIES),
+                result_summary={"error_type": type(exc).__name__, "message": str(exc)[:200]},
+            )
+            raise
         context["left_brain_advisor_result"] = result
         return result
 

--- a/plugins/memory/memory_os/cron_registry.py
+++ b/plugins/memory/memory_os/cron_registry.py
@@ -17,6 +17,17 @@ RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES = frozenset(
         *RETIRED_MEMORY_OS_CRON_SCRIPTS.values(),
         "memory_os_right_brain_expression.py",
         "memory_os_right_brain_expression_outcome_cron.py",
+        # Commit 47bbc13 extracted the "sannai community" feature (see
+        # docs/resolver/hermes-memory-os-optimization-roadmap.md section 11)
+        # out of the repo, but these self-contained community cron scripts
+        # (no ExecutionGate wrapper ever existed for them) can still be
+        # running on already-deployed hosts. Neither their job "name" nor
+        # "script" starts with "memory-os-"/"memory_os_", so without a raw
+        # script-name entry here they fall through to external_unmanaged
+        # (invisible drift) in classify_hermes_cron_jobs instead of the
+        # retired_legacy bucket.
+        "community_monitor.py",
+        "community_partner_reply.py",
     }
 )
 

--- a/plugins/memory/memory_os/index.py
+++ b/plugins/memory/memory_os/index.py
@@ -1017,13 +1017,24 @@ def _entity_index_enabled(store: MemoryOSStore) -> bool:
         return bool(resolve_knob("entity_index_enabled", default=False, roots=store.roots))
     except Exception as _exc:
         from .jsonl_io import build_error_record as _build_error_record
-        _build_error_record(
+        _error_record = _build_error_record(
             component="entity_index",
             operation="knob_resolution",
             error_code="ENTITY_INDEX_KNOB_FAILED",
             severity="warning",
             recoverable=True,
             details={"error": str(_exc)},
+        )
+        # Persisted the same way neighboring index.py operations (index_rebuild,
+        # index_rebuild_failed, index_sync) surface their outcomes — via the
+        # shared audit log — so a corrupt knob-override read is never silently
+        # dropped with zero diagnostic trace.
+        append_audit(
+            store.roots.audit_path,
+            action="entity_index_knob_resolution_failed",
+            status="warning",
+            target=str(store.roots.memory_os_root),
+            details={"error_record": _error_record},
         )
         return False
 

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -158,6 +158,28 @@ PERMANENT_PROMOTION_ACTION_TYPES = {
     "defer_permanent_promotion",
 }
 
+# `_surface_action_token_map` recomputes stable `oa_` tokens from CURRENT live
+# state, so a surface-token match is not proof that a digest was ever rendered,
+# delivered, or recorded. When a caller demands a recorded digest binding (the
+# Hermes reply ingress always does), only these actions may be resolved from a
+# surface token — each one is surfaced to the owner by its own bounded review
+# surface and none is on the permanent OwnerGate boundary:
+#   * mark_feedback / expression feedback — report-only rating writes.
+#   * apply_proposal — already owner-approved, OpsGate would_allow, bounded
+#     proposal kinds only, and published with an explicit apply affordance by
+#     `_attach_proposal_followup_apply_actions`.
+# Everything else defaults to refused, which today means the OwnerGate-class
+# crystallized revoke/demote pair from `_crystallized_revoke_action_token_map`
+# (never rendered into any digest or owner surface, so a surface match there is
+# only ever an offline-computed token) and any surface map added later.
+DIGEST_OPTIONAL_SURFACE_ACTION_TYPES = frozenset(
+    {"mark_feedback", "apply_proposal", *EXPRESSION_FEEDBACK_ACTION_TYPES}
+)
+
+DIGEST_OPTIONAL_SURFACE_TARGET_TYPES = frozenset(
+    {"memory_source", "expression", "proposal"}
+)
+
 ACTION_TYPES = {
     "approve_candidate",
     "reject_candidate",
@@ -370,13 +392,34 @@ def _candidate_aggregation_status_block(store: MemoryOSStore) -> dict[str, Any]:
                     component="owner_actions._candidate_aggregation_status_block",
                     operation="candidate_aggregation_status_read",
                     error_code="candidate_aggregation_status_read_failed",
-                    severity="warn",
+                    severity="warning",
                     recoverable=True,
                     details={"error_type": type(exc).__name__, "message": str(exc)[:200]},
                 ),
             )
-        except Exception:
-            pass
+        except Exception as record_exc:
+            try:
+                append_audit(
+                    store.roots.audit_path,
+                    action="owner_digest_error_record_failed",
+                    status="warning",
+                    target=str(store.roots.memory_os_root / "system" / "error_records.jsonl"),
+                    details={
+                        "component": "owner_actions._candidate_aggregation_status_block",
+                        "operation": "candidate_aggregation_status_read",
+                        "original_error_type": type(exc).__name__,
+                        "original_error_message": str(exc)[:200],
+                        "error_record_write_error_type": type(record_exc).__name__,
+                        "error_record_write_error_message": str(record_exc)[:200],
+                    },
+                )
+            except Exception as audit_exc:
+                print(
+                    "Memory-OS owner digest candidate aggregation error reporting failed: "
+                    f"record={type(record_exc).__name__}:{str(record_exc)[:120]} "
+                    f"audit={type(audit_exc).__name__}:{str(audit_exc)[:120]}",
+                    file=sys.stderr,
+                )
         latest = None
     if not latest:
         return {
@@ -2095,6 +2138,16 @@ def parse_owner_review_reply(
         max_fyi=max_fyi,
     )
     surface_token_match = _surface_action_token_map(store.roots).get(action_token) if action_token else None
+    if surface_token_match is not None and require_recorded_digest:
+        # OwnerGate boundary: surface token maps are derived from live state, so
+        # they can never substitute for proof that a digest was recorded. Drop
+        # high-risk surface matches here so the token must be found in the
+        # resolved recorded digest below. Reuses the existing not-found reason
+        # codes on purpose — the reply ingress retries its other candidate
+        # channels for exactly those reasons, and a legitimate token recorded on
+        # another channel must still resolve.
+        if not _surface_token_allowed_without_recorded_digest(surface_token_match):
+            surface_token_match = None
     if binding == "digest_not_found" and not surface_token_match:
         return _reply_result(
             status="needs_clarification",
@@ -2122,7 +2175,11 @@ def parse_owner_review_reply(
     if action_token:
         token_match = _rendered_action_token_map(rendered).get(action_token)
         if not token_match:
-            token_match = surface_token_match or _surface_action_token_map(store.roots).get(action_token)
+            # Deliberately reuse the single surface lookup resolved above: a
+            # second `_surface_action_token_map` call would recompute the same
+            # live-state map and re-admit high-risk tokens that the
+            # recorded-digest guard just refused.
+            token_match = surface_token_match
         if token_match:
             item = token_match["item"]
             action_type = str(token_match.get("action_type") or "")
@@ -5834,6 +5891,24 @@ def _review_action(verb: str, action_type: str, target_type: str, target_id: str
 
 
 def _action_token(*, action_type: str, target_type: str, target_id: str) -> str:
+    """Stable, PUBLIC owner-action identity — never a secret, never an authority.
+
+    The digest is a keyless SHA256 over public-format strings, so anyone who
+    learns an action type plus a target id (both of which appear in prefetch
+    context, digests, and `safe_source_ids`) can recompute the token offline.
+    Contrast `permanent_promotion.issue_token`, which mints `ppmt_` tokens from
+    `secrets.token_urlsafe(32)` and is a real bearer secret — that is why
+    `_redact_permanent_action_tokens` redacts `ppmt_` but leaves `oa_` in place.
+
+    Consequences for every caller:
+      * An `oa_` token proves owner INTENT only in combination with a recorded
+        digest binding, or with a low-risk surface allowlisted by
+        `_surface_token_allowed_without_recorded_digest`. It is never on its own
+        proof that the owner saw or approved anything.
+      * Do not add a new `_surface_action_token_map` contributor for any
+        OwnerGate-class action expecting the token itself to gate it.
+    """
+
     payload = "|".join([str(action_type), str(target_type), str(target_id)])
     return "oa_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:14]
 
@@ -5954,7 +6029,7 @@ def _rendered_digest_text(
                         component="owner_actions._rendered_digest_text",
                         operation="edge_digest_query",
                         error_code="edge_digest_query_failed",
-                        severity="warn",
+                        severity="warning",
                         recoverable=True,
                         details={"error_type": type(exc).__name__, "message": str(exc)[:200]},
                     ),
@@ -6159,6 +6234,28 @@ MEMORY_SOURCE_FEEDBACK_CONTEXT_RATINGS = (
     "clarification_selected",
     "clarification_rejected",
 )
+
+
+def _surface_token_allowed_without_recorded_digest(token_match: dict[str, Any] | None) -> bool:
+    """Only low-risk feedback surface tokens may act without a recorded digest.
+
+    Surface token maps are recomputed from current live state, so matching one
+    proves nothing about digest delivery. Callers that require a recorded digest
+    binding must not let a surface match stand in for that proof on any
+    OwnerGate-class action (crystallized revoke/demote, proposal apply, speak
+    permission, session-mirror graduation, provisional confirm, permanent
+    promotion). Both the action type and the target type must be low risk, so a
+    future surface map cannot widen the hole by reusing a feedback action type
+    against a governed target.
+    """
+
+    if not isinstance(token_match, dict):
+        return False
+    action_type = str(token_match.get("action_type") or "")
+    target_type = str(token_match.get("target_type") or "")
+    if action_type not in DIGEST_OPTIONAL_SURFACE_ACTION_TYPES:
+        return False
+    return target_type in DIGEST_OPTIONAL_SURFACE_TARGET_TYPES
 
 
 def _surface_action_token_map(roots: MemoryOSRoots) -> dict[str, dict[str, Any]]:

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -937,13 +937,19 @@ def _append_section(sections: list[tuple[str, list[str]]], title: str, lines: li
         sections.append((title, lines))
 
 
-def _overlay_has_data(overlay: dict[str, Any]) -> bool:
-    """Return True if at least one overlay section has actual data."""
-    for key in (
-        "identity_snapshot", "relationship_snapshot", "active_projects",
-        "open_threads", "recent_events", "owner_preferences",
-        "capability_map", "material_index",
-    ):
+def _overlay_has_data(overlay: dict[str, Any], section_keys: tuple[str, ...]) -> bool:
+    """Return True if at least one overlay section has actual data.
+
+    *section_keys* must be the full set of StateOverlay section fields
+    (``state_overlay_schema.OVERLAY_SECTION_FIELDS``) — the caller passes it
+    in rather than this function importing/hardcoding it at module level, so
+    this module keeps its fail-open behavior when the state_overlay feature
+    isn't deployed on a given host (see the guarded import in
+    ``_state_overlay_lines`` below). A previously hardcoded copy of this
+    section list silently excluded a since-removed section (community_snapshot)
+    for its entire lifetime because it was never kept in sync with the schema.
+    """
+    for key in section_keys:
         section = overlay.get(key)
         if isinstance(section, dict) and section.get("status") == "ok":
             return True
@@ -967,6 +973,7 @@ def _state_overlay_lines(
     try:
         from .state_overlay import build_state_overlay as _build
         from .state_overlay_renderer import render_state_overlay_md as _render
+        from .state_overlay_schema import OVERLAY_SECTION_FIELDS
     except ImportError:
         return []
 
@@ -994,7 +1001,7 @@ def _state_overlay_lines(
 
     # Suppress overlay when no section has any data — an empty overlay
     # must not consume prefetch budget or pollute context.
-    if not _overlay_has_data(overlay):
+    if not _overlay_has_data(overlay, OVERLAY_SECTION_FIELDS):
         return []
     try:
         md = _render(overlay)

--- a/plugins/memory/memory_os/recall_arbitration.py
+++ b/plugins/memory/memory_os/recall_arbitration.py
@@ -11,6 +11,7 @@ from .recall_policy import (
     AUTHORITY_FRESHNESS_MATRIX_DIGEST,
     AUTHORITY_FRESHNESS_MATRIX_VERSION,
     OBSERVATION_WINDOW_ID,
+    resolve_authority_rank,
 )
 from .recall_types import RecallObject, RecallType
 
@@ -48,6 +49,7 @@ def build_recall_plan(
     candidates: list[dict[str, Any]] = []
     suppressed: list[dict[str, Any]] = []
     shadow_findings: list[dict[str, Any]] = []
+    unknown_authority_classes: set[str] = set()
     for index, obj in enumerate(objects):
         fingerprint = content_fingerprint(obj.content)
         authority = obj.authority_class or str(obj.metadata.get("authority_class") or "") or _DEFAULT_AUTHORITY.get(obj.recall_type, "")
@@ -56,12 +58,24 @@ def build_recall_plan(
         metadata = obj.metadata if isinstance(obj.metadata, dict) else {}
         source_rev = str(metadata.get("source_updated_at") or "")
         cooldown_escape_reason = _cooldown_escape_reason(obj, current_query=current_query)
+        # Defect-2 fix: `authority` may carry either this module's native
+        # arbitration vocabulary OR a raw substrates-layer vocabulary
+        # string (see recall_policy.resolve_authority_rank). A plain
+        # `_AUTHORITY_RANK.get(authority, 0)` would silently rank an
+        # unrecognized-but-genuinely-authoritative string (e.g.
+        # "local_canonical") at 0 -- the same tier as an intentionally
+        # empty value, and BELOW Hindsight's own "external_unverified"
+        # (rank 1). `resolve_authority_rank` maps known substrates values
+        # explicitly and flags anything recognized by neither vocabulary.
+        authority_rank, authority_recognized = resolve_authority_rank(authority)
+        if not authority_recognized:
+            unknown_authority_classes.add(authority)
         entry = {
             "index": index,
             "object": obj,
             "fingerprint": fingerprint,
             "authority_class": authority,
-            "authority_rank": _AUTHORITY_RANK.get(authority, 0),
+            "authority_rank": authority_rank,
             "freshness": max(0.0, min(1.0, float(obj.freshness))),
             "task_revision": task_revision,
             "source_rev": source_rev,
@@ -221,6 +235,7 @@ def build_recall_plan(
         "near_duplicate_count": near_duplicate_count,
         "ambiguous_pair_count": ambiguous_pair_count,
         "conflict_count": len(conflicts),
+        "unknown_authority_classes": sorted(unknown_authority_classes),
         "used_budget_chars": used_chars,
         "budget_chars": max(0, int(budget_chars)),
         "selected": selected,

--- a/plugins/memory/memory_os/recall_policy.py
+++ b/plugins/memory/memory_os/recall_policy.py
@@ -57,6 +57,59 @@ AUTHORITY_FRESHNESS_MATRIX_DIGEST = authority_freshness_matrix_digest(AUTHORITY_
 OBSERVATION_WINDOW_ID = f"{AUTHORITY_FRESHNESS_MATRIX_VERSION}:{AUTHORITY_FRESHNESS_MATRIX_DIGEST}"
 
 
+# --- Bridge for the substrates-layer authority vocabulary ------------------
+#
+# Two independent vocabularies encode the same "how authoritative is this
+# fact" invariant in this codebase:
+#
+#   * this module's arbitration vocabulary, keyed directly in
+#     ``AUTHORITY_FRESHNESS_MATRIX["authority_rank"]`` above
+#     (direct_current_task .. external_unverified, plus "").
+#   * the substrates vocabulary produced by GroundingFact-based providers
+#     (plugins/memory/memory_os/substrates/base.py): "local_canonical",
+#     "owner_approved", "derived_projection".
+#
+# A RecallObject-based retriever built on top of a substrate (e.g.
+# retrievers/hindsight.py) can end up copying a raw substrates-vocabulary
+# string into ``authority_class``. Looking that string up directly against
+# ``authority_rank`` used to silently default to rank 0 via
+# ``.get(authority, 0)`` for ANY unrecognized value -- including a
+# genuinely authoritative "local_canonical"/"owner_approved" claim, which
+# would then rank BELOW "external_unverified" (rank 1), inverting the
+# local-first authority guarantee with no visible signal. This table maps
+# every known substrates-vocabulary value onto its arbitration-vocabulary
+# equivalent so the lookup is correct instead of a silent zero-default.
+SUBSTRATE_AUTHORITY_ALIASES: dict[str, str] = {
+    "local_canonical": "approved_canonical",
+    "owner_approved": "owner_confirmed",
+    "derived_projection": "external_unverified",
+}
+
+
+def resolve_authority_rank(authority_class: str) -> tuple[int, bool]:
+    """Resolve an ``authority_class`` string to its arbitration rank.
+
+    Checks the native arbitration vocabulary first (``authority_rank``,
+    which also covers the intentionally-empty ``""`` default), then falls
+    back to ``SUBSTRATE_AUTHORITY_ALIASES`` for substrates-vocabulary
+    strings. Returns ``(rank, recognized)``. ``recognized`` is False only
+    when ``authority_class`` matches NEITHER vocabulary -- callers MUST
+    treat that case as a flagged anomaly, not as an ordinary rank-0 fact:
+    an unrecognized string reaching this function is either a bug (typo,
+    stale constant) or drift between the two vocabularies, and silently
+    collapsing it into the same rank as an intentionally-unset value would
+    hide exactly the authority-inversion failure this bridge exists to
+    prevent.
+    """
+    authority_rank_table = AUTHORITY_FRESHNESS_MATRIX["authority_rank"]
+    if authority_class in authority_rank_table:
+        return authority_rank_table[authority_class], True
+    aliased = SUBSTRATE_AUTHORITY_ALIASES.get(authority_class)
+    if aliased is not None and aliased in authority_rank_table:
+        return authority_rank_table[aliased], True
+    return 0, False
+
+
 def evaluate_observation_window(observations: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     """Keep only the latest contiguous suffix produced by the current matrix.
 

--- a/plugins/memory/memory_os/retrievers/hindsight.py
+++ b/plugins/memory/memory_os/retrievers/hindsight.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
+from plugins.memory.memory_os.recall_policy import SUBSTRATE_AUTHORITY_ALIASES
 from plugins.memory.memory_os.recall_types import RecallObject, RecallType
 
 if TYPE_CHECKING:
@@ -67,7 +68,20 @@ class HindsightRetriever:
             summary = str(fact.get("body_summary") or fact.get("summary") or "")
             if not summary.strip():
                 continue
-            authority = str(fact.get("authority_class") or "derived_projection")
+            # Defect-2 bridge: `raw_authority` is in the SUBSTRATES
+            # vocabulary ("local_canonical" / "owner_approved" /
+            # "derived_projection" -- see substrates/base.py), while
+            # RecallObject.authority_class and recall_arbitration's ranking
+            # are keyed on the DISJOINT arbitration vocabulary
+            # (recall_policy.AUTHORITY_FRESHNESS_MATRIX["authority_rank"]).
+            # Copying `raw_authority` straight into the object's authority
+            # field would let an unrecognized substrates string silently
+            # rank at 0 in build_recall_plan (`.get(authority, 0)`).
+            # SUBSTRATE_AUTHORITY_ALIASES maps every known substrates value
+            # onto its arbitration-vocabulary equivalent; the raw value is
+            # still preserved in metadata for audit/debugging.
+            raw_authority = str(fact.get("authority_class") or "derived_projection")
+            authority = SUBSTRATE_AUTHORITY_ALIASES.get(raw_authority, raw_authority)
             try:
                 score = float(fact.get("relevance_score") or fact.get("confidence") or 0.5)
             except (TypeError, ValueError):
@@ -78,9 +92,10 @@ class HindsightRetriever:
                 content=summary[:300],
                 score=score,
                 source_ref=f"hindsight:{str(fact.get('substrate_snapshot_id', ''))}",
+                authority_class=authority,
                 metadata={
                     "advisory_only": True,
-                    "authority_class": authority,
+                    "authority_class": raw_authority,
                     "provider": provider,
                     "recall_llm_triggered": bool(fact.get("recall_llm_triggered")),
                 },

--- a/plugins/memory/memory_os/retrievers/state_overlay.py
+++ b/plugins/memory/memory_os/retrievers/state_overlay.py
@@ -6,9 +6,59 @@ import json
 from typing import Any, TYPE_CHECKING
 
 from plugins.memory.memory_os.recall_types import RecallObject, RecallType
+from plugins.memory.memory_os.state_overlay_schema import OVERLAY_SECTION_FIELDS
 
 if TYPE_CHECKING:
     from plugins.memory.memory_os.store import MemoryOSStore
+
+
+# Sections this retriever surfaces, in priority order (most useful first;
+# preserves the historical iteration order so tie-break behavior between
+# equal-score entries is unchanged). Deliberately excludes capability_map
+# and material_index: state_overlay_schema marks both "not_wired" — no data
+# source is connected, so their status is never "ok" and surfacing them
+# here would only ever be a no-op.
+#
+# This subset must be declared explicitly and exhaustively against
+# OVERLAY_SECTION_FIELDS (the single source of truth in
+# state_overlay_schema.py) — validated below so that a newly added
+# StateOverlay section either lands in _RETRIEVABLE_SECTIONS or
+# _NOT_RETRIEVABLE_SECTIONS explicitly, and can never silently drop out of
+# recall the way `community_snapshot` previously did.
+_RETRIEVABLE_SECTIONS: tuple[str, ...] = (
+    "active_projects", "open_threads", "recent_events",
+    "owner_preferences", "identity_snapshot", "relationship_snapshot",
+)
+_NOT_RETRIEVABLE_SECTIONS: frozenset[str] = frozenset({
+    "capability_map", "material_index",
+})
+
+
+def _assert_sections_classified(
+    section_fields: tuple[str, ...] = OVERLAY_SECTION_FIELDS,
+) -> None:
+    """Raise loudly if any overlay section is neither retrievable nor
+    explicitly marked not-retrievable.
+
+    Called at module import time against the real derived section list.
+    Exposed with an overridable *section_fields* argument so tests can
+    exercise the failure path directly (via an extended/synthetic tuple)
+    without needing to mutate the StateOverlay dataclass itself.
+    """
+    unclassified = (
+        set(section_fields) - set(_RETRIEVABLE_SECTIONS) - _NOT_RETRIEVABLE_SECTIONS
+    )
+    if unclassified:
+        raise RuntimeError(
+            "StateOverlayRetriever: overlay section(s) "
+            f"{sorted(unclassified)} are not classified as retrievable or "
+            "not-retrievable — add each new StateOverlay section to "
+            "_RETRIEVABLE_SECTIONS or _NOT_RETRIEVABLE_SECTIONS in "
+            "plugins/memory/memory_os/retrievers/state_overlay.py."
+        )
+
+
+_assert_sections_classified()
 
 
 class StateOverlayRetriever:
@@ -55,10 +105,7 @@ class StateOverlayRetriever:
 
         objects: list[RecallObject] = []
         overlay_task_revision = str(overlay.get("task_revision") or "")
-        for section_key in (
-            "active_projects", "open_threads", "recent_events",
-            "owner_preferences", "identity_snapshot", "relationship_snapshot",
-        ):
+        for section_key in _RETRIEVABLE_SECTIONS:
             section = overlay.get(section_key)
             if not isinstance(section, dict):
                 continue

--- a/plugins/memory/memory_os/runtime.py
+++ b/plugins/memory/memory_os/runtime.py
@@ -97,153 +97,185 @@ class MemoryOSRuntime:
             },
             precheck={"already_processed_event_count": len(already_processed_ids)},
         )
-        session_mirror_auto_apply = auto_apply_graduated_session_mirror(self.store)
-        events = sorted(self.store.read_events(), key=lambda event: event.ts)
-        # Write event_stats cache for O(1) status/monitor reads
-        try:
-            event_dicts = [e.to_dict() for e in events]
-            stats = build_event_stats(event_dicts)
-            stats.events_root = str(self.store.roots.events_root)
-            write_event_stats(self.store.roots, stats)
-        except Exception as _stats_exc:
-            # stats are best-effort; never fail heartbeat for stats
-            _stats_error = build_error_record(
-                component="runtime",
-                operation="heartbeat_write_event_stats",
-                error_code="event_stats_write_failed",
-                severity="warning",
-                recoverable=True,
-                path=event_stats_path(self.store.roots),
-                details={
-                    "error_type": type(_stats_exc).__name__,
-                    "message": str(_stats_exc)[:200],
-                },
-            )
-            try:
-                _snap_state = self._read_state()
-                _snap_state["suppressed_error_count"] = int(_snap_state.get("suppressed_error_count") or 0) + 1
-                _recent = [
-                    str(c) for c in (
-                        _snap_state.get("recent_error_codes")
-                        if isinstance(_snap_state.get("recent_error_codes"), list)
-                        else []
-                    ) if str(c)
-                ]
-                _recent.append("event_stats_write_failed")
-                _snap_state["recent_error_codes"] = _recent[-5:]
-                _snap_state["last_error_record"] = _stats_error
-                self._write_state(_snap_state)
-            except Exception:
-                pass  # state write itself failed — nothing more we can do
-        pending, cap_deferred = select_events_for_inner_drive(
-            events,
-            processed_ids,
-            max_events=max_events,
-            max_events_per_source_class=max_events_per_source_class,
-        )
-        # Secondary dedup: events that slid out of the 2000-ID window may
-        # already have candidates — check the candidate queue to avoid
-        # re-processing them (duplicate WorkingItems + CrystallizedCandidates).
-        _existing_candidate_event_ids: set[str] = set()
-        for _existing in read_candidate_queue(self.store):
-            for _seid in _existing.source_event_ids:
-                _existing_candidate_event_ids.add(_seid)
-        engine = InnerDriveEngine(self.store)
+        envelope_id = str(runtime_gate.get("execution_gate_envelope_id") or "")
+        # Safe defaults for the error-path postcheck below: if an exception is
+        # raised before these are (re)assigned inside the try block, the except
+        # clause must still be able to report accurate (not fabricated) partial
+        # progress instead of raising UnboundLocalError while handling the error.
+        session_mirror_auto_apply: dict[str, Any] = {}
         processed_now: list[str] = []
-        policy_skipped_now: list[str] = []
-        source_class_counts: dict[str, int] = {}
-        candidate_created_count = 0
         working_created_count = 0
-        newly_processed_count = 0
-        for event in pending:
-            # Skip events that already have a candidate (window-overflow dedup);
-            # still track in processed_now for ID windowing but do NOT count
-            # toward cumulative processed_event_count_total (already counted).
-            if event.id in _existing_candidate_event_ids:
+        candidate_created_count = 0
+        try:
+            session_mirror_auto_apply = auto_apply_graduated_session_mirror(self.store)
+            events = sorted(self.store.read_events(), key=lambda event: event.ts)
+            # Write event_stats cache for O(1) status/monitor reads
+            try:
+                event_dicts = [e.to_dict() for e in events]
+                stats = build_event_stats(event_dicts)
+                stats.events_root = str(self.store.roots.events_root)
+                write_event_stats(self.store.roots, stats)
+            except Exception as _stats_exc:
+                # stats are best-effort; never fail heartbeat for stats
+                _stats_error = build_error_record(
+                    component="runtime",
+                    operation="heartbeat_write_event_stats",
+                    error_code="event_stats_write_failed",
+                    severity="warning",
+                    recoverable=True,
+                    path=event_stats_path(self.store.roots),
+                    details={
+                        "error_type": type(_stats_exc).__name__,
+                        "message": str(_stats_exc)[:200],
+                    },
+                )
+                try:
+                    _snap_state = self._read_state()
+                    _snap_state["suppressed_error_count"] = int(_snap_state.get("suppressed_error_count") or 0) + 1
+                    _recent = [
+                        str(c) for c in (
+                            _snap_state.get("recent_error_codes")
+                            if isinstance(_snap_state.get("recent_error_codes"), list)
+                            else []
+                        ) if str(c)
+                    ]
+                    _recent.append("event_stats_write_failed")
+                    _snap_state["recent_error_codes"] = _recent[-5:]
+                    _snap_state["last_error_record"] = _stats_error
+                    self._write_state(_snap_state)
+                except Exception:
+                    pass  # state write itself failed — nothing more we can do
+            pending, cap_deferred = select_events_for_inner_drive(
+                events,
+                processed_ids,
+                max_events=max_events,
+                max_events_per_source_class=max_events_per_source_class,
+            )
+            # Secondary dedup: events that slid out of the 2000-ID window may
+            # already have candidates — check the candidate queue to avoid
+            # re-processing them (duplicate WorkingItems + CrystallizedCandidates).
+            _existing_candidate_event_ids: set[str] = set()
+            for _existing in read_candidate_queue(self.store):
+                for _seid in _existing.source_event_ids:
+                    _existing_candidate_event_ids.add(_seid)
+            engine = InnerDriveEngine(self.store)
+            policy_skipped_now: list[str] = []
+            source_class_counts: dict[str, int] = {}
+            newly_processed_count = 0
+            for event in pending:
+                # Skip events that already have a candidate (window-overflow dedup);
+                # still track in processed_now for ID windowing but do NOT count
+                # toward cumulative processed_event_count_total (already counted).
+                if event.id in _existing_candidate_event_ids:
+                    processed_ids.add(event.id)
+                    processed_now.append(event.id)
+                    continue
+                result = engine.process_event(event)
+                source_class = result.decision.source_class
+                source_class_counts[source_class] = source_class_counts.get(source_class, 0) + 1
+                if result.working_item is not None:
+                    working_created_count += 1
+                if result.candidate is not None:
+                    append_candidate_queue(self.store, result.candidate)
+                    candidate_created_count += 1
+                if result.working_item is None and result.candidate is None:
+                    policy_skipped_now.append(event.id)
                 processed_ids.add(event.id)
                 processed_now.append(event.id)
-                continue
-            result = engine.process_event(event)
-            source_class = result.decision.source_class
-            source_class_counts[source_class] = source_class_counts.get(source_class, 0) + 1
-            if result.working_item is not None:
-                working_created_count += 1
-            if result.candidate is not None:
-                append_candidate_queue(self.store, result.candidate)
-                candidate_created_count += 1
-            if result.working_item is None and result.candidate is None:
-                policy_skipped_now.append(event.id)
-            processed_ids.add(event.id)
-            processed_now.append(event.id)
-            newly_processed_count += 1
+                newly_processed_count += 1
 
-        working = WorkingMemoryService(self.store)
-        decayed_documents: list[str] = []
-        pruned_total = 0
-        for kind in sorted(ALLOWED_WORKING_KINDS):
-            before = working.read_document(kind)
-            if before.get("items"):
-                working.decay_items(kind, now=current, audit_write=False)
-                pruned_total += working.prune_expired_items(kind, now=current, audit_write=False)
-                decayed_documents.append(kind)
+            working = WorkingMemoryService(self.store)
+            decayed_documents: list[str] = []
+            pruned_total = 0
+            for kind in sorted(ALLOWED_WORKING_KINDS):
+                before = working.read_document(kind)
+                if before.get("items"):
+                    working.decay_items(kind, now=current, audit_write=False)
+                    pruned_total += working.prune_expired_items(kind, now=current, audit_write=False)
+                    decayed_documents.append(kind)
 
-        latest_processed_event_id = processed_now[-1] if processed_now else str(state.get("last_processed_event_id") or "")
-        current_ts = current.isoformat()
-        # Maintain full processed ledger for dedup (primary) + recent window (shadow/observability).
-        # Full ledger is restored until EventCursor apply takes over dedup.
-        prev_full = list(state.get("processed_event_ids") or state.get("recent_processed_event_ids", []))
-        full_processed_ids = _dedupe_preserve_order(prev_full + processed_now)
-        recent_processed_ids = full_processed_ids[-RECENT_PROCESSED_EVENT_IDS_LIMIT:]
-        self._write_state(
-            {
-                "schema_version": "memory-os.runtime_state.v0",
-                "last_attempt_at": current_ts,
-                "last_heartbeat_at": current_ts,
-                "processed_event_count": state.get("processed_event_count_total", 0) + newly_processed_count,
-                "processed_event_count_total": state.get("processed_event_count_total", 0) + newly_processed_count,
-                "last_processed_event_id": latest_processed_event_id,
-                "last_processed_event_ts": current_ts,
-                "processed_event_ids": full_processed_ids,
-                "recent_processed_event_ids": recent_processed_ids,
-                "recent_processed_event_ids_limit": RECENT_PROCESSED_EVENT_IDS_LIMIT,
-                "processed_event_ids_compacted": False,
+            latest_processed_event_id = processed_now[-1] if processed_now else str(state.get("last_processed_event_id") or "")
+            current_ts = current.isoformat()
+            # Maintain full processed ledger for dedup (primary) + recent window (shadow/observability).
+            # Full ledger is restored until EventCursor apply takes over dedup.
+            prev_full = list(state.get("processed_event_ids") or state.get("recent_processed_event_ids", []))
+            full_processed_ids = _dedupe_preserve_order(prev_full + processed_now)
+            recent_processed_ids = full_processed_ids[-RECENT_PROCESSED_EVENT_IDS_LIMIT:]
+            self._write_state(
+                {
+                    "schema_version": "memory-os.runtime_state.v0",
+                    "last_attempt_at": current_ts,
+                    "last_heartbeat_at": current_ts,
+                    "processed_event_count": state.get("processed_event_count_total", 0) + newly_processed_count,
+                    "processed_event_count_total": state.get("processed_event_count_total", 0) + newly_processed_count,
+                    "last_processed_event_id": latest_processed_event_id,
+                    "last_processed_event_ts": current_ts,
+                    "processed_event_ids": full_processed_ids,
+                    "recent_processed_event_ids": recent_processed_ids,
+                    "recent_processed_event_ids_limit": RECENT_PROCESSED_EVENT_IDS_LIMIT,
+                    "processed_event_ids_compacted": False,
+                }
+            )
+            index_counts = MemoryOSIndex(self.store.roots).sync_from_store(self.store)
+            approved_crystallized_record_count = int(index_counts.get("crystallized_records", 0) or 0)
+            report = {
+                "schema_version": "memory-os.heartbeat.v0",
+                "processed_event_count": len(processed_now),
+                "processed_event_ids": processed_now,
+                "policy_skipped_event_count": len(policy_skipped_now),
+                "policy_skipped_event_ids": policy_skipped_now,
+                "cap_deferred_event_count": len(cap_deferred),
+                "cap_deferred_event_ids": [event.id for event in cap_deferred],
+                "source_class_counts": source_class_counts,
+                "working_created_count": working_created_count,
+                "candidate_created_count": candidate_created_count,
+                "already_processed_event_count": len([event for event in events if event.id in already_processed_ids]),
+                "total_event_count": len(events),
+                "working_item_count": _working_item_count(self.store),
+                "candidate_count": len(read_candidate_queue(self.store.roots)),
+                "crystallized_record_count": approved_crystallized_record_count,
+                "approved_crystallized_record_count": approved_crystallized_record_count,
+                "legacy_markdown_record_block_count": _legacy_markdown_record_block_count(self.store),
+                "index_counts": index_counts,
+                "decayed_documents": decayed_documents,
+                "pruned_working_items": pruned_total,
+                "runtime_state_path": str(self._state_path),
+                "session_mirror_auto_apply": _bounded_session_mirror_auto_apply(session_mirror_auto_apply),
+                "session_mirror_auto_apply_written_event_ids_count": int(
+                    session_mirror_auto_apply.get("written_event_ids_count") or 0
+                ),
+                "runtime_heartbeat_core_execution_gate_envelope_id": envelope_id,
             }
-        )
-        index_counts = MemoryOSIndex(self.store.roots).sync_from_store(self.store)
-        approved_crystallized_record_count = int(index_counts.get("crystallized_records", 0) or 0)
-        report = {
-            "schema_version": "memory-os.heartbeat.v0",
-            "processed_event_count": len(processed_now),
-            "processed_event_ids": processed_now,
-            "policy_skipped_event_count": len(policy_skipped_now),
-            "policy_skipped_event_ids": policy_skipped_now,
-            "cap_deferred_event_count": len(cap_deferred),
-            "cap_deferred_event_ids": [event.id for event in cap_deferred],
-            "source_class_counts": source_class_counts,
-            "working_created_count": working_created_count,
-            "candidate_created_count": candidate_created_count,
-            "already_processed_event_count": len([event for event in events if event.id in already_processed_ids]),
-            "total_event_count": len(events),
-            "working_item_count": _working_item_count(self.store),
-            "candidate_count": len(read_candidate_queue(self.store.roots)),
-            "crystallized_record_count": approved_crystallized_record_count,
-            "approved_crystallized_record_count": approved_crystallized_record_count,
-            "legacy_markdown_record_block_count": _legacy_markdown_record_block_count(self.store),
-            "index_counts": index_counts,
-            "decayed_documents": decayed_documents,
-            "pruned_working_items": pruned_total,
-            "runtime_state_path": str(self._state_path),
-            "session_mirror_auto_apply": _bounded_session_mirror_auto_apply(session_mirror_auto_apply),
-            "session_mirror_auto_apply_written_event_ids_count": int(
-                session_mirror_auto_apply.get("written_event_ids_count") or 0
-            ),
-            "runtime_heartbeat_core_execution_gate_envelope_id": str(
-                runtime_gate.get("execution_gate_envelope_id") or ""
-            ),
-        }
+        except Exception as exc:
+            complete_execution_gate_envelope(
+                self.store,
+                envelope_id=envelope_id,
+                lane_id="runtime_heartbeat_core",
+                execution_status="error",
+                postcheck={
+                    "processed_event_count": len(processed_now),
+                    "working_created_count": working_created_count,
+                    "candidate_created_count": candidate_created_count,
+                    "boundary": {
+                        "actual_send": False,
+                        "actual_execute": False,
+                        "actual_identity_write": False,
+                        "actual_unapproved_crystallized_approval": False,
+                    },
+                },
+                result_summary={
+                    "error_type": type(exc).__name__,
+                    "message": str(exc)[:200],
+                    "processed_event_count": len(processed_now),
+                    "session_mirror_auto_apply_written_event_ids_count": int(
+                        session_mirror_auto_apply.get("written_event_ids_count") or 0
+                    ),
+                },
+            )
+            raise
         complete_execution_gate_envelope(
             self.store,
-            envelope_id=str(runtime_gate.get("execution_gate_envelope_id") or ""),
+            envelope_id=envelope_id,
             lane_id="runtime_heartbeat_core",
             execution_status="ok",
             postcheck={

--- a/plugins/memory/memory_os/session_mirror.py
+++ b/plugins/memory/memory_os/session_mirror.py
@@ -291,6 +291,11 @@ class SessionMirror:
 
     def __init__(self, store: MemoryOSStore) -> None:
         self.store = store
+        # Bounded error records for session files that could not be read or
+        # parsed during the most recent _read_session_json_files() pass.
+        # A dropped session file must never be indistinguishable from one
+        # that never existed — `doctor()` surfaces these as findings.
+        self._session_read_error_records: list[dict[str, Any]] = []
 
     @property
     def state_db_path(self) -> Path:
@@ -338,6 +343,20 @@ class SessionMirror:
                 findings.append(_finding("session_state_db_unreadable", "error", "state.db cannot be read in read-only mode", {"error": str(exc)}))
         if self.sessions_root.exists() and not self.sessions_root.is_dir():
             findings.append(_finding("sessions_root_not_directory", "error", "sessions root exists but is not a directory"))
+        if self.sessions_root.is_dir():
+            # Surface session files that were skipped during discovery. Without
+            # this, a dropped session is indistinguishable from one that never
+            # existed: it silently never reaches the auto-apply candidate list.
+            self._read_session_json_files()
+            for error_record in self._session_read_error_records:
+                findings.append(
+                    _finding(
+                        str(error_record.get("error_code") or "session_json_unreadable"),
+                        "warning",
+                        "A session file was skipped and excluded from the SessionMirror candidate list.",
+                        {"error_record": error_record},
+                    )
+                )
         status = "error" if any(finding["severity"] == "error" for finding in findings) else "ok"
         return {
             "schema_version": "memory-os.session_mirror_doctor.v0",
@@ -551,12 +570,38 @@ class SessionMirror:
         if not self.sessions_root.exists():
             return []
         sessions: list[dict[str, Any]] = []
+        self._session_read_error_records = []
         for path in sorted(self.sessions_root.glob("session_*.json")):
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
-            except Exception:
+            except Exception as exc:
+                # A truncated / non-UTF8 / unreadable session file used to be
+                # skipped silently, so it simply vanished from the auto-apply
+                # candidate list with no operator-visible signal.
+                self._session_read_error_records.append(
+                    build_error_record(
+                        component="session_mirror",
+                        operation="read_session_json_files",
+                        error_code="session_json_unreadable",
+                        severity="warning",
+                        recoverable=True,
+                        path=path,
+                        details={"error_type": type(exc).__name__, "message": str(exc)[:200]},
+                    )
+                )
                 continue
             if not isinstance(data, dict):
+                self._session_read_error_records.append(
+                    build_error_record(
+                        component="session_mirror",
+                        operation="read_session_json_files",
+                        error_code="session_json_not_an_object",
+                        severity="warning",
+                        recoverable=True,
+                        path=path,
+                        details={"parsed_type": type(data).__name__},
+                    )
+                )
                 continue
             session_id = str(data.get("id") or data.get("session_id") or path.stem)
             platform = str(data.get("platform") or data.get("source") or data.get("channel") or "unknown")

--- a/plugins/memory/memory_os/signal_collectors.py
+++ b/plugins/memory/memory_os/signal_collectors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -775,8 +776,58 @@ def _owner_review_pressure_payload(roots: MemoryOSRoots, base: dict[str, Any]) -
     }
 
 
+_MAILBOX_AGENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _configured_mailbox_root(hermes_home: Path) -> Path | None:
+    """Resolve a per-agent mailbox root from config.yaml.
+
+    Reads ``platforms.mailbox.extra.root`` and ``platforms.mailbox.extra.agent_id``
+    from ``<hermes_home>/config.yaml``. Both fields must be present and valid
+    (``agent_id`` must match ``[A-Za-z0-9_-]{1,64}``) for a configured root to
+    be returned; a relative ``root`` is resolved against ``hermes_home``. The
+    returned path is the bare per-agent directory (``<root>/agents/<agent_id>``)
+    -- callers append their own ``inbox``/``outbox`` suffixes, mirroring how the
+    hardcoded fallback roots are also bare directories.
+
+    Returns ``None`` -- never raises -- when config.yaml is absent, unreadable,
+    malformed, or the mailbox/extra fields are missing or invalid, so callers
+    can fall back to their existing hardcoded probe unchanged.
+    """
+    config_path = hermes_home / "config.yaml"
+    if not config_path.is_file():
+        return None
+    try:
+        import yaml
+
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    platforms = loaded.get("platforms")
+    mailbox_cfg = platforms.get("mailbox") if isinstance(platforms, dict) else None
+    extra = mailbox_cfg.get("extra") if isinstance(mailbox_cfg, dict) else None
+    if not isinstance(extra, dict):
+        return None
+    raw_root = extra.get("root")
+    agent_id = extra.get("agent_id")
+    if not isinstance(raw_root, str) or not raw_root.strip():
+        return None
+    if not isinstance(agent_id, str) or not _MAILBOX_AGENT_ID_PATTERN.fullmatch(agent_id):
+        return None
+    root_path = Path(raw_root.strip())
+    if not root_path.is_absolute():
+        root_path = hermes_home / root_path
+    return root_path / "agents" / agent_id
+
+
 def _mailbox_payload(roots: MemoryOSRoots, base: dict[str, Any]) -> dict[str, Any]:
-    root = _first_existing_path(roots.hermes_home, ("mailbox", "system/mailbox"))
+    configured_root = _configured_mailbox_root(roots.hermes_home)
+    if configured_root is not None and configured_root.exists():
+        root = configured_root
+    else:
+        root = _first_existing_path(roots.hermes_home, ("mailbox", "system/mailbox"))
     inbox = root / "inbox" if root else roots.hermes_home / "mailbox" / "inbox"
     outbox = root / "outbox" if root else roots.hermes_home / "mailbox" / "outbox"
     would_send_records = _read_jsonl(roots.hermes_home / "system-modules" / "mailbox" / "would_send.jsonl")

--- a/plugins/memory/memory_os/state_overlay_renderer.py
+++ b/plugins/memory/memory_os/state_overlay_renderer.py
@@ -14,7 +14,18 @@ from __future__ import annotations
 
 from typing import Any
 
+from .state_overlay_schema import OVERLAY_SECTION_FIELDS
+
 # ── Per-section labels (keep short — every char counts) ─────────────
+#
+# This dict must have an entry for *every* section in OVERLAY_SECTION_FIELDS
+# (the single source of truth in state_overlay_schema.py). Labels are
+# human-readable display strings and cannot be auto-generated, so this is a
+# deliberate, explicit mapping — but it is validated exhaustively below so
+# that adding a section to the StateOverlay dataclass and forgetting to add
+# a label here fails loudly at import time instead of silently rendering
+# that section as blank (this is exactly how `community_snapshot` silently
+# dropped out of several consumers previously).
 _SECTION_LABELS: dict[str, str] = {
     "identity_snapshot": "Identity",
     "relationship_snapshot": "Relationships",
@@ -26,8 +37,58 @@ _SECTION_LABELS: dict[str, str] = {
     "material_index": "Materials",
 }
 
-# Sections rendered in the short (casual-chat) version.
+# Sections rendered in the short (casual-chat) version. A deliberate subset
+# of OVERLAY_SECTION_FIELDS — validated (not exhaustively covered, since it
+# IS a subset) to at least reject typos/unknown section names below.
 _SHORT_SECTIONS = {"active_projects", "open_threads", "owner_preferences"}
+
+# Sections that are known-empty architectural placeholders (no data source
+# wired yet, e.g. capability_map/material_index) or expected to often be
+# empty by nature (identity/relationship crystallized memory). For these we
+# skip the "_(insufficient data)_" marker line entirely rather than waste
+# render budget on a marker for something with no near-term prospect of
+# populating. Every other section is assumed to eventually carry data, so an
+# empty one is worth surfacing to the reader as insufficient rather than
+# silently omitted. Also a deliberate subset of OVERLAY_SECTION_FIELDS.
+_PLACEHOLDER_SECTIONS = {
+    "identity_snapshot", "relationship_snapshot",
+    "capability_map", "material_index",
+}
+
+
+def _assert_labels_cover_all_sections(
+    section_fields: tuple[str, ...] = OVERLAY_SECTION_FIELDS,
+) -> None:
+    """Raise loudly if any overlay section has no display label.
+
+    Called at module import time against the real derived section list.
+    Exposed with an overridable *section_fields* argument so tests can
+    exercise the failure path directly (by passing an extended/synthetic
+    tuple) without needing to mutate the StateOverlay dataclass itself.
+    """
+    missing = set(section_fields) - set(_SECTION_LABELS)
+    if missing:
+        raise RuntimeError(
+            "state_overlay_renderer: no display label for overlay "
+            f"section(s) {sorted(missing)} — add an entry to _SECTION_LABELS "
+            "in plugins/memory/memory_os/state_overlay_renderer.py."
+        )
+
+
+def _assert_subset_known(name: str, subset: set[str]) -> None:
+    """Raise loudly if a declared subset references an unknown section name."""
+    unknown = subset - set(OVERLAY_SECTION_FIELDS)
+    if unknown:
+        raise RuntimeError(
+            f"state_overlay_renderer: {name} references unknown overlay "
+            f"section(s) {sorted(unknown)} — check for typos or a removed "
+            "section in plugins/memory/memory_os/state_overlay_renderer.py."
+        )
+
+
+_assert_labels_cover_all_sections()
+_assert_subset_known("_SHORT_SECTIONS", _SHORT_SECTIONS)
+_assert_subset_known("_PLACEHOLDER_SECTIONS", _PLACEHOLDER_SECTIONS)
 
 
 def render_state_overlay_md(
@@ -90,8 +151,7 @@ def _render(overlay: dict[str, Any], *, max_chars: int, short: bool) -> str:
                     lines.append(line)
         elif status in ("insufficient_data",):
             # Only show insufficient_data for sections that should have data
-            if section_key in ("identity_snapshot", "relationship_snapshot",
-                               "capability_map", "material_index"):
+            if section_key in _PLACEHOLDER_SECTIONS:
                 continue  # skip placeholders — don't waste budget
             lines.append(f"- [{label}] _(insufficient data)_")
         # to_be_populated sections are silently skipped

--- a/plugins/memory/memory_os/state_overlay_schema.py
+++ b/plugins/memory/memory_os/state_overlay_schema.py
@@ -8,9 +8,9 @@ with ``status="insufficient_data"`` rather than fabricated.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, asdict, fields
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, get_type_hints
 
 STATE_OVERLAY_SCHEMA_VERSION = "memory-os.state_overlay.v1"
 
@@ -92,18 +92,41 @@ class StateOverlay:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "schema_version": self.schema_version,
             "generated_at": self.generated_at,
             "profile": self.profile,
-            "identity_snapshot": self.identity_snapshot.to_dict(),
-            "relationship_snapshot": self.relationship_snapshot.to_dict(),
-            "active_projects": self.active_projects.to_dict(),
-            "open_threads": self.open_threads.to_dict(),
-            "recent_events": self.recent_events.to_dict(),
-            "owner_preferences": self.owner_preferences.to_dict(),
-            "capability_map": self.capability_map.to_dict(),
-            "material_index": self.material_index.to_dict(),
-            "risk_notes": list(self.risk_notes),
-            "evidence_refs": list(self.evidence_refs),
         }
+        for name in OVERLAY_SECTION_FIELDS:
+            result[name] = getattr(self, name).to_dict()
+        result["risk_notes"] = list(self.risk_notes)
+        result["evidence_refs"] = list(self.evidence_refs)
+        return result
+
+
+def _compute_overlay_section_fields() -> tuple[str, ...]:
+    """Derive the ordered list of ``StateOverlay`` fields typed ``OverlaySection``.
+
+    This is the single source of truth for "what overlay sections exist".
+    Every other site that needs to enumerate sections — the renderer's
+    labels/short-list, prefetch's has-data check, the refresh script's
+    section counter, and the retriever's section tuple — must derive from
+    this constant instead of hand-maintaining its own copy.
+
+    That hand-maintenance is exactly what caused a real drift bug: when
+    ``community_snapshot`` was removed from this dataclass, several other
+    hardcoded copies elsewhere in the codebase were never updated, and the
+    section silently vanished from those consumers for its entire lifetime
+    without anyone noticing.
+
+    Order matches declaration order in :class:`StateOverlay`, which matches
+    the historical explicit key order used by ``to_dict()``.
+    """
+    hints = get_type_hints(StateOverlay)
+    return tuple(
+        f.name for f in fields(StateOverlay)
+        if hints.get(f.name) is OverlaySection
+    )
+
+
+OVERLAY_SECTION_FIELDS: tuple[str, ...] = _compute_overlay_section_fields()

--- a/plugins/memory/memory_os/substrates/router.py
+++ b/plugins/memory/memory_os/substrates/router.py
@@ -39,6 +39,23 @@ def _fact_to_dict(fact: Any) -> dict[str, Any]:
     }
 
 
+def _is_spoofed_local_authority_claim(fact: dict[str, Any]) -> bool:
+    """True when a NON-local-artifact provider self-reports a local
+    authority_class (``local_canonical`` / ``owner_approved``).
+
+    Provider identity is checked structurally -- ``provider ==
+    "local_artifact"`` -- never inferred from the fact's own claim. Every
+    substrate GroundingFact is supposed to be ``advisory_only=True`` /
+    ``authority_class="derived_projection"`` (see substrates/base.py and
+    this repo's CLAUDE.md: LocalArtifactProvider is the sole primary
+    authority). A fact from any other provider claiming otherwise is a
+    guard violation regardless of its own ``advisory_only`` value.
+    """
+    provider = str(fact.get("provider") or "")
+    authority_class = str(fact.get("authority_class") or "")
+    return provider != "local_artifact" and authority_class in LOCAL_AUTHORITY_CLASSES
+
+
 def _rank_fact(fact: dict[str, Any]) -> tuple[int, float]:
     authority_class = str(fact.get("authority_class") or "")
     provider = str(fact.get("provider") or "")
@@ -46,11 +63,16 @@ def _rank_fact(fact: dict[str, Any]) -> tuple[int, float]:
         confidence = float(fact.get("confidence") or 0.0)
     except (TypeError, ValueError):
         confidence = 0.0
+    # Tier 0: genuine local-authority facts. Structural provider-identity
+    # check only -- a self-reported authority_class from any OTHER
+    # provider earns no distinguished tier here. (Defense in depth: by the
+    # time facts reach this sort key, SubstrateRouter.recall() has already
+    # excluded spoofed claims from the list entirely -- see
+    # `_is_spoofed_local_authority_claim` -- so this branch is the only
+    # path that can ever produce tier 0.)
     if provider == "local_artifact" and authority_class in LOCAL_AUTHORITY_CLASSES:
         return (0, -confidence)
-    if authority_class in LOCAL_AUTHORITY_CLASSES:
-        return (1, -confidence)
-    return (2, -confidence)
+    return (1, -confidence)
 
 
 class SubstrateRouter:
@@ -59,7 +81,7 @@ class SubstrateRouter:
         self.mode = mode if mode in {"shadow", "active"} else "shadow"
 
     def recall(self, query: str, *, consumer: str) -> dict[str, Any]:
-        facts: list[dict[str, Any]] = []
+        raw_facts: list[dict[str, Any]] = []
         fallback_triggered = True
         for provider in self.providers:
             health = provider.health()
@@ -71,22 +93,29 @@ class SubstrateRouter:
             except Exception:
                 continue
             if provider_facts:
-                facts.extend(_fact_to_dict(fact) for fact in provider_facts)
+                raw_facts.extend(_fact_to_dict(fact) for fact in provider_facts)
                 fallback_triggered = False
-        facts.sort(key=_rank_fact)
-        selected = str(facts[0].get("provider") or "unknown") if facts else "deterministic_fallback"
+
+        # Telemetry (authoritative / external_authoritative_count /
+        # local_first_authority_preserved) is computed from the UNFILTERED
+        # raw_facts so a guard violation is still visible even though it is
+        # excluded from the selectable/returned `facts` below -- detection
+        # must not disappear just because the offending content is dropped.
         authoritative = any(
             str(fact.get("provider") or "") == "local_artifact"
             and fact.get("advisory_only") is False
             and str(fact.get("authority_class") or "") in LOCAL_AUTHORITY_CLASSES
-            for fact in facts
+            for fact in raw_facts
         )
-        external_authoritative_count = sum(
-            1
-            for fact in facts
-            if str(fact.get("provider") or "") != "local_artifact"
-            and str(fact.get("authority_class") or "") in LOCAL_AUTHORITY_CLASSES
-        )
+        external_authoritative_count = sum(1 for fact in raw_facts if _is_spoofed_local_authority_claim(fact))
+
+        # Structural guard: a spoofed local-authority claim from a
+        # non-local_artifact provider is excluded from `facts` entirely --
+        # it must never become `facts[0]`, `selected_provider`, or visible
+        # content, only a counted/flagged violation.
+        facts = [fact for fact in raw_facts if not _is_spoofed_local_authority_claim(fact)]
+        facts.sort(key=_rank_fact)
+        selected = str(facts[0].get("provider") or "unknown") if facts else "deterministic_fallback"
         return {
             "schema_version": "memory-os.substrate_recall.v0",
             "mode": self.mode,
@@ -97,5 +126,5 @@ class SubstrateRouter:
             "external_authoritative_count": external_authoritative_count,
             "local_first_authority_preserved": external_authoritative_count == 0,
             "fallback_triggered": fallback_triggered,
-            "recall_llm_triggered": any(bool(fact.get("recall_llm_triggered")) for fact in facts),
+            "recall_llm_triggered": any(bool(fact.get("recall_llm_triggered")) for fact in raw_facts),
         }

--- a/plugins/modules/messaging/mailbox.py
+++ b/plugins/modules/messaging/mailbox.py
@@ -3,10 +3,57 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+
+
+_MAILBOX_AGENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _configured_mailbox_root(hermes_home: Path) -> Path | None:
+    """Resolve a per-agent mailbox root from config.yaml.
+
+    Reads ``platforms.mailbox.extra.root`` and ``platforms.mailbox.extra.agent_id``
+    from ``<hermes_home>/config.yaml``. Both fields must be present and valid
+    (``agent_id`` must match ``[A-Za-z0-9_-]{1,64}``) for a configured root to
+    be returned; a relative ``root`` is resolved against ``hermes_home``. The
+    returned path is the bare per-agent directory (``<root>/agents/<agent_id>``);
+    ``inbox_root``/``outbox_root`` append their own suffixes on top of it, the
+    same way they do for the hardcoded ``hermes_home / "mailbox"`` default.
+
+    Returns ``None`` -- never raises -- when config.yaml is absent, unreadable,
+    malformed, or the mailbox/extra fields are missing or invalid, so callers
+    fall back to the hardcoded default unchanged.
+    """
+    config_path = hermes_home / "config.yaml"
+    if not config_path.is_file():
+        return None
+    try:
+        import yaml
+
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    platforms = loaded.get("platforms")
+    mailbox_cfg = platforms.get("mailbox") if isinstance(platforms, dict) else None
+    extra = mailbox_cfg.get("extra") if isinstance(mailbox_cfg, dict) else None
+    if not isinstance(extra, dict):
+        return None
+    raw_root = extra.get("root")
+    agent_id = extra.get("agent_id")
+    if not isinstance(raw_root, str) or not raw_root.strip():
+        return None
+    if not isinstance(agent_id, str) or not _MAILBOX_AGENT_ID_PATTERN.fullmatch(agent_id):
+        return None
+    root_path = Path(raw_root.strip())
+    if not root_path.is_absolute():
+        root_path = hermes_home / root_path
+    return root_path / "agents" / agent_id
 
 
 def mailbox_manifest() -> dict[str, Any]:
@@ -54,6 +101,9 @@ class MailboxNoSendModule:
 
     @property
     def mailbox_root(self) -> Path:
+        configured = _configured_mailbox_root(self.hermes_home)
+        if configured is not None:
+            return configured
         return self.hermes_home / "mailbox"
 
     @property

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -54,6 +54,7 @@ SOURCE_FULL_MONITOR_REFRESH = REPO_ROOT / "scripts" / "memory_os_full_monitor_re
 SOURCE_FULL_MONITOR = REPO_ROOT / "scripts" / "memory_os_3_200_monitor.py"
 SOURCE_CLOSURE_RUNTIME_EVIDENCE = REPO_ROOT / "scripts" / "memory_os_closure_runtime_evidence.py"
 SOURCE_LEGACY_RIGHT_BRAIN_RETIREMENT = REPO_ROOT / "scripts" / "memory_os_retire_legacy_right_brain.py"
+SOURCE_COMMUNITY_RETIREMENT = REPO_ROOT / "scripts" / "memory_os_community_retirement.py"
 SOURCE_V3_SEED_EVIDENCE = REPO_ROOT / "scripts" / "memory_os_v3_seed_evidence.py"
 SOURCE_V3_SEED_EVIDENCE_GATE = REPO_ROOT / "scripts" / "memory_os_cron_v3_seed_evidence_gate.py"
 SOURCE_V3_WANDERING = REPO_ROOT / "scripts" / "memory_os_v3_wandering.py"
@@ -1134,7 +1135,6 @@ def _write_module_cadence_report_script(hermes_home: Path, *, dry_run: bool) -> 
     return target
 
 
-
 def _write_operational_helper_scripts(hermes_home: Path, *, dry_run: bool) -> dict[str, Path]:
     sources = {
         "module_cadence_report_cron": SOURCE_MODULE_CADENCE_REPORT_CRON,
@@ -1157,6 +1157,7 @@ def _write_operational_helper_scripts(hermes_home: Path, *, dry_run: bool) -> di
         "full_monitor": SOURCE_FULL_MONITOR,
         "closure_runtime_evidence": SOURCE_CLOSURE_RUNTIME_EVIDENCE,
         "legacy_right_brain_retirement": SOURCE_LEGACY_RIGHT_BRAIN_RETIREMENT,
+        "community_retirement": SOURCE_COMMUNITY_RETIREMENT,
         "v3_seed_evidence": SOURCE_V3_SEED_EVIDENCE,
         "v3_seed_evidence_gate": SOURCE_V3_SEED_EVIDENCE_GATE,
         "v3_wandering": SOURCE_V3_WANDERING,

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -4112,6 +4112,75 @@ def _int_at(payload: dict[str, Any], path: tuple[str, ...]) -> int:
     return _to_int(current)
 
 
+# Every component string passed to `build_error_record(component=...)` anywhere
+# in this repository.
+#
+# `monitor_error_observability` can only roll a component into the headline
+# `suppressed_error_count` / `degraded_component_count` when the snapshot
+# actually carries that component's status payload — and today only four do.
+# The rest still write error records to disk, but those records never reach the
+# monitor, so the headline number silently undercounts.
+#
+# Listing them here does not fix the collection gap; it makes the gap explicit
+# and measurable (`component_coverage.unaggregated_components`) instead of
+# invisible, and `tests/scripts/test_memory_os_3_200_monitor.py` derives the
+# real emitter list from source so a NEW emitter cannot be added without either
+# being aggregated or being consciously recorded here.
+ERROR_RECORD_EMITTING_COMPONENTS = frozenset({
+    "abstraction_distillation",
+    "candidate_aggregation_lane",
+    "candidate_review",
+    "cascade_routing_policy",
+    "clearance_cycle",
+    "entity_index",
+    "feature_score",
+    "imagination_loop",
+    "judge_calibration",
+    "knob_ab_eval",
+    "llm_contradiction_lane",
+    "memory_os.permanent_promotion",
+    "memory_projection",
+    "migration_controller",
+    "override_sweep",
+    "owner_actions._candidate_aggregation_status_block",
+    "owner_actions._rendered_digest_text",
+    "prefetch",
+    "prefetch._crystallized_lines",
+    "prefetch._floor_match_score",
+    "prefetch._indexed_lines",
+    "prefetch_facade",
+    "provenance",
+    "provisional",
+    "provisional_sweep",
+    "runtime",
+    "session_mirror",
+    "shadow_recall",
+    "state_source_mirror",
+    "symbolic_offloader",
+})
+
+
+def _error_record_component_coverage(aggregated: set[str]) -> dict[str, Any]:
+    """Report which error-record emitters the headline aggregate actually covers.
+
+    A component counts as covered when it is aggregated directly or is a dotted
+    sub-component of an aggregated parent (e.g. ``prefetch._indexed_lines`` is
+    covered by ``prefetch``).
+    """
+
+    def _is_covered(name: str) -> bool:
+        return any(name == parent or name.startswith(f"{parent}.") for parent in aggregated)
+
+    unaggregated = sorted(
+        name for name in ERROR_RECORD_EMITTING_COMPONENTS if not _is_covered(name)
+    )
+    return {
+        "aggregated_components": sorted(aggregated),
+        "unaggregated_components": unaggregated,
+        "unaggregated_component_count": len(unaggregated),
+    }
+
+
 def monitor_error_observability(snapshot: dict[str, Any]) -> dict[str, Any]:
     module_artifacts = snapshot.get("module_artifacts") if isinstance(snapshot.get("module_artifacts"), dict) else {}
     component_sources = {
@@ -4174,6 +4243,7 @@ def monitor_error_observability(snapshot: dict[str, Any]) -> dict[str, Any]:
         },
         "recent_error_codes": _bounded_error_codes(recent_codes, limit=10),
         "raw_body_included": raw_body_included,
+        "component_coverage": _error_record_component_coverage(set(component_sources)),
     }
 
 

--- a/scripts/memory_os_community_retirement.py
+++ b/scripts/memory_os_community_retirement.py
@@ -1,0 +1,871 @@
+#!/usr/bin/env python3
+"""Retire on-host residue of the extracted "sannai community" feature.
+
+Commit 47bbc13 removed the community feature's source from this repository:
+8 plugin modules, the installer's community-layout initializer, the
+``deploy_community.py`` helper, the cognitive-loop step, the
+``memory-os-agent-os`` CLI alias, and the StateOverlay section. The repo side
+is clean. Hosts that had already installed and run the feature keep every
+artifact it left behind, because the deployment path never had an inverse
+operation:
+
+- 8 plugin module files under ``plugins/memory_os/`` (``community.py``,
+  ``community_shared.py``, ``community_snapshot.py``, ``community_table.py``,
+  ``community_triggers.py``, ``community_interest_garden.py``,
+  ``community_partner_runtime.py``, ``partner_create.py``). Several contain
+  raw ``open(..., "a")`` append surfaces that were previously enumerated in
+  the write-surface allowlist.
+- the community data layout under ``memory-os/community/`` (``charters/``,
+  ``shared/``, ``partners/``, ``system/``, ``roster.jsonl``,
+  ``budget.yaml`` with ``enforcement: fail-closed``).
+- three executable helper scripts under ``scripts/`` (``deploy_community.py``,
+  ``community_monitor.py``, ``community_partner_reply.py``) whose own logic
+  can still recreate the removed data layout or keep writing to it.
+
+This script performs the missing inverse operation. It ARCHIVES (never
+deletes) that residue under ``memory-os/legacy-archive/community/<timestamp>/``,
+records a bounded manifest under
+``memory-os/system/community_retirement.json``, and leaves a read-only,
+integrity-checkable archive tree. It is idempotent (safe to run twice),
+never auto-invoked by install/deploy, and a no-op when a Hermes home has no
+community residue at all.
+
+Modeled on ``plugins/memory/memory_os/legacy_right_brain_retirement.py``
+(read that module first to see the precedent this mirrors), but kept as a
+single self-contained script rather than a new plugin module: the community
+feature was deliberately extracted out of the Memory-OS package, and no
+runtime code imports this retirement operation. Community work now lives in
+a separate repository, https://github.com/btnalit/sannai-community.
+
+Usage::
+
+    python3 memory_os_community_retirement.py --hermes-home /path/to/.hermes
+        # plan / dry-run (default): reports what WOULD be archived, changes nothing
+
+    python3 memory_os_community_retirement.py --hermes-home /path/to/.hermes --apply
+        # archives residue and writes the retired manifest
+
+    python3 memory_os_community_retirement.py --hermes-home /path/to/.hermes --status
+        # reports bounded audit status only; changes nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - fcntl is always present on POSIX
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - msvcrt exists only on Windows
+    msvcrt = None  # type: ignore[assignment]
+
+
+SCHEMA_VERSION = "memory-os.community_retirement.v0"
+STATUS_SCHEMA_VERSION = "memory-os.community_retirement_status.v0"
+REPLACEMENT = "sannai_community_external_repo"
+SOURCE_REPO = "https://github.com/btnalit/sannai-community"
+
+# Exact residue inventory. Matches the "moved out" record in
+# docs/resolver/hermes-memory-os-optimization-roadmap.md section 11 for what
+# commit 47bbc13 extracted, and the ``target = hermes_home / "plugins" /
+# "memory_os"`` install layout in scripts/install_memory_os_plugin.py.
+COMMUNITY_PLUGIN_MODULE_NAMES = (
+    "community.py",
+    "community_shared.py",
+    "community_snapshot.py",
+    "community_table.py",
+    "community_triggers.py",
+    "community_interest_garden.py",
+    "community_partner_runtime.py",
+    "partner_create.py",
+)
+COMMUNITY_HELPER_SCRIPT_NAMES = (
+    "deploy_community.py",
+    "community_monitor.py",
+    "community_partner_reply.py",
+)
+COMMUNITY_DATA_RELATIVE_PATH = Path("memory-os/community")
+COMMUNITY_SOURCE_RELATIVE_PATHS = (
+    tuple(Path("plugins/memory_os") / name for name in COMMUNITY_PLUGIN_MODULE_NAMES)
+    + tuple(Path("scripts") / name for name in COMMUNITY_HELPER_SCRIPT_NAMES)
+    + (COMMUNITY_DATA_RELATIVE_PATH,)
+)
+MANIFEST_RELATIVE_PATH = Path("memory-os/system/community_retirement.json")
+ARCHIVE_ROOT_RELATIVE_PATH = Path("memory-os/legacy-archive/community")
+LOCK_RELATIVE_PATH = Path("memory-os/system/community_retirement.lock")
+_ARCHIVE_STAMP_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z$")
+
+
+@contextmanager
+def _community_retirement_write_lock(hermes_home: str | Path):
+    with _community_retirement_lock(hermes_home, exclusive=True):
+        yield
+
+
+@contextmanager
+def _community_retirement_lock(hermes_home: str | Path, *, exclusive: bool):
+    home = Path(hermes_home).expanduser().resolve()
+    path = home / LOCK_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, stat.S_IRUSR | stat.S_IWUSR)
+    locked = False
+    try:
+        _lock_descriptor(descriptor, exclusive=exclusive)
+        locked = True
+        yield
+    finally:
+        try:
+            if locked:
+                _unlock_descriptor(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+_WIN32_LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
+
+
+def _win32_lockfileex(descriptor: int, *, exclusive: bool, unlock: bool) -> None:
+    """Windows advisory lock through LockFileEx/UnlockFileEx (mirrors fcntl.flock)."""
+
+    import ctypes
+
+    if msvcrt is None:  # pragma: no cover - neither fcntl nor msvcrt present
+        raise RuntimeError("no advisory file lock primitive available on this platform")
+
+    class _Overlapped(ctypes.Structure):
+        _fields_ = (
+            ("Internal", ctypes.c_void_p),
+            ("InternalHigh", ctypes.c_void_p),
+            ("Offset", ctypes.c_uint32),
+            ("OffsetHigh", ctypes.c_uint32),
+            ("hEvent", ctypes.c_void_p),
+        )
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = ctypes.c_void_p(msvcrt.get_osfhandle(descriptor))
+    overlapped = _Overlapped()
+    if unlock:
+        ok = kernel32.UnlockFileEx(handle, 0, 1, 0, ctypes.byref(overlapped))
+    else:
+        mode = _WIN32_LOCKFILE_EXCLUSIVE_LOCK if exclusive else 0
+        ok = kernel32.LockFileEx(handle, mode, 0, 1, 0, ctypes.byref(overlapped))
+    if not ok:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _lock_descriptor(descriptor: int, *, exclusive: bool) -> None:
+    if fcntl is not None:
+        fcntl.flock(descriptor, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        return
+    _win32_lockfileex(descriptor, exclusive=exclusive, unlock=False)
+
+
+def _unlock_descriptor(descriptor: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return
+    _win32_lockfileex(descriptor, exclusive=False, unlock=True)
+
+
+def retirement_manifest_path(hermes_home: str | Path) -> Path:
+    return Path(hermes_home).expanduser().resolve() / MANIFEST_RELATIVE_PATH
+
+
+def load_retirement_manifest(hermes_home: str | Path) -> dict[str, Any]:
+    path = retirement_manifest_path(hermes_home)
+    if path.is_symlink():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _path_lexists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def _safe_nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed >= 0 else 0
+
+
+def _manifest_validation_errors(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        errors.append("schema_version")
+    if manifest.get("lifecycle") not in {"retirement_pending", "retired"}:
+        errors.append("lifecycle")
+    if manifest.get("active_observation") is not False or manifest.get("active_execution") is not False:
+        errors.append("active_flags")
+    if manifest.get("replacement") != REPLACEMENT:
+        errors.append("replacement")
+    expected_sources = [path.as_posix() for path in COMMUNITY_SOURCE_RELATIVE_PATHS]
+    if manifest.get("source_relative_paths") != expected_sources:
+        errors.append("source_relative_paths")
+    archive_relative = str(manifest.get("archive_relative_path") or "")
+    archive_path = Path(archive_relative)
+    if (
+        archive_path.parent != ARCHIVE_ROOT_RELATIVE_PATH
+        or not _ARCHIVE_STAMP_RE.fullmatch(archive_path.name)
+        or archive_path.is_absolute()
+    ):
+        errors.append("archive_relative_path")
+    archived_files = manifest.get("archived_files")
+    if not isinstance(archived_files, list):
+        errors.append("archived_files")
+        return errors
+    seen: set[str] = set()
+    allowed_prefixes = tuple(
+        f"{path.as_posix()}/" for path in COMMUNITY_SOURCE_RELATIVE_PATHS if path.suffix == ""
+    )
+    allowed_exact = {path.as_posix() for path in COMMUNITY_SOURCE_RELATIVE_PATHS if path.suffix != ""}
+    for record in archived_files:
+        if not isinstance(record, dict):
+            errors.append("archived_file_record")
+            continue
+        relative = str(record.get("relative_path") or "")
+        digest = str(record.get("sha256") or "")
+        if (
+            not relative
+            or relative in seen
+            or (relative not in allowed_exact and not relative.startswith(allowed_prefixes))
+            or not re.fullmatch(r"[0-9a-f]{64}", digest)
+            or not isinstance(record.get("size_bytes"), int)
+            or isinstance(record.get("size_bytes"), bool)
+            or int(record.get("size_bytes") or 0) < 0
+            or not isinstance(record.get("jsonl_record_count"), int)
+            or isinstance(record.get("jsonl_record_count"), bool)
+            or int(record.get("jsonl_record_count") or 0) < 0
+        ):
+            errors.append("archived_file_record")
+        seen.add(relative)
+    if isinstance(manifest.get("archived_file_count"), bool) or manifest.get("archived_file_count") != len(
+        archived_files
+    ):
+        errors.append("archived_file_count")
+    expected_jsonl_count = sum(
+        int(record.get("jsonl_record_count") or 0)
+        for record in archived_files
+        if isinstance(record, dict)
+    )
+    if (
+        isinstance(manifest.get("archived_jsonl_record_count"), bool)
+        or not isinstance(manifest.get("archived_jsonl_record_count"), int)
+        or manifest.get("archived_jsonl_record_count") != expected_jsonl_count
+    ):
+        errors.append("archived_jsonl_record_count")
+    return sorted(set(errors))
+
+
+def retire_community(
+    hermes_home: str | Path,
+    *,
+    apply: bool,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    with _community_retirement_write_lock(hermes_home):
+        return _retire_community_locked(hermes_home, apply=apply, now=now)
+
+
+def _retire_community_locked(
+    hermes_home: str | Path,
+    *,
+    apply: bool,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build or apply an idempotent community retirement plan.
+
+    A Hermes home with zero community residue must be left untouched: no
+    manifest, no archive directory, no lock artifact beyond the lock file
+    itself. That noop path is checked before any prerequisite or archive
+    step runs.
+    """
+
+    home = Path(hermes_home).expanduser().resolve()
+    existing = load_retirement_manifest(home)
+    if existing.get("lifecycle") == "retired":
+        status = retirement_status(home)
+        if status.get("status") != "ok" and status.get("violations") == [
+            "retirement_manifest_writable"
+        ]:
+            manifest_path = retirement_manifest_path(home)
+            manifest_path.chmod(stat.S_IRUSR)
+            _fsync_file(manifest_path)
+            _fsync_directory(manifest_path.parent)
+            status = retirement_status(home)
+            if status.get("status") == "ok":
+                return {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "retired_recovered",
+                    "applied": True,
+                    "manifest_path": str(manifest_path),
+                    "retirement": status,
+                }
+        if status.get("status") != "ok":
+            raise RuntimeError("invalid existing retirement manifest")
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "already_retired",
+            "applied": False,
+            "manifest_path": str(retirement_manifest_path(home)),
+            "retirement": status,
+        }
+    if apply and existing.get("lifecycle") == "retirement_pending":
+        if _manifest_validation_errors(existing):
+            raise RuntimeError("invalid pending retirement manifest")
+        return _recover_pending_retirement(home, existing)
+    if _path_lexists(retirement_manifest_path(home)):
+        raise RuntimeError("invalid existing retirement manifest")
+
+    file_records = _inventory_sources(home)
+    if not file_records:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "noop_no_residue",
+            "applied": False,
+            "manifest_path": str(retirement_manifest_path(home)),
+            "source_relative_paths": [path.as_posix() for path in COMMUNITY_SOURCE_RELATIVE_PATHS],
+        }
+
+    _assert_prerequisites(home)
+    timestamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    retired_at = timestamp.isoformat()
+    archive_stamp = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    archive_rel = ARCHIVE_ROOT_RELATIVE_PATH / archive_stamp
+    archive_root = home / archive_rel
+    cron_records = _community_cron_records(home)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "lifecycle": "retirement_pending" if apply else "retired",
+        "retired_at": retired_at,
+        "cutoff_at": retired_at,
+        "replacement": REPLACEMENT,
+        "source_repo": SOURCE_REPO,
+        "community_cron_jobs": cron_records,
+        "source_relative_paths": [path.as_posix() for path in COMMUNITY_SOURCE_RELATIVE_PATHS],
+        "archive_relative_path": archive_rel.as_posix(),
+        "archived_files": file_records,
+        "archived_file_count": len(file_records),
+        "archived_jsonl_record_count": sum(int(item.get("jsonl_record_count") or 0) for item in file_records),
+        "active_observation": False,
+        "active_execution": False,
+        "raw_body_included": False,
+        "archive_contains_private_bodies": bool(file_records),
+        "actual_send": False,
+        "actual_execute": False,
+    }
+    if not apply:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "dry_run",
+            "applied": False,
+            "manifest_path": str(retirement_manifest_path(home)),
+            "plan": payload,
+        }
+
+    manifest_path = retirement_manifest_path(home)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(manifest_path, payload)
+    _complete_archive_moves(home, archive_root)
+    _make_tree_read_only(archive_root)
+    integrity_errors = _archive_integrity_errors(home, archive_root, payload)
+    if integrity_errors:
+        raise RuntimeError(f"community retirement archive integrity failed: {', '.join(integrity_errors)}")
+    payload["lifecycle"] = "retired"
+    _atomic_write_json(manifest_path, payload)
+    manifest_path.chmod(stat.S_IRUSR)
+    _fsync_file(manifest_path)
+    _fsync_directory(manifest_path.parent)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "retired",
+        "applied": True,
+        "manifest_path": str(manifest_path),
+        "retirement": retirement_status(home),
+    }
+
+
+def _recover_pending_retirement(home: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    archive_rel = str(manifest.get("archive_relative_path") or "")
+    archive_root = _safe_relative_target(home, archive_rel)
+    _complete_archive_moves(home, archive_root)
+    _make_tree_read_only(archive_root)
+    integrity_errors = _archive_integrity_errors(home, archive_root, manifest)
+    if integrity_errors:
+        raise RuntimeError(f"community retirement archive integrity failed: {', '.join(integrity_errors)}")
+    finalized = dict(manifest)
+    finalized["lifecycle"] = "retired"
+    manifest_path = retirement_manifest_path(home)
+    _atomic_write_json(manifest_path, finalized)
+    manifest_path.chmod(stat.S_IRUSR)
+    _fsync_file(manifest_path)
+    _fsync_directory(manifest_path.parent)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "retired_recovered",
+        "applied": True,
+        "manifest_path": str(manifest_path),
+        "retirement": retirement_status(home),
+    }
+
+
+def retirement_status(hermes_home: str | Path) -> dict[str, Any]:
+    """Return bounded audit metadata; never return an archived body."""
+
+    home = Path(hermes_home).expanduser().resolve()
+    manifest_path = retirement_manifest_path(home)
+    manifest = load_retirement_manifest(home)
+    manifest_present = _path_lexists(manifest_path)
+    manifest_errors = _manifest_validation_errors(manifest) if manifest_present else []
+    manifest_writable = bool(
+        manifest_present
+        and not manifest_path.is_symlink()
+        and manifest_path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+    )
+    lifecycle = str(manifest.get("lifecycle") or "active")
+    retired = lifecycle == "retired"
+    pending = lifecycle == "retirement_pending"
+    archive_rel = str(manifest.get("archive_relative_path") or "")
+    archive_root = (
+        _safe_relative_target(home, archive_rel)
+        if archive_rel and "archive_relative_path" not in manifest_errors
+        else None
+    )
+    archived_value = manifest.get("archived_files")
+    archived_files: list[Any] = archived_value if isinstance(archived_value, list) else []
+    hash_mismatches = 0
+    writable_archive_files = 0
+    writable_archive_directories = 0
+    missing_archive_files = 0
+    for record in archived_files:
+        if not isinstance(record, dict) or archive_root is None:
+            hash_mismatches += 1
+            continue
+        relative = str(record.get("relative_path") or "")
+        try:
+            path = _safe_relative_target(archive_root, relative)
+        except RuntimeError:
+            hash_mismatches += 1
+            continue
+        if not path.is_file() or path.is_symlink():
+            missing_archive_files += 1
+            continue
+        if _sha256(path) != str(record.get("sha256") or ""):
+            hash_mismatches += 1
+        if path.stat().st_size != record.get("size_bytes"):
+            hash_mismatches += 1
+        actual_jsonl_count = _jsonl_record_count(path) if path.suffix == ".jsonl" else 0
+        if actual_jsonl_count != record.get("jsonl_record_count"):
+            hash_mismatches += 1
+        if path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH):
+            writable_archive_files += 1
+    if archive_root and archive_root.is_dir():
+        for path in [archive_root, archive_root.parent, *archive_root.rglob("*")]:
+            if path.is_dir() and path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH):
+                writable_archive_directories += 1
+
+    live_inventory_error = False
+    try:
+        live_files = _inventory_sources(home)
+    except RuntimeError:
+        live_files = []
+        live_inventory_error = True
+    live_sources = [
+        relative.as_posix()
+        for relative in COMMUNITY_SOURCE_RELATIVE_PATHS
+        if _path_lexists(home / relative)
+    ]
+    archived_paths = {
+        str(record.get("relative_path") or "")
+        for record in archived_files
+        if isinstance(record, dict)
+    }
+    archive_inventory_error = False
+    try:
+        current_archive = _inventory(archive_root) if archive_root and archive_root.is_dir() else []
+    except RuntimeError:
+        current_archive = []
+        archive_inventory_error = True
+    current_archive_paths = {str(record.get("relative_path") or "") for record in current_archive}
+    archive_extra_files = current_archive_paths - archived_paths
+    cron_registry_error = False
+    try:
+        cron_records = _community_cron_records(home)
+    except RuntimeError:
+        cron_records = []
+        cron_registry_error = True
+    enabled_community_crons = [record["name"] or record["script"] for record in cron_records if record.get("enabled") is True]
+    violations = []
+    if manifest_errors:
+        violations.append("retirement_manifest_invalid")
+    if live_inventory_error:
+        violations.append("community_source_inventory_error")
+    if archive_inventory_error:
+        violations.append("archive_inventory_error")
+    if cron_registry_error:
+        violations.append("community_cron_registry_invalid")
+    if retired and (archive_root is None or not archive_root.is_dir()):
+        violations.append("archive_missing")
+    if retired and manifest_writable:
+        violations.append("retirement_manifest_writable")
+    if pending:
+        violations.append("retirement_pending_incomplete")
+    if retired and live_sources:
+        violations.append("community_source_recreated")
+    if missing_archive_files:
+        violations.append("archive_file_missing")
+    if hash_mismatches:
+        violations.append("archive_hash_mismatch")
+    if writable_archive_files:
+        violations.append("archive_file_writable")
+    if writable_archive_directories:
+        violations.append("archive_directory_writable")
+    if archive_extra_files:
+        violations.append("archive_extra_file")
+    if enabled_community_crons:
+        violations.append("community_cron_enabled")
+    status = (
+        "error"
+        if manifest_present and violations
+        else "error"
+        if pending
+        else "not_retired"
+        if not retired
+        else "ok"
+    )
+    return {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "status": status,
+        "lifecycle": lifecycle,
+        "retired_at": manifest.get("retired_at"),
+        "cutoff_at": manifest.get("cutoff_at"),
+        "replacement": manifest.get("replacement"),
+        "source_repo": manifest.get("source_repo"),
+        "archived_file_count": _safe_nonnegative_int(manifest.get("archived_file_count")),
+        "archived_jsonl_record_count": _safe_nonnegative_int(manifest.get("archived_jsonl_record_count")),
+        "archive_present": bool(archive_root and archive_root.is_dir()),
+        "manifest_writable": manifest_writable,
+        "archive_hash_mismatch_count": hash_mismatches,
+        "archive_missing_file_count": missing_archive_files,
+        "archive_writable_file_count": writable_archive_files,
+        "archive_writable_directory_count": writable_archive_directories,
+        "archive_extra_file_count": len(archive_extra_files),
+        "post_cutoff_live_root_exists": bool(live_sources),
+        "post_cutoff_source_paths": live_sources,
+        "post_cutoff_file_count": len(live_files),
+        "post_cutoff_jsonl_record_count": sum(int(item.get("jsonl_record_count") or 0) for item in live_files),
+        "enabled_community_cron_count": len(enabled_community_crons),
+        "enabled_community_cron_names": enabled_community_crons,
+        "violations": violations,
+        "active_observation": False if retired or pending else None,
+        "active_execution": False if retired or pending else None,
+        "raw_body_included": False,
+        "actual_send": False,
+        "actual_execute": False,
+    }
+
+
+def _assert_prerequisites(home: Path) -> None:
+    enabled = [record for record in _community_cron_records(home) if record.get("enabled") is True]
+    if enabled:
+        names = ", ".join(sorted(record["name"] or record["script"] for record in enabled))
+        raise RuntimeError(f"community cron jobs must be paused before retirement: {names}")
+
+
+def _community_cron_records(home: Path) -> list[dict[str, Any]]:
+    """Bounded scan of cron/jobs.json for jobs pointing at community scripts.
+
+    Only inspects the ``script`` basename against the known community helper
+    script names; it does not need MemoryOSCronSpec wiring since none of
+    these scripts were ever wrapped by ExecutionGate.
+    """
+
+    jobs_path = home / "cron" / "jobs.json"
+    try:
+        loaded = json.loads(jobs_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RuntimeError(f"invalid community cron registry: {jobs_path}") from exc
+    if isinstance(loaded, dict):
+        jobs = loaded.get("jobs", [])
+    elif isinstance(loaded, list):
+        jobs = loaded
+    else:
+        raise RuntimeError(f"invalid community cron registry root: {jobs_path}")
+    if not isinstance(jobs, list):
+        raise RuntimeError(f"invalid community cron jobs list: {jobs_path}")
+    result = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        script = str(job.get("script") or "")
+        script_name = Path(script).name if script else ""
+        if script_name not in COMMUNITY_HELPER_SCRIPT_NAMES:
+            continue
+        result.append(
+            {
+                "name": str(job.get("name") or ""),
+                "job_id": str(job.get("job_id") or job.get("id") or ""),
+                "enabled": bool(job.get("enabled", True)),
+                "script": script,
+                "last_run_at": job.get("last_run_at"),
+                "last_status": job.get("last_status"),
+            }
+        )
+    return sorted(result, key=lambda item: (item["name"], item["script"]))
+
+
+def _inventory_sources(home: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for relative_root in COMMUNITY_SOURCE_RELATIVE_PATHS:
+        source = home / relative_root
+        if not _path_lexists(source):
+            continue
+        if source.is_symlink():
+            raise RuntimeError(f"symlink is not allowed in community archive: {source}")
+        if source.is_file():
+            records.append(_file_record(source, relative_root.as_posix()))
+            continue
+        if not source.is_dir():
+            raise RuntimeError(f"unsupported community artifact source: {source}")
+        for record in _inventory(source):
+            record["relative_path"] = (relative_root / str(record["relative_path"])).as_posix()
+            records.append(record)
+    return sorted(records, key=lambda item: str(item["relative_path"]))
+
+
+def _inventory(root: Path) -> list[dict[str, Any]]:
+    if not root.exists():
+        return []
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError(f"community artifact root must be a real directory: {root}")
+    records = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise RuntimeError(f"symlink is not allowed in community archive: {path}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise RuntimeError(f"unsupported file type in community archive: {path}")
+        records.append(_file_record(path, path.relative_to(root).as_posix()))
+    return records
+
+
+def _file_record(path: Path, relative: str) -> dict[str, Any]:
+    return {
+        "relative_path": relative,
+        "size_bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+        "jsonl_record_count": _jsonl_record_count(path) if path.suffix == ".jsonl" else 0,
+    }
+
+
+def _complete_archive_moves(home: Path, archive_root: Path) -> None:
+    archive_root.mkdir(parents=True, exist_ok=True)
+    archive_root.chmod(stat.S_IRWXU)
+    for relative in COMMUNITY_SOURCE_RELATIVE_PATHS:
+        source = home / relative
+        target = archive_root / relative
+        if _path_lexists(source) and _path_lexists(target):
+            raise RuntimeError(f"community retirement source and archive target both exist: {relative}")
+        if not _path_lexists(source):
+            continue
+        if source.is_symlink():
+            raise RuntimeError(f"symlink is not allowed in community archive: {source}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(source, target)
+        _fsync_directory(source.parent)
+        _fsync_directory(target.parent)
+
+
+def _jsonl_record_count(path: Path) -> int:
+    count = 0
+    with path.open("rb") as handle:
+        for line in handle:
+            if line.strip():
+                count += 1
+    return count
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _archive_integrity_errors(home: Path, archive_root: Path, manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not archive_root.is_dir() or archive_root.is_symlink():
+        return ["archive_root_missing_or_invalid"]
+    expected = {
+        str(record.get("relative_path") or ""): record
+        for record in manifest.get("archived_files", [])
+        if isinstance(record, dict)
+    }
+    actual = {str(record["relative_path"]): record for record in _inventory(archive_root)}
+    if set(actual) != set(expected):
+        errors.append("archive_file_set")
+    for relative, expected_record in expected.items():
+        path = archive_root / relative
+        if relative not in actual or not path.is_file() or path.is_symlink():
+            continue
+        if _sha256(path) != str(expected_record.get("sha256") or ""):
+            errors.append("archive_hash")
+        if path.stat().st_size != expected_record.get("size_bytes"):
+            errors.append("archive_size")
+        actual_jsonl_count = _jsonl_record_count(path) if path.suffix == ".jsonl" else 0
+        if actual_jsonl_count != expected_record.get("jsonl_record_count"):
+            errors.append("archive_jsonl_record_count")
+        if path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH):
+            errors.append("archive_file_writable")
+    for path in [archive_root, archive_root.parent, *archive_root.rglob("*")]:
+        if path.is_symlink():
+            errors.append("archive_symlink")
+        elif path.is_dir() and path.stat().st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH):
+            errors.append("archive_directory_writable")
+        elif not path.is_dir() and not path.is_file():
+            errors.append("archive_unsupported_file_type")
+    if any(_path_lexists(home / relative) for relative in COMMUNITY_SOURCE_RELATIVE_PATHS):
+        errors.append("community_source_still_live")
+    expected_total = sum(
+        int(record.get("jsonl_record_count") or 0)
+        for record in manifest.get("archived_files", [])
+        if isinstance(record, dict)
+    )
+    if manifest.get("archived_jsonl_record_count") != expected_total:
+        errors.append("archive_jsonl_record_count_total")
+    return sorted(set(errors))
+
+
+def _make_tree_read_only(root: Path) -> None:
+    for path in sorted(root.rglob("*"), reverse=True):
+        if path.is_symlink():
+            raise RuntimeError(f"symlink is not allowed in community archive: {path}")
+        if path.is_file():
+            path.chmod(stat.S_IRUSR)
+            _fsync_file(path)
+        elif path.is_dir():
+            path.chmod(stat.S_IRUSR | stat.S_IXUSR)
+            _fsync_directory(path)
+        else:
+            raise RuntimeError(f"unsupported file type in community archive: {path}")
+    root.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    root.parent.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    _fsync_directory(root)
+    _fsync_directory(root.parent)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    existing_mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else stat.S_IRUSR | stat.S_IWUSR
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(temporary, flags, existing_mode)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = -1
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+            os.fchmod(handle.fileno(), existing_mode)
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort directory fsync after an atomic replace.
+
+    Platforms that cannot open directory descriptors (Windows raises
+    PermissionError from os.open) skip the directory fsync; the file itself
+    is already flushed+fsynced and os.replace stays atomic.
+    """
+
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0))
+    except (NotImplementedError, OSError):
+        return
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_file(path: Path) -> None:
+    if os.name == "nt":
+        # FlushFileBuffers requires a writable handle, but this durability
+        # fsync targets manifest/archive files that are chmod'ed read-only
+        # first, so a read-only descriptor cannot be fsynced on Windows.
+        # The content was already flush+fsync'ed before os.replace.
+        return
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _safe_relative_target(root: Path, relative: str) -> Path:
+    candidate = (root / relative).resolve()
+    root_resolved = root.resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise RuntimeError(f"archive path escapes Hermes home: {relative}") from exc
+    return candidate
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Archive residue and write the retired manifest")
+    mode.add_argument("--status", action="store_true", help="Report bounded retirement status only; changes nothing")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    home = Path(args.hermes_home).expanduser().resolve()
+    report = retirement_status(home) if args.status else retire_community(home, apply=bool(args.apply))
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    if args.status:
+        return 0 if report.get("status") in {"ok", "not_retired"} else 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory_os_monitor_dashboard_snapshot.py
+++ b/scripts/memory_os_monitor_dashboard_snapshot.py
@@ -43,6 +43,7 @@ for _candidate in reversed(_PATH_CANDIDATES):
 
 from scripts.memory_os_module_cadence_report import build_cadence_report
 from plugins.memory.memory_os.audit import read_audit_records
+from plugins.memory.memory_os.cron_registry import memory_os_cron_specs
 from plugins.memory.memory_os.clearance_receipts import clearance_snapshot_freshness
 from plugins.memory.memory_os.exposure_rollup import exposure_monitor_stats
 from plugins.memory.memory_os.owner_actions import owner_review_queue_report
@@ -62,28 +63,33 @@ DEFAULT_PROFILE = "default"
 # artifact stale; a one-hour threshold makes the dashboard stale for most of
 # every healthy day and recreates a second, misleading status truth.
 FULL_MONITOR_STALE_SECONDS = 30 * 3600
-CORE_MEMORY_OS_CRON = frozenset({
-    "memory-os-owner-review-digest",
-    "memory-os-proposal-followups-opsgate",
-    "memory-os-index-sync",
-    "memory-os-working-cleanup",
-    "memory-os-candidate-aggregation",
-    "memory-os-fact-judge",
-    "memory-os-event-stats-refresh",
-    "memory-os-exposure-rollup",
-    "memory-os-v3-seed-evidence",
-    "memory-os-v3-wandering",
-    "memory-os-v3-journal-sweep",
-    "memory-os-state-overlay-refresh",
-    "memory-os-entity-index-refresh",
-    "memory-os-full-monitor-refresh",
-    "memory-os-memory-sources-feedback-request",
+# Registry keys the dashboard tolerates seeing paused/disabled without
+# treating it as drift -- pausing one of these is a legitimate owner or
+# host-profile choice, not a signal something is broken. A registry key
+# that is NOT listed here defaults into CORE (must stay enabled or the
+# dashboard WARNs), so a newly registered cron spec is visible and health
+# is derived by default instead of silently falling into the unclassified
+# "other" bucket (see cron_registry.py MEMORY_OS_CRON_SPECS / the
+# active-closure onboarding profile in memory_os_owner_cron_onboarding.py
+# for the install-time counterpart of this distinction).
+#
+#   - module_cadence_report: not installed by active-closure at all (the
+#     report is generated on-demand elsewhere); tolerate absence/pause.
+#   - l3_probe_verification / expression_feedback_request: owner- and
+#     host-profile-tolerant jobs that are expected to be paused on some
+#     hosts without indicating an unhealthy install.
+OPTIONAL_MEMORY_OS_CRON_KEYS = frozenset({
+    "module_cadence_report",
+    "l3_probe_verification",
+    "expression_feedback_request",
 })
-OPTIONAL_MEMORY_OS_CRON = frozenset({
-    "memory-os-module-cadence-report",
-    "memory-os-l3-probe-verification",
-    "memory-os-expression-feedback-request",
-})
+_ALL_MEMORY_OS_CRON_SPECS = memory_os_cron_specs()
+CORE_MEMORY_OS_CRON = frozenset(
+    spec.name for spec in _ALL_MEMORY_OS_CRON_SPECS if spec.key not in OPTIONAL_MEMORY_OS_CRON_KEYS
+)
+OPTIONAL_MEMORY_OS_CRON = frozenset(
+    spec.name for spec in _ALL_MEMORY_OS_CRON_SPECS if spec.key in OPTIONAL_MEMORY_OS_CRON_KEYS
+)
 # Keep legacy tuple for backward-compatible reference; health now uses the
 # frozensets above so paused optional jobs don't contribute to WARN.
 EXPECTED_CRON_NAMES = tuple(sorted(CORE_MEMORY_OS_CRON))

--- a/scripts/memory_os_monitor_dashboard_snapshot.py
+++ b/scripts/memory_os_monitor_dashboard_snapshot.py
@@ -82,6 +82,12 @@ OPTIONAL_MEMORY_OS_CRON_KEYS = frozenset({
     "module_cadence_report",
     "l3_probe_verification",
     "expression_feedback_request",
+    # Kept OPTIONAL for as long as active-closure onboarding defers it (see
+    # ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS in memory_os_owner_cron_onboarding.py).
+    # Classifying a job we deliberately do not install as CORE would raise a
+    # permanent missing_core WARN for its expected absence. Promote it to CORE
+    # in the same change that enables the cron.
+    "clearance_cycle",
 })
 _ALL_MEMORY_OS_CRON_SPECS = memory_os_cron_specs()
 CORE_MEMORY_OS_CRON = frozenset(

--- a/scripts/memory_os_owner_cron_onboarding.py
+++ b/scripts/memory_os_owner_cron_onboarding.py
@@ -38,27 +38,26 @@ from plugins.seam.hermes_memory_os.cron_adapter import HermesCronAdapter
 
 
 SCHEMA_VERSION = "memory-os.owner_cron_onboarding.v0"
-ACTIVE_CLOSURE_CRON_KEYS = frozenset({
-    "owner_review_digest",
-    "proposal_followups_opsgate",
-    "index_sync",
-    "working_cleanup",
-    "l3_probe_verification",
-    "candidate_aggregation",
-    "fact_judge",
-    "event_stats_refresh",
-    "exposure_rollup",
-    "full_monitor_refresh",
-    "v3_seed_evidence",
-    "v3_wandering",
-    "v3_journal_sweep",
-    "state_overlay_refresh",
-    "entity_index_refresh",
-    "hindsight_advisory_digest",
-    "hindsight_health_probe",
-    "expression_feedback_request",
-    "memory_sources_feedback_request",
+
+# Registry keys deliberately withheld from the active-closure cron profile.
+# A key belongs here ONLY for a documented, deliberate reason -- never
+# merely because the spec happens to be new. Every OTHER key returned by
+# memory_os_cron_specs() is onboarded on active-closure hosts by default, so
+# a future registry addition defaults to being installed and visible rather
+# than silently skipped (a hand-typed inclusion allowlist is exactly the
+# "unknown spec silently dropped" trap this derivation avoids).
+#
+#   - module_cadence_report: the cadence report artifact itself is already
+#     produced on-demand by build_cadence_report() from both the monitor
+#     dashboard snapshot and the 3.200 full monitor on every run, so a
+#     dedicated periodic cron job is redundant. It remains available under
+#     the "full" cron profile for hosts that want a standalone report cron.
+ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS = frozenset({
+    "module_cadence_report",
 })
+ACTIVE_CLOSURE_CRON_KEYS = frozenset(
+    spec.key for spec in memory_os_cron_specs()
+) - ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
 DEFAULT_OWNER_REVIEW_SCHEDULE = "0 9 * * *"
 DEFAULT_RIGHT_BRAIN_SCHEDULE = "30 4 * * 0"
 DEFAULT_FACT_JUDGE_SCHEDULE = "0 */4 * * *"

--- a/scripts/memory_os_owner_cron_onboarding.py
+++ b/scripts/memory_os_owner_cron_onboarding.py
@@ -53,7 +53,29 @@ SCHEMA_VERSION = "memory-os.owner_cron_onboarding.v0"
 #     dedicated periodic cron job is redundant. It remains available under
 #     the "full" cron profile for hosts that want a standalone report cron.
 ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS = frozenset({
+    # Permanent exclusion: its report is already generated on demand elsewhere.
     "module_cadence_report",
+    # DEFERRED ACTIVATION, not a permanent exclusion.
+    #
+    # clearance_cycle is a real registered spec whose helper/gate scripts the
+    # installer already deploys, but it was never added to the (previously
+    # hand-typed) active-closure key set -- an oversight, since every sibling
+    # spec was classified in the same commit that registered it. So the job has
+    # never actually been created on a production host, and the lane has never
+    # run there.
+    #
+    # It is held back here on purpose rather than switched on as a side effect
+    # of the registry-drift fix: the same change set also repaired
+    # `append_terminal(detail=...)`, which means
+    # `sweep_unavailable_open_proposals_on_flag_flip` -- which REVOKES open
+    # proposals and lives in clearance_cycle.py -- went from raising TypeError
+    # on every call to actually working. Enabling the cron in the same step
+    # would make two never-exercised paths live at once on 3.200, so a failure
+    # could not be attributed to either.
+    #
+    # To enable: delete this one line. The drift guard below still guarantees a
+    # newly registered spec can never be silently omitted again.
+    "clearance_cycle",
 })
 ACTIVE_CLOSURE_CRON_KEYS = frozenset(
     spec.key for spec in memory_os_cron_specs()

--- a/scripts/memory_os_state_overlay_refresh.py
+++ b/scripts/memory_os_state_overlay_refresh.py
@@ -58,6 +58,7 @@ from plugins.memory.memory_os.state_overlay import (
     append_overlay_run,
 )
 from plugins.memory.memory_os.state_overlay_renderer import render_state_overlay_md
+from plugins.memory.memory_os.state_overlay_schema import OVERLAY_SECTION_FIELDS
 from plugins.memory.memory_os.task_state import read_effective_current_task
 
 
@@ -108,12 +109,12 @@ def main(argv: list[str] | None = None) -> int:
         # anchor record's own record_id instead, which is real and stable.
         overlay["task_record_id"] = str((effective_task or {}).get("record_id") or "")
 
-        # Count populated sections
-        for key in (
-            "identity_snapshot", "relationship_snapshot", "active_projects",
-            "open_threads", "recent_events", "owner_preferences",
-            "capability_map", "material_index",
-        ):
+        # Count populated sections — derived from OVERLAY_SECTION_FIELDS
+        # (state_overlay_schema.py), the single source of truth for the set
+        # of StateOverlay sections. Do not hand-maintain a separate tuple
+        # here: a previously hardcoded copy silently excluded a since-removed
+        # section for its entire lifetime because it was never kept in sync.
+        for key in OVERLAY_SECTION_FIELDS:
             section = overlay.get(key)
             if isinstance(section, dict) and section.get("status") == "ok":
                 section_count += 1

--- a/scripts/memory_os_write_surface_check.py
+++ b/scripts/memory_os_write_surface_check.py
@@ -173,6 +173,14 @@ ALLOWED_WRITE_SURFACES: dict[str, str] = {
     "plugins/memory/memory_os/index.py::_write_edge_canonical::append_jsonl_locked_call::edges_path": "graph_edge_canonical",
     "plugins/memory/memory_os/left_brain_advisor.py::_append_jsonl::append_jsonl_locked_call::path": "left_brain_advisor_private_manual_writer",
     "plugins/memory/memory_os/legacy_right_brain_retirement.py::_retire_legacy_right_brain_locked::atomic_json_replace_call::manifest_path": "legacy_right_brain_retirement_manifest",
+    # Community retirement mirrors the legacy_right_brain_retirement precedent
+    # above: an explicitly-invoked, owner-driven host cleanup — never an
+    # automatic lane write, never reached from heartbeat, cognitive loop, or
+    # any cron spec. Both manifest writes are the two phases of one
+    # crash-safe commit (pending -> retired) taken under the retirement write
+    # lock, plus a recovery path that finishes an interrupted run.
+    "scripts/memory_os_community_retirement.py::_retire_community_locked::atomic_json_replace_call::manifest_path": "community_retirement_manifest",
+    "scripts/memory_os_community_retirement.py::_recover_pending_retirement::atomic_json_replace_call::manifest_path": "community_retirement_manifest_recovery",
     "plugins/memory/memory_os/memory_projection.py::_append_jsonl::append_jsonl_locked_call::path": "memory_projection_private_manual_writer",
     "plugins/memory/memory_os/memory_sources.py::append_memory_source_record::append_jsonl_locked_call::path": "memory_sources_existing_surface",
     "plugins/memory/memory_os/owner_actions.py::_append_jsonl::append_jsonl_locked_call::path": "owner_actions_private_writer",

--- a/tests/plugins/memory/test_memory_os_clearance_cycle.py
+++ b/tests/plugins/memory/test_memory_os_clearance_cycle.py
@@ -7,6 +7,7 @@ and monitor stats.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -579,3 +580,315 @@ class TestClearanceCycleMonitorStats:
         assert stats["clearance_receipts_conflict"] == 1
         assert stats["clearance_receipts_unknown"] == 1
         assert stats["receipts_invalidated_count"] == 0
+
+
+# ── Error observability (silent-failure fix) ────────────────────────────
+
+
+class TestRunClearanceCycleErrorObservability:
+    """run_clearance_cycle must never report status='ok' after a total
+    per-item judge failure, and per-item error_records must be full
+    schema-conformant error_record dicts (not raw ad-hoc dicts).
+    """
+
+    def test_run_clearance_cycle_empty_batch_stays_ok(self, tmp_path: Path) -> None:
+        """No queue items at all — status must remain 'ok' (nothing to fail)."""
+        from plugins.memory.memory_os.clearance_cycle import run_clearance_cycle
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+        store.initialize()
+
+        report = run_clearance_cycle(store, v2e_enabled=True)
+        assert report["status"] == "ok"
+        assert report["budget_used"] == 0
+        assert report["error_records"] == []
+
+    def test_run_clearance_cycle_total_batch_failure_flips_status_to_error(
+        self, tmp_path: Path,
+    ) -> None:
+        """Counterfactual for Defect 2.
+
+        Before the fix, run_clearance_cycle initialized report["status"] to
+        "ok" and never re-evaluated it after the per-item try/except loop,
+        so a cycle where EVERY item in the rejudge batch raised still
+        reported "ok" — and memory_os_clearance_cycle_helper.py maps
+        status=="ok" straight to cron exit code 0. The per-item except
+        handler also appended a raw dict (record_id/error_code/
+        error_summary) instead of a schema-conformant error_record. This
+        test asserts both are fixed: status flips to "error" on total
+        failure, and the error_record carries the full canonical schema.
+        """
+        from unittest.mock import patch
+
+        from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+        from plugins.memory.memory_os.clearance_cycle import run_clearance_cycle
+        from plugins.memory.memory_os.crystallized import (
+            CrystallizedCandidate,
+            CrystallizedMemoryService,
+        )
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+        store.initialize()
+        service = CrystallizedMemoryService(store)
+
+        # One never-judged provisional -> exactly one item in the batch.
+        candidate = CrystallizedCandidate(
+            "cand_total_fail", "fact", "A provisional fact.", ["evt_total_fail"],
+        )
+        decision = ApprovalDecision(
+            "cand_total_fail", ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED, "owner",
+            "2026-07-01T00:00:00Z", provisional=True,
+            expires_at="2026-08-01T00:00:00Z",
+        )
+        service.write_approved_record(candidate, decision, file_name="prov_total_fail.md")
+
+        # A permanent record is required so the real judge branch
+        # (_judge_against_permanents) is invoked instead of the
+        # empty-corpus "always clear" shortcut.
+        perm_candidate = CrystallizedCandidate(
+            "cand_total_fail_perm", "fact", "An unrelated permanent fact.", ["evt_perm"],
+        )
+        perm_decision = ApprovalDecision(
+            "cand_total_fail_perm", ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED, "owner",
+            "2026-06-01T00:00:00Z", provisional=False,
+        )
+        service.write_approved_record(perm_candidate, perm_decision, file_name="perm_total_fail.md")
+
+        # Crystallized records get their own auto-generated frontmatter
+        # "id" (not the candidate_id) — that generated id is what
+        # run_clearance_cycle uses as record_id.
+        prov_records = service.list_provisional_records()
+        assert len(prov_records) == 1
+        real_record_id = str(prov_records[0]["id"])
+
+        with patch(
+            "plugins.memory.memory_os.clearance_cycle._judge_against_permanents",
+            side_effect=RuntimeError("judge unavailable"),
+        ):
+            report = run_clearance_cycle(store, v2e_enabled=True)
+
+        assert report["judged"] == 0
+        assert report["budget_used"] == 1
+        assert len(report["error_records"]) == 1
+        assert report["status"] == "error", (
+            "every item in the batch errored — status must not report 'ok'"
+        )
+        error_record = report["error_records"][0]
+        assert error_record["schema_version"] == "memory-os.error_record.v0"
+        assert error_record["component"] == "clearance_cycle"
+        assert error_record["operation"] == "run_clearance_cycle_judge_item"
+        assert error_record["error_code"] == "RuntimeError"
+        assert error_record["severity"] == "error"
+        assert error_record["recoverable"] is True
+        assert error_record["details"]["record_id"] == real_record_id
+
+    def test_run_clearance_cycle_partial_batch_failure_keeps_status_ok(
+        self, tmp_path: Path,
+    ) -> None:
+        """One bad record among several must not flip the cron exit code.
+
+        memory_os_clearance_cycle_helper.py maps status=="ok" to exit 0 —
+        a single flaky judge call is expected/recoverable noise (the record
+        stays unjudged and is retried next cycle), so it must not fail the
+        whole cron run. Only a *total* batch failure should.
+        """
+        from unittest.mock import patch
+
+        from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+        from plugins.memory.memory_os.clearance_cycle import run_clearance_cycle
+        from plugins.memory.memory_os.crystallized import (
+            CrystallizedCandidate,
+            CrystallizedMemoryService,
+        )
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+        store.initialize()
+        service = CrystallizedMemoryService(store)
+
+        fail_id = "cand_partial_fail"
+        ok_id = "cand_partial_ok"
+        for cid, entered_at in ((fail_id, "2026-07-01T00:00:00Z"), (ok_id, "2026-07-02T00:00:00Z")):
+            candidate = CrystallizedCandidate(cid, "fact", f"Provisional {cid}.", [f"evt_{cid}"])
+            decision = ApprovalDecision(
+                cid, ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED, "owner",
+                entered_at, provisional=True, expires_at="2026-08-01T00:00:00Z",
+            )
+            service.write_approved_record(candidate, decision, file_name=f"{cid}.md")
+
+        perm_candidate = CrystallizedCandidate(
+            "cand_partial_perm", "fact", "An unrelated permanent fact.", ["evt_perm2"],
+        )
+        perm_decision = ApprovalDecision(
+            "cand_partial_perm", ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED, "owner",
+            "2026-06-01T00:00:00Z", provisional=False,
+        )
+        service.write_approved_record(perm_candidate, perm_decision, file_name="perm_partial.md")
+
+        # Fail one item by patching the receipt write, NOT the judge.
+        # run_clearance_cycle only calls _judge_against_permanents in its
+        # `else` branch; when the permanent corpus is empty it takes the
+        # "empty corpus clause" branch and never calls the judge at all.
+        # A judge-level patch therefore silently never fires, every item
+        # succeeds, and the test asserts nothing. write_clearance_receipt
+        # is reached on BOTH branches, inside the same try, immediately
+        # before `report["judged"] += 1` — so it fails exactly one item.
+        from plugins.memory.memory_os.clearance_receipts import (
+            write_clearance_receipt as _real_write_clearance_receipt,
+        )
+
+        # The batch item's record_id is the GENERATED crystallized record id
+        # (`cry_<timestamp>_<hash>`) assigned by write_approved_record — NOT
+        # the candidate id. Matching on the candidate id would never fire, so
+        # fail the first receipt write and remember which record it was.
+        failed_record_ids: list[str] = []
+
+        def _flaky_receipt_write(roots, receipt):
+            if not failed_record_ids:
+                failed_record_ids.append(receipt.record_id)
+                raise RuntimeError("receipt store unavailable")
+            return _real_write_clearance_receipt(roots, receipt)
+
+        with patch(
+            "plugins.memory.memory_os.clearance_cycle.write_clearance_receipt",
+            side_effect=_flaky_receipt_write,
+        ):
+            report = run_clearance_cycle(store, v2e_enabled=True)
+
+        # Two provisional records enter the batch; exactly one was induced
+        # to fail, so the other must still have been judged successfully.
+        assert len(failed_record_ids) == 1, "expected exactly one induced failure"
+        assert report["judged"] == 1
+        assert len(report["error_records"]) == 1
+        assert report["error_records"][0]["details"]["record_id"] == failed_record_ids[0]
+        assert report["status"] == "ok", (
+            "a single per-item failure among a larger batch must not flip status"
+        )
+
+
+class TestSweepUnavailableOpenProposalsOnFlagFlip:
+    """Defect 2 coverage for sweep_unavailable_open_proposals_on_flag_flip.
+
+    Also covers a functional bug found in the same call while fixing the
+    error-record schema: the call passed append_terminal(detail=...), but
+    ProposalLedger.append_terminal() has no `detail` parameter (confirmed —
+    no other call site in the repo passes it), so the sweep TypeError'd on
+    every single eligible proposal, unconditionally. That is fixed alongside
+    the error-record/status fix since it lives in the same function.
+    """
+
+    def _make_eligible_proposal(self, store: Any, seed: str) -> str:
+        from plugins.memory.memory_os.permanent_promotion import PermanentPromotionService
+
+        service = PermanentPromotionService(store, v2e_enabled=False)
+        proposal, created = service.proposals.create_or_get(
+            target_id=f"target_{seed}",
+            candidate_id=f"cand_{seed}",
+            body=f"body for {seed}",
+            channel="cli",
+            origin="owner_initiated",
+            clearance={"status": "unavailable", "reason_code": "test"},
+        )
+        assert created is True
+        assert proposal["status"] == "open"
+        return str(proposal["proposal_id"])
+
+    def test_sweep_revokes_eligible_open_proposals_real_path(self, tmp_path: Path) -> None:
+        """End-to-end, no mocking: proves the append_terminal(detail=...)
+        TypeError bug is fixed and the sweep now actually revokes proposals.
+        """
+        from plugins.memory.memory_os.clearance_cycle import (
+            sweep_unavailable_open_proposals_on_flag_flip,
+        )
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+        store.initialize()
+        proposal_id = self._make_eligible_proposal(store, "sweep_real")
+
+        result = sweep_unavailable_open_proposals_on_flag_flip(store)
+
+        assert result["status"] == "ok"
+        assert result["error_records"] == []
+        assert result["swept_count"] == 1
+        assert proposal_id in result["swept_proposal_ids"]
+
+    def test_sweep_total_failure_flips_status_to_error(self, tmp_path: Path) -> None:
+        """Counterfactual for Defect 2 (second call site).
+
+        Before the fix this always returned status="ok" (initialized once,
+        never re-evaluated) with raw (proposal_id, error_code)-only dicts
+        instead of schema-conformant error_records — even when every
+        eligible proposal failed to sweep.
+        """
+        from unittest.mock import patch
+
+        from plugins.memory.memory_os.clearance_cycle import (
+            sweep_unavailable_open_proposals_on_flag_flip,
+        )
+        from plugins.memory.memory_os.permanent_promotion import ProposalLedger
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+        store.initialize()
+        self._make_eligible_proposal(store, "sweep_total_fail")
+
+        with patch.object(
+            ProposalLedger, "append_terminal",
+            side_effect=RuntimeError("ledger unavailable"),
+        ):
+            result = sweep_unavailable_open_proposals_on_flag_flip(store)
+
+        assert result["swept_count"] == 0
+        assert len(result["error_records"]) == 1
+        assert result["status"] == "error"
+        error_record = result["error_records"][0]
+        assert error_record["schema_version"] == "memory-os.error_record.v0"
+        assert error_record["component"] == "clearance_cycle"
+        assert error_record["operation"] == "sweep_unavailable_open_proposals_on_flag_flip"
+        assert error_record["severity"] == "error"
+        assert error_record["recoverable"] is True
+        assert "proposal_id" in error_record["details"]
+
+    def test_sweep_partial_failure_keeps_status_ok(self, tmp_path: Path) -> None:
+        """One proposal failing to sweep is recoverable noise (retried on
+        the next flag-flip pass) and must not fail the whole sweep result.
+        """
+        from unittest.mock import patch
+
+        from plugins.memory.memory_os.clearance_cycle import (
+            sweep_unavailable_open_proposals_on_flag_flip,
+        )
+        from plugins.memory.memory_os.permanent_promotion import ProposalLedger
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+        store.initialize()
+        fail_id = self._make_eligible_proposal(store, "sweep_partial_fail")
+        ok_id = self._make_eligible_proposal(store, "sweep_partial_ok")
+
+        real_append_terminal = ProposalLedger.append_terminal
+
+        def _flaky_append_terminal(self, proposal_id, status, **kwargs):
+            if proposal_id == fail_id:
+                raise RuntimeError("ledger unavailable")
+            return real_append_terminal(self, proposal_id, status, **kwargs)
+
+        with patch.object(ProposalLedger, "append_terminal", _flaky_append_terminal):
+            result = sweep_unavailable_open_proposals_on_flag_flip(store)
+
+        assert result["swept_count"] == 1
+        assert ok_id in result["swept_proposal_ids"]
+        assert len(result["error_records"]) == 1
+        assert result["error_records"][0]["details"]["proposal_id"] == fail_id
+        assert result["status"] == "ok", (
+            "a single per-proposal failure must not flip status when others swept fine"
+        )

--- a/tests/plugins/memory/test_memory_os_cognitive_loop.py
+++ b/tests/plugins/memory/test_memory_os_cognitive_loop.py
@@ -356,6 +356,101 @@ def test_spontaneous_expression_completes_execution_gate_envelope_on_delivery_er
     assert records[-1]["result_summary"]["error_type"] == "RuntimeError"
 
 
+def _lane_envelope_records(tmp_path, lane_id: str) -> list[dict]:
+    records = [
+        json.loads(line)
+        for line in (tmp_path / "memory-os" / "system" / "execution_gate_envelopes.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    return [record for record in records if record.get("lane_id") == lane_id]
+
+
+def test_ground_truth_miner_completes_execution_gate_envelope_on_error(tmp_path, monkeypatch):
+    # Counterfactual: GroundTruthMinerModule.run_once() only calls
+    # complete_execution_gate_envelope() on its own happy-path line (mine() at
+    # ground_truth_miner.py). _ground_truth_miner() opened the permit and handed
+    # off with zero exception safety, so a raise inside run_once() orphaned the
+    # permit. Without the try/except fix, this test fails because lane_records
+    # has length 1 (permit only).
+    store = _init_store(tmp_path)
+    runner = CognitiveLoopRunner(store)
+
+    def fail_run_once(self, **kwargs):
+        raise RuntimeError("synthetic ground truth miner failure")
+
+    monkeypatch.setattr(
+        "plugins.modules.governance.ground_truth_miner.GroundTruthMinerModule.run_once",
+        fail_run_once,
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic ground truth miner failure"):
+        runner._ground_truth_miner({})
+
+    lane_records = _lane_envelope_records(tmp_path, "reversible_labels")
+    assert [record["stage"] for record in lane_records] == ["permit", "completion"]
+    assert lane_records[0]["execution_gate_envelope_id"] == lane_records[1]["execution_gate_envelope_id"]
+    assert lane_records[-1]["execution_status"] == "error"
+    assert lane_records[-1]["result_summary"]["error_type"] == "RuntimeError"
+
+
+def test_memory_projection_completes_execution_gate_envelope_on_error(tmp_path, monkeypatch):
+    # Counterfactual: collect_and_project_signals() only calls
+    # complete_execution_gate_envelope() on its own happy-path line. The
+    # _memory_projection() lane opened the permit and delegated with zero
+    # exception safety, so a raise inside the collector orphaned the permit.
+    # Without the try/except fix, this test fails because lane_records has
+    # length 1 (permit only).
+    store = _init_store(tmp_path)
+    runner = CognitiveLoopRunner(store)
+
+    def fail_collect(*args, **kwargs):
+        raise RuntimeError("synthetic projection failure")
+
+    monkeypatch.setattr(
+        "plugins.memory.memory_os.memory_projection.collect_and_project_signals",
+        fail_collect,
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic projection failure"):
+        runner._memory_projection({"host_capability_probe_result": {}})
+
+    lane_records = _lane_envelope_records(tmp_path, "memory_projection_collect")
+    assert [record["stage"] for record in lane_records] == ["permit", "completion"]
+    assert lane_records[0]["execution_gate_envelope_id"] == lane_records[1]["execution_gate_envelope_id"]
+    assert lane_records[-1]["execution_status"] == "error"
+    assert lane_records[-1]["result_summary"]["error_type"] == "RuntimeError"
+
+
+def test_left_brain_advisor_completes_execution_gate_envelope_on_error(tmp_path, monkeypatch):
+    # Counterfactual: run_left_brain_advisor() only calls
+    # complete_execution_gate_envelope() on its own happy-path line. The
+    # _left_brain_advisor() lane opened the permit and delegated with zero
+    # exception safety, so a raise inside the advisor orphaned the permit.
+    # Without the try/except fix, this test fails because lane_records has
+    # length 1 (permit only).
+    store = _init_store(tmp_path)
+    runner = CognitiveLoopRunner(store)
+
+    def fail_advisor(*args, **kwargs):
+        raise RuntimeError("synthetic advisor failure")
+
+    monkeypatch.setattr(
+        "plugins.memory.memory_os.left_brain_advisor.run_left_brain_advisor",
+        fail_advisor,
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic advisor failure"):
+        runner._left_brain_advisor({})
+
+    lane_records = _lane_envelope_records(tmp_path, "left_brain_advisor_report")
+    assert [record["stage"] for record in lane_records] == ["permit", "completion"]
+    assert lane_records[0]["execution_gate_envelope_id"] == lane_records[1]["execution_gate_envelope_id"]
+    assert lane_records[-1]["execution_status"] == "error"
+    assert lane_records[-1]["result_summary"]["error_type"] == "RuntimeError"
+
+
 def test_cognitive_loop_continues_after_step_failure(tmp_path, monkeypatch):
     store = _init_store(tmp_path)
     _write_deep_reflection_test_host_config(tmp_path)

--- a/tests/plugins/memory/test_memory_os_entity_index.py
+++ b/tests/plugins/memory/test_memory_os_entity_index.py
@@ -392,6 +392,58 @@ class TestEntityIndexCognitiveLoop:
         assert result["status"] == "ok"
         assert result["entities_indexed"] > 0
 
+    def test_entity_index_enabled_persists_error_record_on_knob_resolution_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_entity_index_enabled must not silently swallow resolve_knob() failures.
+
+        Counterfactual: before the fix, the except-Exception handler in
+        _entity_index_enabled built an error_record via build_error_record()
+        but discarded the return value as a bare expression statement —
+        never appending, never writing it anywhere. A corrupt knob-override
+        read therefore produced zero diagnostic trace. This test forces
+        resolve_knob() to raise and asserts a fully-shaped error_record
+        (component/operation/error_code/severity/recoverable/schema_version)
+        lands durably in the audit log.
+        """
+        from plugins.memory.memory_os.audit import read_audit_records
+        from plugins.memory.memory_os.index import _entity_index_enabled
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="entity-index-error-test")
+        store = MemoryOSStore(roots)
+        store.initialize()
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("corrupt knob-override store")
+
+        monkeypatch.setattr(
+            "plugins.memory.memory_os.knob_overrides.resolve_knob", _boom
+        )
+
+        result = _entity_index_enabled(store)
+        assert result is False  # fail-closed default is preserved
+
+        audit_records = read_audit_records(roots.audit_path)
+        matching = [
+            r for r in audit_records
+            if r.get("action") == "entity_index_knob_resolution_failed"
+        ]
+        assert len(matching) == 1, (
+            "expected exactly one durable audit record for the knob "
+            f"resolution failure, got: {audit_records}"
+        )
+        error_record = matching[0].get("details", {}).get("error_record")
+        assert isinstance(error_record, dict), "error_record must be persisted in details"
+        assert error_record["schema_version"] == "memory-os.error_record.v0"
+        assert error_record["component"] == "entity_index"
+        assert error_record["operation"] == "knob_resolution"
+        assert error_record["error_code"] == "ENTITY_INDEX_KNOB_FAILED"
+        assert error_record["severity"] == "warning"
+        assert error_record["recoverable"] is True
+        assert "corrupt knob-override store" in error_record["details"]["error"]
+
 
 # ── Whitespace collapse ─────────────────────────────────────────────
 

--- a/tests/plugins/memory/test_memory_os_owner_actions.py
+++ b/tests/plugins/memory/test_memory_os_owner_actions.py
@@ -2505,6 +2505,157 @@ def test_owner_review_reply_can_demote_crystallized_record_by_token(tmp_path):
     assert projection["projection_stale_count"] == 0
 
 
+def _crystallized_record_id_for_forgery(store) -> str:
+    append_candidate_queue(store, _candidate())
+    apply_owner_action(
+        store,
+        action_type="approve_candidate",
+        target="candidate:cand_owner_001",
+        owner_id="owner",
+        channel="cli",
+        apply=True,
+    )
+    record = CrystallizedMemoryService(store).read_records("owner_approved.md")[0]
+    return str(record.frontmatter["id"])
+
+
+def _legacy_scheme_action_token(action_type: str, target_type: str, target_id: str) -> str:
+    """Reproduce the pre-fix keyless oa_ token an attacker can compute offline."""
+
+    return "oa_" + hashlib.sha256(
+        f"{action_type}|{target_type}|{target_id}".encode("utf-8")
+    ).hexdigest()[:14]
+
+
+def test_repro_offline_forged_revoke_token_is_refused_without_recorded_digest(tmp_path):
+    store = _store(tmp_path)
+    record_id = _crystallized_record_id_for_forgery(store)
+    forged = _legacy_scheme_action_token("revoke_crystallized", "crystallized_record", record_id)
+
+    result = parse_owner_review_reply(
+        store,
+        f"memory revoke {forged}",
+        owner_id="owner",
+        channel="telegram",
+        apply=True,
+        require_recorded_digest=True,
+    )
+
+    after = CrystallizedMemoryService(store).find_record(record_id)
+    assert result["status"] == "needs_clarification"
+    assert result["reason"] == "digest_not_found_or_expired"
+    assert result["active_digest"]["binding"] == "digest_not_found"
+    assert after is not None
+    assert after.frontmatter.get("canonical_state") != "owner_revoked"
+
+
+def test_repro_offline_forged_demote_token_is_refused_when_recorded_digest_lacks_it(tmp_path):
+    store = _store(tmp_path)
+    record_id = _crystallized_record_id_for_forgery(store)
+    rendered = render_owner_review_digest(store, owner_id="owner", channel="telegram")
+    owner_actions_module._append_owner_review_rendered_digest(store, rendered, channel="telegram")
+    forged = _legacy_scheme_action_token("demote_crystallized", "crystallized_record", record_id)
+    recorded = _jsonl(owner_review_rendered_digests_path(store.roots))[-1]
+    assert forged not in json.dumps(recorded, ensure_ascii=False)
+
+    result = parse_owner_review_reply(
+        store,
+        f"memory demote {forged}",
+        owner_id="owner",
+        channel="telegram",
+        apply=True,
+        require_recorded_digest=True,
+    )
+
+    after = CrystallizedMemoryService(store).find_record(record_id)
+    assert result["active_digest"]["binding"] == "latest_recorded_digest"
+    assert result["status"] == "needs_clarification"
+    assert result["reason"] == "action_token_not_found_in_recorded_digest"
+    assert after is not None
+    assert after.frontmatter.get("canonical_state") != "demoted"
+
+
+def test_surface_token_digest_optional_allowlist_refuses_ownergate_action_types():
+    allowed = owner_actions_module._surface_token_allowed_without_recorded_digest
+    for action_type, target_type in (
+        ("mark_feedback", "memory_source"),
+        ("too_mechanical", "expression"),
+        ("apply_proposal", "proposal"),
+    ):
+        assert allowed({"action_type": action_type, "target_type": target_type}) is True
+    for action_type, target_type in (
+        ("revoke_crystallized", "crystallized_record"),
+        ("demote_crystallized", "crystallized_record"),
+        ("approve_candidate", "candidate"),
+        ("allow_speak_once", "speak"),
+        ("approve_session_mirror_apply", "session_mirror_apply"),
+        ("confirm_provisional_crystallized_record", "provisional_crystallized_record"),
+        # A future surface map must not widen the hole by reusing a low-risk
+        # action type against a governed target, or vice versa.
+        ("mark_feedback", "crystallized_record"),
+        ("revoke_crystallized", "memory_source"),
+    ):
+        assert allowed({"action_type": action_type, "target_type": target_type}) is False
+    assert allowed({}) is False
+    assert allowed(None) is False
+
+
+def test_proposal_followup_apply_token_still_applies_with_require_recorded_digest(tmp_path):
+    store = _store(tmp_path)
+    proposal_queue = ProposalQueueModule(tmp_path, profile="main")
+    candidate = proposal_queue.create_candidate(
+        store=store,
+        title="调整右脑表达策略：too_frequent 反馈",
+        body=(
+            "具体改动：降低右脑表达触发频次。\n"
+            "证据：owner 标记 too_frequent。\n"
+            "验收标准：policy.json 写入并保留 rollback。\n"
+            "后续状态：approved_for_proposal -> OpsGate report-only -> owner manual apply decision。\n"
+            "边界：不创建 generic executor。"
+        ),
+        kind="expression_policy",
+        proposal_class="expression_policy:too_frequent",
+        dedupe_key="expression_policy:too_frequent",
+        source_refs=["expression_feedback:too_frequent"],
+    )
+    apply_owner_action(
+        store,
+        action_type="approve_proposal",
+        target=f"proposal:{candidate['candidate_id']}",
+        owner_id="owner",
+        channel="telegram",
+        apply=True,
+    )
+    route_approved_proposal_followup_to_ops_gate(
+        store,
+        proposal_id=candidate["candidate_id"],
+        owner_id="owner",
+        channel="telegram",
+        apply=True,
+    )
+    surface = owner_review_surface_report(
+        store,
+        operation="proposal_followups",
+        owner_id="owner",
+        channel="telegram",
+    )
+    apply_token = surface["proposal_followups"]["items"][0]["action_tokens"]["apply_proposal"]
+
+    result = parse_owner_review_reply(
+        store,
+        f"memory apply {apply_token}",
+        owner_id="owner",
+        channel="telegram",
+        apply=True,
+        require_recorded_digest=True,
+    )
+
+    assert result["active_digest"]["binding"] == "digest_not_found"
+    assert result["status"] == "ok"
+    assert result["parsed"]["action_type"] == "apply_proposal"
+    assert result["owner_action_result"]["result_ref"]["status"] == "applied"
+
+
 def test_render_digest_turns_schema_items_into_owner_readable_review_items(tmp_path):
     store = _store(tmp_path)
     append_candidate_queue(store, _candidate())
@@ -4713,3 +4864,62 @@ def test_repeat_decision_item_count_integration_across_two_digest_renders(tmp_pa
     report = owner_review_queue_report(store)
     burden = report["burden"]
     assert burden["repeat_decision_item_count"] >= 1
+
+
+def _raise_candidate_aggregation_status(monkeypatch):
+    from plugins.memory.memory_os import crystallized as crystallized_module
+
+    def _boom(_store):
+        raise RuntimeError("aggregation status unavailable")
+
+    monkeypatch.setattr(crystallized_module, "latest_candidate_aggregation_status", _boom)
+
+
+def test_candidate_aggregation_status_error_record_uses_warning_severity(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _raise_candidate_aggregation_status(monkeypatch)
+
+    report = owner_review_status_report(store)
+
+    records = _jsonl(store.roots.memory_os_root / "system" / "error_records.jsonl")
+    matching = [
+        record
+        for record in records
+        if record.get("error_code") == "candidate_aggregation_status_read_failed"
+    ]
+    assert report["candidate_aggregation"]["available"] is False
+    assert matching
+    # Downstream consumers filter on exact severity == "warning"; "warn" is
+    # silently dropped.
+    assert matching[-1]["severity"] == "warning"
+
+
+def test_candidate_aggregation_error_record_write_failure_falls_back_to_audit(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _raise_candidate_aggregation_status(monkeypatch)
+    original_append = owner_actions_module._append_jsonl
+
+    def _refuse_error_record_writes(path, record):
+        if str(path).endswith("error_records.jsonl"):
+            raise OSError("error record surface unavailable")
+        return original_append(path, record)
+
+    monkeypatch.setattr(owner_actions_module, "_append_jsonl", _refuse_error_record_writes)
+
+    report = owner_review_status_report(store)
+
+    entries = [
+        entry
+        for entry in read_audit_entries(store.roots.audit_path)
+        if entry.get("action") == "owner_digest_error_record_failed"
+        and (entry.get("details") or {}).get("operation") == "candidate_aggregation_status_read"
+    ]
+    assert report["candidate_aggregation"]["available"] is False
+    # Without the fallback both the original failure and the recording failure
+    # vanish into `except Exception: pass`.
+    assert entries
+    details = entries[-1]["details"]
+    assert entries[-1]["status"] == "warning"
+    assert details["component"] == "owner_actions._candidate_aggregation_status_block"
+    assert details["original_error_type"] == "RuntimeError"
+    assert details["error_record_write_error_type"] == "OSError"

--- a/tests/plugins/memory/test_memory_os_recall_arbitration.py
+++ b/tests/plugins/memory/test_memory_os_recall_arbitration.py
@@ -586,6 +586,59 @@ def test_l4_ambiguous_pair_neither_suppressed_and_cross_linked_by_fingerprint():
     assert selected_by_ref["amb-right"]["ambiguity_related"] == [left_fp]
 
 
+# --- Defect 2: substrates-vocabulary authority_class must not silently rank 0 ---
+
+
+def test_substrate_vocabulary_authority_class_resolves_to_correct_rank_not_zero():
+    """Counterfactual for Defect 2: a RecallObject carrying a SUBSTRATES-
+    vocabulary authority_class ("local_canonical") -- as would be produced
+    by a retriever built on LocalArtifactProvider/GroundingFact -- must be
+    ranked using the alias bridge (recall_policy.SUBSTRATE_AUTHORITY_ALIASES),
+    not looked up directly against the arbitration vocabulary's
+    `authority_rank` table. Before the fix, `_AUTHORITY_RANK.get(authority, 0)`
+    had no entry for "local_canonical" and silently fell back to rank 0 --
+    the SAME rank as an intentionally-empty authority_class, and BELOW
+    "external_unverified" (rank 1). This is a genuinely-authoritative claim
+    that must never rank below an unverified external fact.
+    """
+    from plugins.memory.memory_os.recall_policy import AUTHORITY_FRESHNESS_MATRIX
+
+    local_canonical_via_substrate = _obj(
+        "genuinely local canonical fact",
+        authority="local_canonical",
+        ref="substrate-local",
+    )
+    external_unverified = _obj(
+        "ordinary external unverified fact",
+        authority="external_unverified",
+        ref="substrate-external",
+    )
+
+    plan = build_recall_plan([local_canonical_via_substrate, external_unverified], budget_chars=10_000)
+
+    by_ref = {entry["object"]["source_ref"]: entry for entry in plan["selected"]}
+    assert by_ref["substrate-local"]["authority_rank"] > by_ref["substrate-external"]["authority_rank"]
+    assert by_ref["substrate-local"]["authority_rank"] == AUTHORITY_FRESHNESS_MATRIX["authority_rank"]["approved_canonical"]
+    assert plan["unknown_authority_classes"] == []
+
+
+def test_unrecognized_authority_class_is_flagged_not_silently_zeroed():
+    """Counterfactual for Defect 2: a value that matches NEITHER the
+    arbitration vocabulary NOR the substrates-alias bridge must still be
+    visible as an anomaly via `unknown_authority_classes`, instead of
+    disappearing into an ordinary-looking rank 0. Reverting the
+    `resolve_authority_rank` wiring (i.e. going back to a plain
+    `_AUTHORITY_RANK.get(authority, 0)`) makes `unknown_authority_classes`
+    disappear entirely (KeyError on the plan dict) while the bad value
+    still silently ranks at 0."""
+    mystery = _obj("value from an unrecognized authority vocabulary", authority="totally_unknown_authority", ref="mystery")
+
+    plan = build_recall_plan([mystery], budget_chars=10_000)
+
+    assert plan["selected"][0]["authority_rank"] == 0
+    assert plan["unknown_authority_classes"] == ["totally_unknown_authority"]
+
+
 def test_apply_recall_plan_ignores_ambiguity_related_and_still_returns_both_objects():
     """`apply_recall_plan` reads only the "object" key of each selected
     entry -- confirm it stays unbroken when entries also carry the new

--- a/tests/plugins/memory/test_memory_os_runtime.py
+++ b/tests/plugins/memory/test_memory_os_runtime.py
@@ -199,6 +199,48 @@ def test_runtime_heartbeat_errors_are_audited_and_record_attempt(tmp_path, monke
     assert entries[-1]["details"]["error_record"]["error_code"] == "runtime_heartbeat_error"
 
 
+def test_runtime_heartbeat_completes_execution_gate_envelope_on_mid_run_error(tmp_path, monkeypatch):
+    # Counterfactual for the runtime_heartbeat_core permit-lifecycle leak: the
+    # ExecutionGate permit is opened at the top of _heartbeat_checked, but the
+    # ~140 lines of work that follow (session mirror auto-apply, per-event
+    # processing, working-memory decay, state write, index sync) previously ran
+    # unguarded. Any mid-run exception left the permit permanently orphaned —
+    # a "permit" record with zero matching "completion" records in
+    # execution_gate_envelopes.jsonl. Without the fix, this test fails because
+    # lane_records has length 1 (permit only) instead of 2 (permit+completion).
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path))
+    store.initialize()
+
+    def fail_read_events():
+        raise RuntimeError("synthetic event read failure")
+
+    monkeypatch.setattr(store, "read_events", fail_read_events)
+
+    try:
+        MemoryOSRuntime(store).heartbeat(now=datetime(2026, 5, 23, 1, tzinfo=timezone.utc))
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("heartbeat should re-raise the original failure")
+
+    envelope_path = tmp_path / "memory-os" / "system" / "execution_gate_envelopes.jsonl"
+    records = [
+        json.loads(line)
+        for line in envelope_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    lane_records = [r for r in records if r.get("lane_id") == "runtime_heartbeat_core"]
+    assert [record["stage"] for record in lane_records] == ["permit", "completion"]
+    assert lane_records[0]["execution_gate_envelope_id"] == lane_records[1]["execution_gate_envelope_id"]
+    assert lane_records[-1]["execution_status"] == "error"
+    assert lane_records[-1]["result_summary"]["error_type"] == "RuntimeError"
+    assert lane_records[-1]["result_summary"]["message"] == "synthetic event read failure"
+    # Error postcheck must reflect real (zero) progress, not a fabricated success shape.
+    assert lane_records[-1]["postcheck"]["processed_event_count"] == 0
+    assert lane_records[-1]["postcheck"]["working_created_count"] == 0
+    assert lane_records[-1]["postcheck"]["candidate_created_count"] == 0
+
+
 def test_runtime_heartbeat_attempt_state_errors_are_audited(tmp_path, monkeypatch):
     store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path))
     store.initialize()

--- a/tests/plugins/memory/test_memory_os_session_mirror.py
+++ b/tests/plugins/memory/test_memory_os_session_mirror.py
@@ -859,3 +859,50 @@ def test_runtime_heartbeat_auto_applies_one_session_after_session_mirror_lane_gr
     assert apply_records[0]["apply_governance"]["execution_gate_permit_resolution"]["unused_before_apply"] is True
     assert apply_records[0]["apply_governance"]["execution_gate_permit_resolution"]["scope_match"] is True
     assert apply_records[1]["apply_governance"]["approval_ref"] == owner_record["owner_action_id"]
+
+
+def test_unreadable_session_json_is_surfaced_not_silently_skipped(tmp_path):
+    """A dropped session file must be distinguishable from one that never existed.
+
+    `_read_session_json_files` used to skip malformed files with a bare
+    `except Exception: continue` — no error record, no counter, no finding.
+    A truncated or non-UTF8 session simply vanished from the SessionMirror
+    auto-apply candidate list with zero operator-visible signal.
+    """
+    store = _store(tmp_path)
+    sessions_root = store.roots.hermes_home / "sessions"
+    sessions_root.mkdir(parents=True, exist_ok=True)
+
+    # One good session, one truncated, one valid JSON that is not an object.
+    (sessions_root / "session_good.json").write_text(
+        json.dumps({"id": "s-good", "platform": "telegram", "messages": []}),
+        encoding="utf-8",
+    )
+    (sessions_root / "session_truncated.json").write_text('{"id": "s-bad",', encoding="utf-8")
+    (sessions_root / "session_notdict.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+    mirror = SessionMirror(store)
+    sessions = mirror._read_session_json_files()
+
+    # The good session is still returned; the two bad ones are excluded...
+    assert [item["session_id"] for item in sessions] == ["s-good"]
+
+    # ...but their exclusion is now recorded, with the full error_record schema.
+    error_codes = {
+        record["error_code"] for record in mirror._session_read_error_records
+    }
+    assert error_codes == {"session_json_unreadable", "session_json_not_an_object"}
+    for record in mirror._session_read_error_records:
+        assert record["component"] == "session_mirror"
+        assert record["operation"] == "read_session_json_files"
+        assert record["severity"] == "warning"
+        assert record["recoverable"] is True
+
+    # And doctor() surfaces them to an operator as findings.
+    findings = mirror.doctor()["findings"]
+    surfaced = {
+        finding["id"]
+        for finding in findings
+        if finding["id"] in {"session_json_unreadable", "session_json_not_an_object"}
+    }
+    assert surfaced == {"session_json_unreadable", "session_json_not_an_object"}

--- a/tests/plugins/memory/test_memory_os_signal_collectors.py
+++ b/tests/plugins/memory/test_memory_os_signal_collectors.py
@@ -2,7 +2,23 @@ import json
 
 from plugins.memory.memory_os.host_capability_probe import probe_host_capabilities
 from plugins.memory.memory_os.roots import MemoryOSRoots
-from plugins.memory.memory_os.signal_collectors import collect_signal_sources
+from plugins.memory.memory_os.signal_collectors import (
+    _mailbox_payload,
+    collect_signal_sources,
+)
+
+
+def _mailbox_base() -> dict:
+    return {
+        "status": "missing",
+        "capability_status": "missing",
+        "available": False,
+        "freshness_seconds": None,
+        "record_count": 0,
+        "latest_status": "",
+        "boundary_true_count": 0,
+        "raw_body_included": False,
+    }
 
 
 def test_collect_signal_sources_outputs_typed_metadata_only_payloads(tmp_path):
@@ -409,3 +425,80 @@ def test_collect_signal_sources_projects_external_hermes_cron_failures_metadata_
     assert payload["latest_failure_deliver"] is True
     assert "SHOULD_NOT_LEAK" not in encoded
     assert "secret token" not in encoded
+
+
+def test_mailbox_status_honors_configured_platform_root(tmp_path):
+    """Counterfactual for the deleted config-aware mailbox resolver.
+
+    Without _configured_mailbox_root, _mailbox_payload only ever probes
+    hermes_home/mailbox and hermes_home/system/mailbox, so it would report
+    mailbox_exists=False here even though a real, populated mailbox exists
+    at the host-configured platforms.mailbox.extra.root location.
+    """
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    community_root = tmp_path / "community_mailbox"
+    inbox = community_root / "agents" / "agent-42" / "inbox"
+    outbox = community_root / "agents" / "agent-42" / "outbox"
+    inbox.mkdir(parents=True)
+    outbox.mkdir(parents=True)
+    (inbox / "letter.json").write_text(json.dumps({"body": "hi"}), encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "\n".join(
+            [
+                "platforms:",
+                "  mailbox:",
+                "    extra:",
+                "      root: community_mailbox",
+                "      agent_id: agent-42",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = _mailbox_payload(roots, _mailbox_base())
+
+    assert payload["mailbox_exists"] is True
+    assert payload["inbox_exists"] is True
+    assert payload["outbox_exists"] is True
+    assert payload["inbox_count"] == 1
+
+
+def test_mailbox_status_falls_back_to_hardcoded_root_without_config(tmp_path):
+    """No-config hosts must resolve identically to before this fix."""
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    (tmp_path / "mailbox" / "inbox").mkdir(parents=True)
+    (tmp_path / "mailbox" / "inbox" / "letter.json").write_text("{}", encoding="utf-8")
+
+    payload = _mailbox_payload(roots, _mailbox_base())
+
+    assert payload["mailbox_exists"] is True
+    assert payload["inbox_count"] == 1
+
+
+def test_mailbox_status_ignores_malformed_config(tmp_path):
+    """A malformed/incomplete config.yaml must never crash signal collection
+    and must fall back to the hardcoded probe unchanged."""
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    (tmp_path / "mailbox" / "inbox").mkdir(parents=True)
+    (tmp_path / "mailbox" / "inbox" / "letter.json").write_text("{}", encoding="utf-8")
+    # agent_id fails the [A-Za-z0-9_-]{1,64} validation -- must be rejected,
+    # not used to build an unsafe path.
+    (tmp_path / "config.yaml").write_text(
+        "\n".join(
+            [
+                "platforms:",
+                "  mailbox:",
+                "    extra:",
+                "      root: community_mailbox",
+                "      agent_id: '../escape'",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = _mailbox_payload(roots, _mailbox_base())
+
+    assert payload["mailbox_exists"] is True
+    assert payload["inbox_count"] == 1

--- a/tests/plugins/memory/test_memory_os_state_overlay.py
+++ b/tests/plugins/memory/test_memory_os_state_overlay.py
@@ -13,6 +13,7 @@ from plugins.memory.memory_os.state_overlay_schema import (
     OverlayEntry,
     OverlaySection,
     STATE_OVERLAY_SCHEMA_VERSION,
+    OVERLAY_SECTION_FIELDS,
 )
 from plugins.memory.memory_os.state_overlay import (
     build_state_overlay,
@@ -101,19 +102,39 @@ class TestStateOverlaySchema:
         assert overlay.schema_version == STATE_OVERLAY_SCHEMA_VERSION
 
     def test_state_overlay_to_dict_has_all_sections(self):
+        """Expectation is derived from OVERLAY_SECTION_FIELDS (the dataclass's
+        own fields typed OverlaySection) rather than a hand-typed list. A
+        hand-typed list here was itself part of a real drift bug: it was kept
+        in sync with to_dict() only, so it never caught that four other
+        consumers had silently dropped a removed section.
+        """
         overlay = StateOverlay.create(profile="test")
         d = overlay.to_dict()
         assert d["schema_version"] == STATE_OVERLAY_SCHEMA_VERSION
-        for key in (
-            "identity_snapshot", "relationship_snapshot", "active_projects",
-            "open_threads", "recent_events", "owner_preferences",
-            "capability_map", "material_index",
-        ):
+        # Sanity: the derivation actually found the sections (guards against
+        # a no-op that would make every assertion below vacuously true).
+        assert len(OVERLAY_SECTION_FIELDS) == 8
+        for key in OVERLAY_SECTION_FIELDS:
             assert key in d
             assert isinstance(d[key], dict)
             assert "status" in d[key]
             assert "source" in d[key]
             assert "data" in d[key]
+
+    def test_state_overlay_to_dict_key_order_matches_declaration_order(self):
+        """Byte-identical serialization guarantee (constraint 4): to_dict()'s
+        key order must still be schema_version, generated_at, profile, each
+        section in declaration order, risk_notes, evidence_refs — unchanged
+        by the refactor to derive sections from OVERLAY_SECTION_FIELDS.
+        """
+        d = StateOverlay.create(profile="test").to_dict()
+        assert list(d.keys()) == [
+            "schema_version", "generated_at", "profile",
+            "identity_snapshot", "relationship_snapshot", "active_projects",
+            "open_threads", "recent_events", "owner_preferences",
+            "capability_map", "material_index",
+            "risk_notes", "evidence_refs",
+        ]
 
 
 # ── Builder tests ────────────────────────────────────────────────────
@@ -640,3 +661,121 @@ class TestPrefetchStateOverlayIntegration:
         assert lines
         assert lines[0] != "### Memory State Overlay"
         assert all(line != "### Memory State Overlay" for line in lines)
+
+
+# ── Registry single-source-of-truth tests ────────────────────────────
+#
+# These guard against the confirmed drift bug: the set of StateOverlay
+# sections used to be hand-duplicated across six independent sites with no
+# shared source of truth. When `community_snapshot` was removed from the
+# dataclass, three of those sites were never updated and the section quietly
+# vanished from `_overlay_has_data`, the refresh cron's `section_count`, and
+# the retriever — for its *entire* lifetime, with no test catching it,
+# because the old version of `test_state_overlay_to_dict_has_all_sections`
+# (above) was itself a seventh hand-typed copy, kept in sync with `to_dict()`
+# only.
+#
+# Every site now derives from `OVERLAY_SECTION_FIELDS`
+# (state_overlay_schema.py). The tests below fail if that stops being true.
+
+
+class TestOverlaySectionRegistrySingleSourceOfTruth:
+    def test_renderer_labels_cover_every_derived_section(self):
+        """Site 2 (state_overlay_renderer._SECTION_LABELS) must have a label
+        for every section — not more, not fewer."""
+        from plugins.memory.memory_os.state_overlay_renderer import _SECTION_LABELS
+        assert set(_SECTION_LABELS) == set(OVERLAY_SECTION_FIELDS)
+
+    def test_renderer_short_sections_is_valid_subset(self):
+        """Site 3 (_SHORT_SECTIONS) is a deliberate subset — must not
+        reference a section name that doesn't exist (typo/removed-section
+        guard)."""
+        from plugins.memory.memory_os.state_overlay_renderer import _SHORT_SECTIONS
+        assert _SHORT_SECTIONS <= set(OVERLAY_SECTION_FIELDS)
+        assert _SHORT_SECTIONS  # non-trivial subset
+
+    def test_renderer_placeholder_sections_is_valid_subset(self):
+        """The renderer's "skip insufficient_data marker" subset must not
+        reference a section name that doesn't exist."""
+        from plugins.memory.memory_os.state_overlay_renderer import _PLACEHOLDER_SECTIONS
+        assert _PLACEHOLDER_SECTIONS <= set(OVERLAY_SECTION_FIELDS)
+
+    def test_renderer_raises_loudly_on_unlabeled_section(self):
+        """Counterfactual: if a section were added to the dataclass and left
+        unlabeled, the renderer must fail loudly at (re-)validation time
+        instead of silently rendering it blank. Simulates the addition via a
+        synthetic extended tuple rather than mutating StateOverlay itself.
+        """
+        from plugins.memory.memory_os.state_overlay_renderer import (
+            _assert_labels_cover_all_sections,
+        )
+        with pytest.raises(RuntimeError, match="community_snapshot"):
+            _assert_labels_cover_all_sections(("community_snapshot", *OVERLAY_SECTION_FIELDS))
+        # And the real, current section set must still validate cleanly.
+        _assert_labels_cover_all_sections(OVERLAY_SECTION_FIELDS)
+
+    def test_retriever_sections_partition_the_full_derived_set(self):
+        """Site 6 (retrievers/state_overlay.py) must classify every section
+        as either retrievable or explicitly not-retrievable — the union must
+        equal the full derived set with no overlap."""
+        from plugins.memory.memory_os.retrievers.state_overlay import (
+            _RETRIEVABLE_SECTIONS,
+            _NOT_RETRIEVABLE_SECTIONS,
+        )
+        retrievable = set(_RETRIEVABLE_SECTIONS)
+        assert retrievable | _NOT_RETRIEVABLE_SECTIONS == set(OVERLAY_SECTION_FIELDS)
+        assert retrievable & _NOT_RETRIEVABLE_SECTIONS == set()
+        # No duplicate entries within the retrievable tuple itself.
+        assert len(_RETRIEVABLE_SECTIONS) == len(retrievable)
+
+    def test_retriever_raises_loudly_on_unclassified_section(self):
+        """Counterfactual: if a section were added to the dataclass and left
+        unclassified here, the retriever must fail loudly instead of
+        silently omitting it from recall (exactly what happened to
+        community_snapshot)."""
+        from plugins.memory.memory_os.retrievers.state_overlay import (
+            _assert_sections_classified,
+        )
+        with pytest.raises(RuntimeError, match="community_snapshot"):
+            _assert_sections_classified(("community_snapshot", *OVERLAY_SECTION_FIELDS))
+        _assert_sections_classified(OVERLAY_SECTION_FIELDS)
+
+    def test_overlay_has_data_honors_whatever_section_keys_it_is_given(self):
+        """Site 4 (prefetch._overlay_has_data) must have no private hardcoded
+        section list of its own — its result must depend entirely on the
+        section_keys argument the caller (prefetch._state_overlay_lines)
+        passes in, which is OVERLAY_SECTION_FIELDS. Simulates a newly added
+        section ('future_section') to prove detection isn't tied to a fixed
+        list baked into this function.
+        """
+        from plugins.memory.memory_os.prefetch import _overlay_has_data
+
+        overlay = {
+            "identity_snapshot": {"status": "insufficient_data"},
+            "future_section": {"status": "ok"},
+        }
+        # Without the new section wired into the passed-in key list, it's
+        # invisible — this is the historical bug, reproduced deliberately.
+        assert _overlay_has_data(overlay, OVERLAY_SECTION_FIELDS) is False
+        # Once the (derived) key list includes it, it's detected.
+        assert _overlay_has_data(overlay, (*OVERLAY_SECTION_FIELDS, "future_section")) is True
+
+    def test_refresh_script_section_counter_uses_derived_fields(self):
+        """Site 5 (scripts/memory_os_state_overlay_refresh.py) must import
+        OVERLAY_SECTION_FIELDS rather than hand-maintaining its own tuple.
+        Direct behavioral coverage (via subprocess + monkeypatched module)
+        lives in tests/scripts/test_memory_os_state_overlay_refresh.py; this
+        is a lightweight static check that the import exists and matches.
+        """
+        script_path = (
+            Path(__file__).resolve().parents[3]
+            / "scripts" / "memory_os_state_overlay_refresh.py"
+        )
+        source = script_path.read_text(encoding="utf-8")
+        assert "OVERLAY_SECTION_FIELDS" in source
+        assert (
+            "from plugins.memory.memory_os.state_overlay_schema import "
+            "OVERLAY_SECTION_FIELDS" in source
+        )
+        # And the old hand-typed tuple must be gone.
+        assert '"identity_snapshot", "relationship_snapshot", "active_projects",' not in source

--- a/tests/plugins/memory/test_memory_os_substrate_router.py
+++ b/tests/plugins/memory/test_memory_os_substrate_router.py
@@ -99,6 +99,18 @@ def test_active_hindsight_does_not_outrank_local_canonical_fact():
 
 
 def test_external_provider_claiming_local_authority_is_a_guard_violation():
+    """Counterfactual: an external provider (not local_artifact) that
+    self-reports authority_class="local_canonical" must not merely be
+    FLAGGED -- it must be structurally excluded from the ranked/selectable
+    output. Before the fix, `_rank_fact` granted this fact tier-1 priority
+    based solely on its own claimed authority_class (no provider-identity
+    check), so with no genuine local_artifact fact in this call it became
+    `facts[0]` and `selected_provider == "hindsight"` -- i.e. the spoofed
+    claim WON despite the detection fields correctly flipping. Reverting
+    the router.py fix makes the two new assertions below fail while the
+    three original detection assertions keep passing -- proving the old
+    test never actually caught the vulnerability it targeted.
+    """
     bad_external_fact = GroundingFact(
         provider="hindsight",
         capability="recall",
@@ -115,5 +127,54 @@ def test_external_provider_claiming_local_authority_is_a_guard_violation():
     result = router.recall("memory", consumer="grounded_expression")
 
     assert result["authoritative"] is False
+    assert result["external_authoritative_count"] == 1
+    assert result["local_first_authority_preserved"] is False
+    # The spoofed fact must never reach selectable/returned content.
+    assert result["facts"] == []
+    assert result["selected_provider"] != "hindsight"
+    assert result["selected_provider"] == "deterministic_fallback"
+
+
+def test_spoofed_local_authority_claim_excluded_even_alongside_genuine_local_fact():
+    """A second counterfactual with a genuine local_artifact fact ALSO
+    present: the spoofed external claim must still be dropped from
+    `facts` (not merely outranked), while the real local fact still wins
+    selection. This guards against a fix that only reorders tiers instead
+    of structurally excluding the spoofed entry."""
+    local_fact = GroundingFact(
+        provider="local_artifact",
+        capability="recall",
+        body_summary="local canonical",
+        confidence=1.0,
+        provenance="crystallized",
+        source_event_refs=["cmem_1"],
+        substrate_snapshot_id="local:canonical:v4",
+        advisory_only=False,
+        authority_class="local_canonical",
+    )
+    bad_external_fact = GroundingFact(
+        provider="hindsight",
+        capability="recall",
+        body_summary="bad authority claim",
+        confidence=0.99,
+        provenance="hindsight_recall",
+        source_event_refs=["h1"],
+        substrate_snapshot_id="hindsight:bank:v1",
+        advisory_only=False,
+        authority_class="owner_approved",
+    )
+    router = SubstrateRouter(
+        providers=[
+            FakeProvider("hindsight", facts=[bad_external_fact]),
+            FakeProvider("local_artifact", facts=[local_fact]),
+        ],
+        mode="active",
+    )
+
+    result = router.recall("memory", consumer="grounded_expression")
+
+    assert len(result["facts"]) == 1
+    assert result["facts"][0]["provider"] == "local_artifact"
+    assert result["selected_provider"] == "local_artifact"
     assert result["external_authoritative_count"] == 1
     assert result["local_first_authority_preserved"] is False

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -6961,3 +6961,57 @@ def test_remote_probe_bounds_missing_system_commands():
     script = _remote_probe_script("/tmp/nonexistent-hermes-home")
     assert "except OSError as exc:" in script
     assert '"code": 127' in script
+
+
+def test_error_record_emitting_components_constant_matches_source():
+    """A new `build_error_record(component=...)` emitter must be classified.
+
+    The monitor's headline `suppressed_error_count` can only aggregate a
+    component whose status payload actually reaches the snapshot — today
+    only four do. Components that emit error records but are not aggregated
+    undercount that headline silently, so the full emitter list is recorded
+    in ERROR_RECORD_EMITTING_COMPONENTS. This test derives the real list
+    from source, so adding an emitter without classifying it fails loudly
+    instead of quietly widening the blind spot.
+    """
+    import re
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pattern = re.compile(r'component=\s*"([^"]+)"')
+    found: set[str] = set()
+    for base in ("plugins", "scripts"):
+        for path in (repo_root / base).rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            found.update(pattern.findall(path.read_text(encoding="utf-8", errors="ignore")))
+
+    missing = found - set(monitor.ERROR_RECORD_EMITTING_COMPONENTS)
+    stale = set(monitor.ERROR_RECORD_EMITTING_COMPONENTS) - found
+    assert not missing, (
+        "new error_record emitter(s) not classified in "
+        f"ERROR_RECORD_EMITTING_COMPONENTS: {sorted(missing)}"
+    )
+    assert not stale, (
+        "ERROR_RECORD_EMITTING_COMPONENTS lists component(s) that no longer "
+        f"emit error records: {sorted(stale)}"
+    )
+
+
+def test_monitor_error_observability_reports_component_coverage_gap():
+    """The undercount must be visible in the monitor output, not silent."""
+    report = monitor.monitor_error_observability({})
+    coverage = report["component_coverage"]
+
+    assert set(coverage["aggregated_components"]) == {
+        "runtime",
+        "memory_projection",
+        "session_mirror",
+        "prefetch",
+    }
+    # Dotted sub-components roll up to an aggregated parent...
+    assert "prefetch._indexed_lines" not in coverage["unaggregated_components"]
+    # ...but genuinely uncollected components are reported as such.
+    assert "state_source_mirror" in coverage["unaggregated_components"]
+    assert "memory_os.permanent_promotion" in coverage["unaggregated_components"]
+    assert coverage["unaggregated_component_count"] == len(coverage["unaggregated_components"])
+    assert coverage["unaggregated_component_count"] > 0

--- a/tests/scripts/test_memory_os_community_retirement.py
+++ b/tests/scripts/test_memory_os_community_retirement.py
@@ -1,0 +1,184 @@
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from scripts.memory_os_community_retirement import (
+    ARCHIVE_ROOT_RELATIVE_PATH,
+    MANIFEST_RELATIVE_PATH,
+    build_parser,
+    main,
+    retire_community,
+    retirement_status,
+)
+
+
+def _seed_residue(home: Path) -> None:
+    """Create a minimal but representative slice of on-host community residue.
+
+    Two plugin module files (one with a raw append write surface, matching
+    the review finding), the community data layout with a roster.jsonl, and
+    one leftover cron helper script.
+    """
+
+    plugin_dir = home / "plugins" / "memory_os"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "community.py").write_text("# community core\n", encoding="utf-8")
+    (plugin_dir / "community_shared.py").write_text(
+        "def write(path):\n    with open(path, 'a') as fh:\n        fh.write('x')\n",
+        encoding="utf-8",
+    )
+
+    community_data = home / "memory-os" / "community"
+    (community_data / "charters").mkdir(parents=True)
+    (community_data / "shared").mkdir(parents=True)
+    (community_data / "roster.jsonl").write_text('{"partner": "a"}\n{"partner": "b"}\n', encoding="utf-8")
+    (community_data / "budget.yaml").write_text("enforcement: fail-closed\n", encoding="utf-8")
+
+    scripts_dir = home / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "community_partner_reply.py").write_text("# leftover cron script\n", encoding="utf-8")
+
+
+def test_status_reports_not_retired_when_no_residue_present(tmp_path):
+    report = retirement_status(tmp_path)
+
+    assert report["status"] == "not_retired"
+    assert report["lifecycle"] == "active"
+    assert report["violations"] == []
+    assert report["archived_file_count"] == 0
+
+
+def test_apply_is_noop_when_no_community_residue_exists(tmp_path):
+    """Must not be destructive if $HERMES_HOME has no community residue at all:
+
+    no manifest, no archive directory, applied stays False."""
+
+    report = retire_community(tmp_path, apply=True)
+
+    assert report["status"] == "noop_no_residue"
+    assert report["applied"] is False
+    assert not (tmp_path / MANIFEST_RELATIVE_PATH).exists()
+    assert not (tmp_path / ARCHIVE_ROOT_RELATIVE_PATH).exists()
+
+
+def test_dry_run_plan_reports_files_without_moving_or_writing_anything(tmp_path):
+    _seed_residue(tmp_path)
+    community_py = tmp_path / "plugins" / "memory_os" / "community.py"
+    roster = tmp_path / "memory-os" / "community" / "roster.jsonl"
+
+    report = retire_community(tmp_path, apply=False)
+
+    assert report["status"] == "dry_run"
+    assert report["applied"] is False
+    plan = report["plan"]
+    assert plan["archived_file_count"] >= 5
+    relative_paths = {item["relative_path"] for item in plan["archived_files"]}
+    assert "plugins/memory_os/community.py" in relative_paths
+    assert "memory-os/community/roster.jsonl" in relative_paths
+    # dry-run changes nothing on disk.
+    assert community_py.is_file()
+    assert roster.is_file()
+    assert not (tmp_path / MANIFEST_RELATIVE_PATH).exists()
+    assert not (tmp_path / ARCHIVE_ROOT_RELATIVE_PATH).exists()
+
+
+def test_apply_archives_sources_and_is_idempotent_on_second_run(tmp_path):
+    _seed_residue(tmp_path)
+    community_py = tmp_path / "plugins" / "memory_os" / "community.py"
+    community_data_dir = tmp_path / "memory-os" / "community"
+
+    first = retire_community(tmp_path, apply=True)
+
+    assert first["status"] == "retired"
+    assert first["applied"] is True
+    # Sources are moved (archived), never deleted outright: they must no
+    # longer exist at their original live location.
+    assert not community_py.exists()
+    assert not community_data_dir.exists()
+    manifest = json.loads((tmp_path / MANIFEST_RELATIVE_PATH).read_text(encoding="utf-8"))
+    assert manifest["lifecycle"] == "retired"
+    archive_root = tmp_path / manifest["archive_relative_path"]
+    archived_community_py = archive_root / "plugins" / "memory_os" / "community.py"
+    assert archived_community_py.is_file()
+    assert archived_community_py.read_text(encoding="utf-8") == "# community core\n"
+    # Archive is read-only.
+    mode = stat.S_IMODE(archived_community_py.stat().st_mode)
+    assert not (mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
+
+    second = retire_community(tmp_path, apply=True)
+
+    assert second["status"] == "already_retired"
+    assert second["applied"] is False
+    # Re-running must not duplicate or re-move anything.
+    assert archived_community_py.read_text(encoding="utf-8") == "# community core\n"
+
+    status = retirement_status(tmp_path)
+    assert status["status"] == "ok"
+    assert status["violations"] == []
+
+
+def test_apply_blocked_while_enabled_community_cron_job_present(tmp_path):
+    """Counterfactual: without the enabled-cron prerequisite guard, apply
+    would silently move community_partner_reply.py out from under a still
+    -enabled cron job. This must refuse instead, and must not touch any
+    file when it refuses."""
+
+    _seed_residue(tmp_path)
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir(parents=True)
+    cron_dir.joinpath("jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"name": "community-partner-reply", "script": "community_partner_reply.py", "enabled": True},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    community_partner_reply = tmp_path / "scripts" / "community_partner_reply.py"
+
+    with pytest.raises(RuntimeError, match="community cron jobs must be paused"):
+        retire_community(tmp_path, apply=True)
+
+    assert community_partner_reply.is_file()
+    assert not (tmp_path / MANIFEST_RELATIVE_PATH).exists()
+    assert not (tmp_path / ARCHIVE_ROOT_RELATIVE_PATH).exists()
+
+
+def test_status_flags_tampered_archive_as_violation(tmp_path):
+    _seed_residue(tmp_path)
+    retire_community(tmp_path, apply=True)
+    manifest = json.loads((tmp_path / MANIFEST_RELATIVE_PATH).read_text(encoding="utf-8"))
+    archive_root = tmp_path / manifest["archive_relative_path"]
+    archived_community_py = archive_root / "plugins" / "memory_os" / "community.py"
+
+    archived_community_py.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    archived_community_py.write_text("# tampered\n", encoding="utf-8")
+
+    status = retirement_status(tmp_path)
+
+    assert status["status"] == "error"
+    assert "archive_hash_mismatch" in status["violations"]
+
+
+def test_cli_default_mode_without_apply_flag_is_dry_run_and_writes_nothing(tmp_path):
+    """Default parameters must never be traps: forgetting --apply must never
+    silently archive/move anything."""
+
+    _seed_residue(tmp_path)
+
+    exit_code = main(["--hermes-home", str(tmp_path)])
+
+    assert exit_code == 0
+    assert not (tmp_path / MANIFEST_RELATIVE_PATH).exists()
+    assert (tmp_path / "plugins" / "memory_os" / "community.py").is_file()
+
+
+def test_build_parser_apply_and_status_are_mutually_exclusive(tmp_path):
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--hermes-home", str(tmp_path), "--apply", "--status"])

--- a/tests/scripts/test_memory_os_monitor_dashboard_snapshot.py
+++ b/tests/scripts/test_memory_os_monitor_dashboard_snapshot.py
@@ -7,6 +7,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from plugins.memory.memory_os.cron_registry import memory_os_cron_specs
 from plugins.memory.memory_os.legacy_right_brain_retirement import retire_legacy_right_brain
 
 
@@ -790,6 +791,45 @@ def test_expression_feedback_is_optional_when_expression_is_disabled():
     module = _load_module()
     assert "memory-os-expression-feedback-request" not in module.CORE_MEMORY_OS_CRON
     assert "memory-os-expression-feedback-request" in module.OPTIONAL_MEMORY_OS_CRON
+
+
+def test_core_and_optional_cron_sets_exhaustively_cover_the_registry():
+    """Counterfactual for registry drift in the dashboard's cron health
+    classification. CORE_MEMORY_OS_CRON and OPTIONAL_MEMORY_OS_CRON must
+    together cover every name in memory_os_cron_specs() -- a name that
+    falls into neither set silently lands in the "other" bucket
+    (_cron_snapshot's other_jobs / classifications["other"]) and never
+    increments missing_core or optional_paused, so the monitor never WARNs
+    if that job is disabled or deleted on a host.
+
+    Before this fix, memory-os-hindsight-advisory-digest,
+    memory-os-hindsight-health-probe, and memory-os-clearance-cycle were
+    all real registered, active-closure-installed cron jobs missing from
+    both hand-typed sets. This test fails without the fix (both sets were
+    static, hand-typed frozensets that predated those specs) and passes
+    once CORE/OPTIONAL are derived from the registry.
+    """
+    module = _load_module()
+    all_names = {spec.name for spec in memory_os_cron_specs()}
+
+    assert module.CORE_MEMORY_OS_CRON.isdisjoint(module.OPTIONAL_MEMORY_OS_CRON)
+    assert module.CORE_MEMORY_OS_CRON | module.OPTIONAL_MEMORY_OS_CRON == all_names
+
+
+def test_hindsight_and_clearance_cron_are_not_left_unclassified():
+    """Direct counterfactual for the three specific jobs identified as
+    missing from the dashboard's hand-typed CORE/OPTIONAL sets. All three
+    are unconditionally onboarded on active-closure hosts (none has a
+    documented reason to tolerate being paused), so all three belong in
+    CORE, not OPTIONAL and not unclassified."""
+    module = _load_module()
+    for name in (
+        "memory-os-hindsight-advisory-digest",
+        "memory-os-hindsight-health-probe",
+        "memory-os-clearance-cycle",
+    ):
+        assert name in module.CORE_MEMORY_OS_CRON, name
+        assert name not in module.OPTIONAL_MEMORY_OS_CRON, name
 
 
 def test_retired_right_brain_is_removed_from_active_cron_surface(tmp_path):

--- a/tests/scripts/test_memory_os_monitor_dashboard_snapshot.py
+++ b/tests/scripts/test_memory_os_monitor_dashboard_snapshot.py
@@ -20,6 +20,15 @@ def _load_module():
     return module
 
 
+def _load_onboarding_module():
+    path = Path(__file__).resolve().parents[2] / "scripts" / "memory_os_owner_cron_onboarding.py"
+    spec = importlib.util.spec_from_file_location("memory_os_owner_cron_onboarding", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
 def _write_jsonl(path: Path, records: list[dict]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -818,18 +827,39 @@ def test_core_and_optional_cron_sets_exhaustively_cover_the_registry():
 
 def test_hindsight_and_clearance_cron_are_not_left_unclassified():
     """Direct counterfactual for the three specific jobs identified as
-    missing from the dashboard's hand-typed CORE/OPTIONAL sets. All three
-    are unconditionally onboarded on active-closure hosts (none has a
-    documented reason to tolerate being paused), so all three belong in
-    CORE, not OPTIONAL and not unclassified."""
+    missing from the dashboard's hand-typed CORE/OPTIONAL sets.
+
+    The two hindsight jobs are unconditionally onboarded on active-closure
+    hosts, so their absence must WARN -- they belong in CORE.
+
+    clearance-cycle is classified OPTIONAL for exactly as long as
+    active-closure onboarding defers it (see ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
+    in memory_os_owner_cron_onboarding.py). Calling a job we deliberately do
+    not install CORE would raise a permanent missing_core WARN for its
+    expected absence. What matters either way is that it is CLASSIFIED --
+    the original bug was that all three fell through to the untracked
+    "other" bucket, so their disappearance could never be noticed.
+    """
     module = _load_module()
     for name in (
         "memory-os-hindsight-advisory-digest",
         "memory-os-hindsight-health-probe",
-        "memory-os-clearance-cycle",
     ):
         assert name in module.CORE_MEMORY_OS_CRON, name
         assert name not in module.OPTIONAL_MEMORY_OS_CRON, name
+
+    assert "memory-os-clearance-cycle" in module.OPTIONAL_MEMORY_OS_CRON
+    assert "memory-os-clearance-cycle" not in module.CORE_MEMORY_OS_CRON
+
+    # The two classifications must stay in lockstep: a job excluded from the
+    # active-closure install must not be CORE, or the monitor WARNs forever.
+    onboarding = _load_onboarding_module()
+    for spec_key, job_name in (("clearance_cycle", "memory-os-clearance-cycle"),):
+        if spec_key in onboarding.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS:
+            assert job_name not in module.CORE_MEMORY_OS_CRON, (
+                f"{job_name} is excluded from active-closure onboarding but "
+                "classified CORE, which would WARN on its expected absence"
+            )
 
 
 def test_retired_right_brain_is_removed_from_active_cron_surface(tmp_path):

--- a/tests/scripts/test_memory_os_owner_cron_onboarding.py
+++ b/tests/scripts/test_memory_os_owner_cron_onboarding.py
@@ -281,19 +281,17 @@ def test_onboarding_dry_run_selects_detected_channel_and_does_not_create_jobs(tm
     assert hindsight_health["schedule"] == "33 * * * *"
     assert hindsight_health["script"] == "memory_os_hindsight_health_probe.py"
     assert hindsight_health["raw_script"] == "memory_os_hindsight_health_probe.py"
-    # Counterfactual: clearance_cycle is a real registered spec whose helper
-    # and gate scripts the installer already deploys (see
-    # install_memory_os_plugin.py). Its absence from the old hand-typed
-    # ACTIVE_CLOSURE_CRON_KEYS frozenset was an oversight (every sibling key
-    # was added to that set in the same commit that registered it -- this
-    # one was not); this asserts it is now actually onboarded on
-    # active-closure hosts.
-    clearance_cycle = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-clearance-cycle"][0]
-    assert clearance_cycle["schedule"] == "*/10 * * * *"
-    assert clearance_cycle["script"] == "memory_os_cron_clearance_cycle_gate.py"
-    assert clearance_cycle["raw_script"] == "memory_os_clearance_cycle_helper.py"
-    assert clearance_cycle["deliver"] == "local"
-    assert clearance_cycle["no_agent"] is True
+    # clearance_cycle is a real registered spec whose helper and gate scripts
+    # the installer already deploys, but its activation is DEFERRED (see the
+    # comment on ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS): enabling it in the same
+    # change that repaired append_terminal would make two never-exercised
+    # paths live at once on production. Assert the deferral is real and
+    # deliberate -- not the old silent drift.
+    assert not [
+        job for job in report["operational_cron_jobs"]
+        if job["name"] == "memory-os-clearance-cycle"
+    ]
+    assert "clearance_cycle" in module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
     for job in report["operational_cron_jobs"]:
         assert home.joinpath("scripts", job["script"]).is_file(), job["script"]
     assert not home.joinpath("cron", "jobs.json").exists()
@@ -656,20 +654,29 @@ def test_active_closure_cron_keys_are_derived_from_the_registry_not_hand_typed()
     therefore silently never created the clearance_cycle cron job even
     though its helper/gate scripts were deployed by the installer.
 
-    Without the derivation fix this test fails two ways: the hand-typed
-    frozenset has no ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS companion (this
-    module previously defined none), and "clearance_cycle" is absent from
-    ACTIVE_CLOSURE_CRON_KEYS.
+    Without the derivation fix this test fails: the hand-typed frozenset has
+    no ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS companion (this module previously
+    defined none), so an unlisted spec was silently dropped rather than
+    deliberately classified.
+
+    Note the distinction this test enforces: clearance_cycle is still not
+    onboarded today, but it is now EXCLUDED BY NAME with a documented reason
+    (deferred activation) instead of merely being absent from a hand-typed
+    list. That is the whole point -- omission must be a decision, not an
+    accident.
     """
     module = _load_module()
     all_keys = {spec.key for spec in memory_os_cron_specs()}
 
     assert module.ACTIVE_CLOSURE_CRON_KEYS == all_keys - module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
-    # module_cadence_report is the one documented, deliberate exclusion --
-    # its report is already generated on-demand elsewhere. Everything else
-    # registered defaults to being onboarded and visible.
-    assert module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS == {"module_cadence_report"}
-    assert "clearance_cycle" in module.ACTIVE_CLOSURE_CRON_KEYS
+    # Both exclusions are documented and deliberate: module_cadence_report is
+    # permanent (generated on demand elsewhere); clearance_cycle is deferred
+    # pending a separate, observed enablement.
+    assert module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS == {
+        "module_cadence_report",
+        "clearance_cycle",
+    }
+    assert "clearance_cycle" not in module.ACTIVE_CLOSURE_CRON_KEYS
     assert "module_cadence_report" not in module.ACTIVE_CLOSURE_CRON_KEYS
     # Every registered key must be classified one way or the other -- no
     # key silently falls through unclassified.

--- a/tests/scripts/test_memory_os_owner_cron_onboarding.py
+++ b/tests/scripts/test_memory_os_owner_cron_onboarding.py
@@ -6,6 +6,8 @@ import os
 import sys
 from pathlib import Path
 
+from plugins.memory.memory_os.cron_registry import memory_os_cron_specs
+
 
 def _load_module():
     path = Path(__file__).resolve().parents[2] / "scripts" / "memory_os_owner_cron_onboarding.py"
@@ -241,28 +243,19 @@ def test_onboarding_dry_run_selects_detected_channel_and_does_not_create_jobs(tm
     assert report["selected_right_brain_deliver"] == "origin"
     assert report["apply_requested"] is False
     assert report["cron_profile"] == "active-closure"
-    assert len(report["operational_cron_jobs"]) == 19
-    assert {job["name"] for job in report["operational_cron_jobs"]} == {
-        "memory-os-owner-review-digest",
-        "memory-os-proposal-followups-opsgate",
-        "memory-os-index-sync",
-        "memory-os-working-cleanup",
-        "memory-os-l3-probe-verification",
-        "memory-os-candidate-aggregation",
-        "memory-os-fact-judge",
-        "memory-os-event-stats-refresh",
-        "memory-os-exposure-rollup",
-        "memory-os-full-monitor-refresh",
-        "memory-os-v3-seed-evidence",
-        "memory-os-v3-wandering",
-        "memory-os-v3-journal-sweep",
-        "memory-os-state-overlay-refresh",
-        "memory-os-entity-index-refresh",
-        "memory-os-hindsight-advisory-digest",
-        "memory-os-hindsight-health-probe",
-        "memory-os-expression-feedback-request",
-        "memory-os-memory-sources-feedback-request",
+    # Derive the expected active-closure job set from the registry itself
+    # (via the module's own ACTIVE_CLOSURE_CRON_KEYS), not a hand-typed
+    # literal -- a hardcoded list here would silently re-hide the same
+    # registry-drift bug (a real registered spec, e.g. clearance_cycle,
+    # missing from the active-closure install) that this test exists to
+    # catch. See test_active_closure_cron_keys_are_derived_from_the_registry_not_hand_typed
+    # for the direct counterfactual on the derivation itself.
+    expected_names = {
+        spec.name for spec in memory_os_cron_specs()
+        if spec.key in module.ACTIVE_CLOSURE_CRON_KEYS
     }
+    assert len(report["operational_cron_jobs"]) == len(expected_names)
+    assert {job["name"] for job in report["operational_cron_jobs"]} == expected_names
     index_sync = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-index-sync"][0]
     assert index_sync["script"] == "memory_os_cron_index_sync_gate.py"
     assert index_sync["raw_script"] == "memory_os_index_sync.py"
@@ -288,6 +281,19 @@ def test_onboarding_dry_run_selects_detected_channel_and_does_not_create_jobs(tm
     assert hindsight_health["schedule"] == "33 * * * *"
     assert hindsight_health["script"] == "memory_os_hindsight_health_probe.py"
     assert hindsight_health["raw_script"] == "memory_os_hindsight_health_probe.py"
+    # Counterfactual: clearance_cycle is a real registered spec whose helper
+    # and gate scripts the installer already deploys (see
+    # install_memory_os_plugin.py). Its absence from the old hand-typed
+    # ACTIVE_CLOSURE_CRON_KEYS frozenset was an oversight (every sibling key
+    # was added to that set in the same commit that registered it -- this
+    # one was not); this asserts it is now actually onboarded on
+    # active-closure hosts.
+    clearance_cycle = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-clearance-cycle"][0]
+    assert clearance_cycle["schedule"] == "*/10 * * * *"
+    assert clearance_cycle["script"] == "memory_os_cron_clearance_cycle_gate.py"
+    assert clearance_cycle["raw_script"] == "memory_os_clearance_cycle_helper.py"
+    assert clearance_cycle["deliver"] == "local"
+    assert clearance_cycle["no_agent"] is True
     for job in report["operational_cron_jobs"]:
         assert home.joinpath("scripts", job["script"]).is_file(), job["script"]
     assert not home.joinpath("cron", "jobs.json").exists()
@@ -635,3 +641,36 @@ def test_updates_existing_memory_sources_feedback_cron_prompt(tmp_path, monkeypa
     assert "旧提示" not in updated_job["prompt"]
     assert "不要写 Cron Run Report" in updated_job["prompt"]
     assert "只输出 OWNER_MESSAGE_BEGIN 和 OWNER_MESSAGE_END 之间的内容" in updated_job["prompt"]
+
+
+def test_active_closure_cron_keys_are_derived_from_the_registry_not_hand_typed():
+    """Counterfactual for the registry-drift bug this module fixes.
+
+    ACTIVE_CLOSURE_CRON_KEYS must be computed from memory_os_cron_specs()
+    minus an explicit, documented exclusion set -- not a hand-typed
+    frozenset literal. Every prior addition to MEMORY_OS_CRON_SPECS updated
+    the (then hand-typed) active-closure key set in the same commit,
+    except clearance_cycle: its commit registered the spec, wired the
+    onboarding CLI schedule arg, and updated the installer, but never added
+    the key to ACTIVE_CLOSURE_CRON_KEYS. A fresh active-closure install
+    therefore silently never created the clearance_cycle cron job even
+    though its helper/gate scripts were deployed by the installer.
+
+    Without the derivation fix this test fails two ways: the hand-typed
+    frozenset has no ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS companion (this
+    module previously defined none), and "clearance_cycle" is absent from
+    ACTIVE_CLOSURE_CRON_KEYS.
+    """
+    module = _load_module()
+    all_keys = {spec.key for spec in memory_os_cron_specs()}
+
+    assert module.ACTIVE_CLOSURE_CRON_KEYS == all_keys - module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
+    # module_cadence_report is the one documented, deliberate exclusion --
+    # its report is already generated on-demand elsewhere. Everything else
+    # registered defaults to being onboarded and visible.
+    assert module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS == {"module_cadence_report"}
+    assert "clearance_cycle" in module.ACTIVE_CLOSURE_CRON_KEYS
+    assert "module_cadence_report" not in module.ACTIVE_CLOSURE_CRON_KEYS
+    # Every registered key must be classified one way or the other -- no
+    # key silently falls through unclassified.
+    assert module.ACTIVE_CLOSURE_CRON_KEYS | module.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS == all_keys

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -42,18 +42,21 @@ def test_installer_copies_monitor_dashboard_snapshot_operational_helper(tmp_path
     full_monitor_source = scripts_root / "memory_os_3_200_monitor.py"
     closure_evidence_source = scripts_root / "memory_os_closure_runtime_evidence.py"
     retirement_source = scripts_root / "memory_os_retire_legacy_right_brain.py"
+    community_retirement_source = scripts_root / "memory_os_community_retirement.py"
     _write_operational_helper_scripts(target_home, dry_run=False)
     installed = target_home / "scripts" / source.name
     refresh_installed = target_home / "scripts" / refresh_source.name
     full_monitor_installed = target_home / "scripts" / full_monitor_source.name
     closure_evidence_installed = target_home / "scripts" / closure_evidence_source.name
     retirement_installed = target_home / "scripts" / retirement_source.name
+    community_retirement_installed = target_home / "scripts" / community_retirement_source.name
 
     assert installed.read_bytes() == source.read_bytes()
     assert refresh_installed.read_bytes() == refresh_source.read_bytes()
     assert full_monitor_installed.read_bytes() == full_monitor_source.read_bytes()
     assert closure_evidence_installed.read_bytes() == closure_evidence_source.read_bytes()
     assert retirement_installed.read_bytes() == retirement_source.read_bytes()
+    assert community_retirement_installed.read_bytes() == community_retirement_source.read_bytes()
 
 
 def test_installer_copies_agent_os_shell_by_default_without_cache_files(tmp_path):
@@ -452,30 +455,27 @@ def test_installer_can_run_owner_cron_onboarding_with_auto_channel(tmp_path):
     assert report["owner_cron_onboarding_report"]["selected_right_brain_deliver"] == "origin"
     assert report["owner_cron_profile"] == "active-closure"
     assert report["owner_cron_onboarding_report"]["cron_profile"] == "active-closure"
-    assert len(report["owner_cron_onboarding_report"]["operational_cron_jobs"]) == 19
+    # Derive the expected active-closure job set from the cron registry
+    # rather than hand-listing it. Two hand-maintained copies used to live
+    # here (a literal count and a literal name set); both silently went
+    # stale whenever a spec was added, which is exactly the drift that hid
+    # `clearance_cycle` from active-closure installs. Deriving means a new
+    # spec is picked up automatically and a misclassified one fails loudly.
+    from plugins.memory.memory_os.cron_registry import memory_os_cron_specs
+    from scripts.memory_os_owner_cron_onboarding import ACTIVE_CLOSURE_CRON_KEYS
+
+    expected_cron_names = {
+        spec.name
+        for spec in memory_os_cron_specs()
+        if spec.key in ACTIVE_CLOSURE_CRON_KEYS
+    }
+    assert (
+        len(report["owner_cron_onboarding_report"]["operational_cron_jobs"])
+        == len(expected_cron_names)
+    )
     jobs = json.loads(home.joinpath("cron", "jobs.json").read_text(encoding="utf-8"))["jobs"]
     by_name = {job["name"]: job for job in jobs}
-    assert set(by_name) == {
-        "memory-os-owner-review-digest",
-        "memory-os-proposal-followups-opsgate",
-        "memory-os-index-sync",
-        "memory-os-working-cleanup",
-        "memory-os-l3-probe-verification",
-        "memory-os-candidate-aggregation",
-        "memory-os-fact-judge",
-        "memory-os-event-stats-refresh",
-        "memory-os-exposure-rollup",
-        "memory-os-full-monitor-refresh",
-        "memory-os-v3-seed-evidence",
-        "memory-os-v3-wandering",
-        "memory-os-v3-journal-sweep",
-        "memory-os-state-overlay-refresh",
-        "memory-os-entity-index-refresh",
-        "memory-os-hindsight-advisory-digest",
-        "memory-os-hindsight-health-probe",
-        "memory-os-expression-feedback-request",
-        "memory-os-memory-sources-feedback-request",
-    }
+    assert set(by_name) == expected_cron_names
     assert by_name["memory-os-owner-review-digest"]["deliver"] == "discord"
     assert by_name["memory-os-proposal-followups-opsgate"]["deliver"] == "local"
     assert by_name["memory-os-index-sync"]["deliver"] == "local"

--- a/tests/scripts/test_memory_os_pytest_policy.py
+++ b/tests/scripts/test_memory_os_pytest_policy.py
@@ -144,8 +144,17 @@ def test_policy_rejects_allowlisted_reason_at_collection_stage(tmp_path: Path) -
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert completed.returncode != 0
     assert report["status"] == "fail"
-    assert report["unknown_skip_count"] == 1
-    assert report["skips"][0]["stage"] == "collect"
+    # A single collection-stage skip can surface as one or two collectreport
+    # events depending on pytest version -- some versions additionally
+    # propagate the skip to an ancestor collector (empty nodeid) on top of
+    # the real module's report. That count is a pytest-internal artifact,
+    # not something this policy controls, so assert the actual invariant:
+    # every collect-stage skip this run captured was rejected as unknown
+    # (the allowlisted reason must never bypass the collection-stage gate),
+    # not an incidental total.
+    assert report["unknown_skip_count"] >= 1
+    assert report["unknown_skip_count"] == report["skip_count"]
+    assert all(skip["stage"] == "collect" for skip in report["skips"])
 
 
 def test_policy_rejects_spoofed_runtest_nodeid_with_allowlisted_reason(tmp_path: Path) -> None:
@@ -267,6 +276,15 @@ def test_policy_captures_unknown_collection_stage_skip(tmp_path: Path) -> None:
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert completed.returncode != 0
-    assert report["skip_count"] == 1
-    assert report["unknown_skip_count"] == 1
-    assert report["skips"][0]["reason"] == "unknown collection skip"
+    assert report["status"] == "fail"
+    # The exact number of collect-stage reports pytest emits for a single
+    # module-level skip varies by pytest version (see the comment in
+    # test_policy_rejects_allowlisted_reason_at_collection_stage above) --
+    # some versions emit one report for the module plus a second, redundant
+    # report for an ancestor collector with an empty nodeid. What this test
+    # cares about is that the skip was captured at all, and that every
+    # captured report was correctly classified as unknown with the right
+    # reason -- not the incidental total.
+    assert report["skip_count"] >= 1
+    assert report["unknown_skip_count"] == report["skip_count"]
+    assert all(skip["reason"] == "unknown collection skip" for skip in report["skips"])

--- a/tests/scripts/test_memory_os_state_overlay_refresh.py
+++ b/tests/scripts/test_memory_os_state_overlay_refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -14,6 +15,20 @@ def _repo_root() -> Path:
 
 def _script_path() -> Path:
     return _repo_root() / "scripts" / "memory_os_state_overlay_refresh.py"
+
+
+def _load_refresh_module():
+    """Load memory_os_state_overlay_refresh.py directly (same importlib
+    pattern used by other tests under tests/scripts/), so a test can
+    monkeypatch its module globals in-process instead of only exercising it
+    as an opaque subprocess.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "memory_os_state_overlay_refresh_direct", _script_path(),
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestStateOverlayRefreshScript:
@@ -170,6 +185,68 @@ class TestStateOverlayRefreshScript:
 
         assert overlay["task_record_id"] == "ata_counterfactualtest01"
         assert "task_source_watermark" not in overlay
+
+
+class TestStateOverlaySectionCounterSingleSourceOfTruth:
+    """Counterfactual for the six-site registry-duplication drift bug: this
+    script's ``section_count`` loop must derive the set of sections from
+    ``state_overlay_schema.OVERLAY_SECTION_FIELDS`` (the single source of
+    truth), not a private hardcoded tuple. A previously hardcoded copy here
+    silently excluded a since-removed section (community_snapshot) from the
+    refresh cron's reported section_count for its entire lifetime.
+    """
+
+    def test_section_count_reflects_a_newly_added_derived_section(self, tmp_path, monkeypatch):
+        module = _load_refresh_module()
+
+        home = tmp_path / ".hermes"
+        (home / "memory-os" / "crystallized").mkdir(parents=True)
+        (home / "memory-os" / "system").mkdir(parents=True)
+
+        # Simulate a future StateOverlay section that isn't among today's
+        # real 8 sections, by extending the derived constant the script
+        # actually imports and injecting it into the built overlay. Without
+        # the fix (a hardcoded tuple in this script), this section would
+        # never be counted no matter what OVERLAY_SECTION_FIELDS says.
+        monkeypatch.setattr(
+            module, "OVERLAY_SECTION_FIELDS",
+            (*module.OVERLAY_SECTION_FIELDS, "future_section"),
+        )
+        original_build = module.build_state_overlay
+
+        def _patched_build(*args, **kwargs):
+            overlay = original_build(*args, **kwargs)
+            overlay["future_section"] = {
+                "data": [{"text": "x", "source": "s", "source_kind": "k"}],
+                "source": "s",
+                "status": "ok",
+            }
+            return overlay
+
+        monkeypatch.setattr(module, "build_state_overlay", _patched_build)
+
+        rc = module.main([
+            "--hermes-home", str(home),
+            "--output", "json",
+        ])
+        assert rc == 0
+
+        json_path = home / "memory-os" / "system" / "state_overlay" / "current.json"
+        overlay = json.loads(json_path.read_text(encoding="utf-8"))
+        assert overlay["future_section"]["status"] == "ok"
+
+        runs_path = home / "memory-os" / "system" / "state_overlay" / "runs.jsonl"
+        last_run = json.loads(runs_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+        # No real data was written (empty home), so only future_section is
+        # "ok" — the count must be exactly 1, proving the injected section
+        # was picked up by the counting loop.
+        assert last_run["sections"] == 1
+
+    def test_no_hand_maintained_section_tuple_remains_in_source(self):
+        """Static guard: the historical hardcoded 8-tuple must not reappear."""
+        source = _script_path().read_text(encoding="utf-8")
+        assert "OVERLAY_SECTION_FIELDS" in source
+        assert '"identity_snapshot", "relationship_snapshot", "active_projects",' not in source
 
 
 class TestStateOverlayCronRegistration:

--- a/tests/system_modularization/test_mailbox_no_send_module.py
+++ b/tests/system_modularization/test_mailbox_no_send_module.py
@@ -70,3 +70,56 @@ def test_mailbox_refuses_real_send_mode(tmp_path):
 
     assert report["status"] == "error"
     assert report["findings"][0]["code"] == "delivery_send_enabled"
+
+
+def test_mailbox_root_honors_configured_platform_root(tmp_path):
+    """Counterfactual: without config-aware resolution, mailbox_root always
+    returns hermes_home/mailbox, ignoring a host-configured mailbox location
+    entirely -- inbox_root/outbox_root would then point at the wrong place."""
+    (tmp_path / "config.yaml").write_text(
+        "\n".join(
+            [
+                "platforms:",
+                "  mailbox:",
+                "    extra:",
+                "      root: community_mailbox",
+                "      agent_id: agent-42",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    module = MailboxNoSendModule(tmp_path, profile="main")
+
+    assert module.mailbox_root == tmp_path / "community_mailbox" / "agents" / "agent-42"
+    assert module.inbox_root == tmp_path / "community_mailbox" / "agents" / "agent-42" / "inbox"
+    assert module.outbox_root == tmp_path / "community_mailbox" / "agents" / "agent-42" / "outbox"
+
+
+def test_mailbox_root_falls_back_to_hardcoded_default_without_config(tmp_path):
+    """No-config hosts must resolve identically to before this fix."""
+    module = MailboxNoSendModule(tmp_path, profile="main")
+
+    assert module.mailbox_root == tmp_path / "mailbox"
+
+
+def test_mailbox_root_ignores_invalid_agent_id(tmp_path):
+    """An agent_id failing [A-Za-z0-9_-]{1,64} must never be used to build a
+    path -- fall back to the hardcoded default instead of crashing or using
+    an unsafe/untrusted path segment."""
+    (tmp_path / "config.yaml").write_text(
+        "\n".join(
+            [
+                "platforms:",
+                "  mailbox:",
+                "    extra:",
+                "      root: community_mailbox",
+                "      agent_id: '../escape'",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    module = MailboxNoSendModule(tmp_path, profile="main")
+
+    assert module.mailbox_root == tmp_path / "mailbox"

--- a/tests/system_modularization/test_memory_os_agent_os_shell.py
+++ b/tests/system_modularization/test_memory_os_agent_os_shell.py
@@ -577,6 +577,39 @@ def test_shell_cli_exposes_status_and_doctor_aliases():
     assert left_brain_args.no_write is True
 
 
+def test_shell_cli_rejects_removed_community_alias():
+    """Counterfactual for the "sannai community" CLI alias extraction (commit
+    47bbc13 removed the community feature; the only test asserting the
+    "community" alias parsed and that "community create-partner" raised
+    SystemExit was deleted along with it, and nothing was added asserting
+    the alias is now genuinely rejected).
+
+    If "community" were ever re-registered as a subparser here -- or a stale
+    host copy of this shell plugin still exposed it -- parse_args would
+    silently accept it instead of raising SystemExit on the unknown choice.
+    """
+    module = load_shell_module()
+    parser = argparse.ArgumentParser()
+    module.register_cli(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["community", "status"])
+
+
+def test_shell_exit_code_rejects_community_command_via_allowed_aliases_guard():
+    """_ALLOWED_ALIASES is the only guard in _memory_os_agent_os_exit_code
+    (per plugins/memory-os-agent-os/__init__.py). "community" must not be a
+    member, and passing it through must return exit code 2 like any other
+    unknown command -- never fall through to _delegate_to_memory_os_cli."""
+    module = load_shell_module()
+
+    assert "community" not in module._ALLOWED_ALIASES
+
+    result = module._memory_os_agent_os_exit_code(argparse.Namespace(agent_os_command="community"))
+
+    assert result == 2
+
+
 def test_shell_status_alias_delegates_to_existing_memory_os_cli(monkeypatch, capsys):
     module = load_shell_module()
     calls: list[argparse.Namespace] = []


### PR DESCRIPTION
Whole-project code review, re-sliced by **invariant** rather than directory after the first pass only covered the last commit's diff. Five cross-cutting review passes (ExecutionGate coverage, no-silent-failures, OwnerGate/ResolverGate authority, governance import topology + substrate authority, hand-maintained parallel registries) produced 28 findings, fixed across 8 file-disjoint packages.

**Common root cause:** a green check whose domain differs from the invariant's domain. `write_surface_check` guarantees `unclassified_count=0` in the *repo* while a write surface persists on a *host*; `import_cycle_check` checks cycles but not direction; several tests asserted their own hand-maintained lists rather than deriving from a single source, so they stayed green through drift.

## Highest severity — reproduced end to end

`oa_` owner-action tokens are a **keyless deterministic SHA256** of public strings. `_surface_action_token_map` recomputes them from live state, which defeated `require_recorded_digest=True` for `revoke_crystallized`/`demote_crystallized`: knowing only a crystallized record's `id` was enough to compute a token offline and revoke the record with no digest ever delivered.

While fixing it, a **worse variant** turned up: the forgery also succeeded when a recorded digest existed but didn't contain the token — the *normal* production state, since the digest cron records regularly. A guard scoped to `binding == "digest_not_found"` (how the finding was originally framed) would have left the hole open in practice. The fix is default-deny by risk class, requiring both a low-risk action type and a low-risk target type, and it removes a duplicate lookup that re-admitted refused tokens.

Keyed tokens (defense in depth) are **deliberately not** included — see checklist BR for why half-migrating would silently desynchronize digest-cron and gateway tokens.

## Also fixed

- **ExecutionGate leaks** in `heartbeat` and three cognitive-loop lanes (reproduced: 1 permit record, 0 completions).
- **Substrate authority**: tier-1 was granted on a fact's *self-reported* `authority_class` with no provider-identity check.
- **Cron registry drift**: `clearance_cycle` was missing from a hand-copied key set, so a fresh active-closure install never created that job. Both copies now derive from `MEMORY_OS_CRON_SPECS`.
- **StateOverlay**: six duplicated section registries (a seventh found inline) now derive from the dataclass; serialized key order unchanged.
- **Error visibility**: a discarded error record, malformed records under a hardcoded `"ok"` status, and two silent skips.
- **Host-side retirement**: `47bbc13` removed the community feature from the repo, but the installer is additive-only, so modules/data/`deploy_community.py` persist on deployed hosts forever. Adds an idempotent, archive-not-delete retirement op modeled on `legacy_right_brain_retirement` (dry-run provably writes nothing; two-phase commit with SHA256 integrity check under a write lock). **Not executed against any host.**
- **Docs**: roadmap §14 still instructed operators to run two deleted scripts.

## No behavior change to installs

`clearance_cycle` is **still not installed** — identical to today's production state. What changed is that its omission is now an explicit named exclusion with a documented reason instead of an accidental gap in a hand-typed list.

It is deliberately not enabled here because the same change set repaired `append_terminal(detail=...)`, which means `sweep_unavailable_open_proposals_on_flag_flip` — which **revokes** open proposals and lives in `clearance_cycle.py` — went from raising `TypeError` on every call to actually working. Creating the cron in the same step would put two never-exercised paths live on production at once, so a failure could not be attributed to either. Enabling it later is a one-line deletion from `ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS`; the drift guard still prevents any newly registered spec from being silently omitted. The dashboard classifies it OPTIONAL for as long as onboarding defers it, so the monitor does not WARN forever about a job we deliberately do not install, and a test locks the two files in step.

## Incidental discovery

`append_terminal` never accepted a `detail=` argument, so `sweep_unavailable_open_proposals_on_flag_flip` raised `TypeError` on every call, swallowed it into a malformed record, and returned hardcoded `status: "ok"` — it had **never swept anything**. A textbook instance of the no-silent-failures invariant.

## Verification

- Full suite: **2968 passed / 2 failed → 3023 passed / 0 failed / 13 skipped** (+55). First fully green run — the two long-standing failures were pytest-version drift, now asserting the real invariant instead of an incidental count.
- All four static gates pass: import cycle, write surface (`unclassified_count=0`), static hygiene, public checkout probe `--strict`, plus `git diff --check`.
- Every fix has a counterfactual test verified to fail without it.

## Reviewer attention

1. **`apply_proposal`/`proposal` kept digest-optional** — refusing it would break a designed flow (the digest publishes an explicit apply affordance), and it already requires owner approval + OpsGate `would_allow` + bounded kinds + a 40-bit proposal-id suffix. Not on the OwnerGate permanent-boundary list.
2. Deliberately out of scope, recorded in checklist BR: keyed `oa_` tokens, monitor collection wiring for 11 components, `error_registry` having zero registered codes, and three unguarded `resolver_auto_approve` envelope sites in `candidate_aggregation.py`.
3. Host-side work is untouched: neither hermes-media nor hermes-feiniu was contacted. Running the community retirement is an owner decision.
