### PR TITLE
refactor(cron): consolidate 19 Hermes cron jobs into 8 group ticks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,36 @@ Broad `except Exception` must record bounded error records (`error_record` schem
 Fast probe PASS is not a substitute for full live monitor PASS.
 
 ### Cron Profile
-Default is `active-closure` (10 jobs: `owner_review_digest`, `proposal_followups_opsgate`, `index_sync`, `working_cleanup`, `l3_probe_verification`, `candidate_aggregation`, `fact_judge`, `event_stats_refresh`, `expression_feedback_request`, `memory_sources_feedback_request`). The `full` profile adds optional expression/cadence/feedback jobs. On upgraded hosts, active-closure onboarding pauses (does not delete) known optional jobs. The monitor classifies paused optional jobs as known optional rather than unregistered drift.
+
+`cron_registry.py` holds **two tables**, and the distinction is load-bearing:
+
+- **Lanes** (`MEMORY_OS_CRON_LANES`, 21) — the governance identity: `lane_id`, `raw_script`, `helper_kind` (risk class), boundary contract. One ExecutionGate envelope per lane per run. This never collapses.
+- **Groups** (`MEMORY_OS_CRON_GROUPS`, 9) — the Hermes scheduling surface: what `hermes cron create` actually creates.
+
+Default profile `active-closure` installs **8 Hermes cron jobs** covering 19 lanes (`module_cadence_report` is full-profile only; `clearance_cycle` activation is deferred):
+
+| Group job | Schedule | Members |
+|---|---|---|
+| `memory-os-tick-derived` | `*/15 * * * *` | event_stats_refresh, index_sync, state_overlay_refresh, entity_index_refresh |
+| `memory-os-tick-governance` | `*/30 * * * *` | proposal_followups_opsgate (+ clearance_cycle when enabled) |
+| `memory-os-tick-evidence` | `0 * * * *` | hindsight_health_probe, fact_judge, candidate_aggregation, l3_probe_verification, v3_wandering |
+| `memory-os-tick-daily` | `5 0 * * *` | exposure_rollup, v3_seed_evidence, v3_journal_sweep, working_cleanup, hindsight_advisory_digest |
+| `memory-os-owner-review-digest` | `0 9 * * *` | owner_review_digest |
+| `memory-os-memory-sources-feedback-request` | `30 10 * * *` | memory_sources_feedback_request |
+| `memory-os-expression-feedback-request` | `0 5 * * 0` | expression_feedback_request |
+| `memory-os-full-monitor-refresh` | `30 2 * * *` | full_monitor_refresh |
+
+Rules that follow from this:
+
+- A group's cron cadence is its **finest** member's. Each lane keeps its own effective rate via `due_interval_minutes`; `scripts/memory_os_cron_group_runner.py` skips members that aren't due. Adding a lane means adding it to a group, **not** creating a cron job.
+- `due_policy="calendar"` exists for date-partitioned lanes (`v3_seed_evidence`), which must run at most once per UTC day rather than on elapsed time.
+- **The monitor's completion-freshness window must come from the lane's `due_interval_minutes`, never from the group job's cron expression** — deriving it from the schedule collapses a weekly lane sharing a daily tick to a 54h window and reports it permanently stale.
+- Owner-facing lanes keep dedicated single-member jobs: each renders a distinct owner message with its own agent prompt and deliver channel. `full_monitor_refresh` stays alone because it is the heavyweight (≤180s) monitor and would block co-tenants.
+- Per-lane disable lives in `<hermes_home>/memory-os/system/cron_lane_disabled.json` (owners lost per-job disable granularity to grouping). Honoured by both the tick runner and the monitor.
+- Legacy pre-consolidation per-lane jobs are listed in `LEGACY_PER_LANE_CRON_JOBS` and classified `known_optional` / `superseded_by_group_tick`. Onboarding **pauses, never deletes** them — that is the rollback path. `classify_hermes_cron_jobs` exists in three places (`hermes_cron_adapter.py`, `plugins/seam/.../cron_adapter.py`, and an embedded fallback in `memory_os_3_200_monitor.py`); the seam copy is what production reads, so any change must be applied to all three.
+- Nothing except `memory_os_owner_cron_onboarding.py` may create Memory-OS cron jobs. `install_memory_os.sh` and `deploy_l3_probe.py --apply` used to create per-lane jobs directly and would double-run a lane that a tick now owns.
+
+The `full` profile adds `module_cadence_report`. On upgraded hosts, active-closure onboarding pauses (does not delete) known optional jobs. The monitor classifies paused optional jobs as known optional rather than unregistered drift.
 
 ### Owner Actions
 Display anchors (`A1`, `R1`, `F1`) in digests are UI labels only. The durable identity is the `oa_` action token. Owner approval moves a proposal into human-controlled follow-up — it does not execute work. Only proposal kinds with a bounded runtime target, rollback, monitor fields, and an explicit apply token can be applied.

--- a/docs/resolver/hermes-memory-os-cron-consolidation-plan.md
+++ b/docs/resolver/hermes-memory-os-cron-consolidation-plan.md
@@ -1,0 +1,350 @@
+# Hermes Cron 任务归类合并方案（2026-07-30）
+
+> 状态：**已实施**（2026-07-31）。实施记录见稳定化清单 BS 节。
+> 结论：**19 个 Hermes cron job → 8 个**（4 个分组 tick + 4 个 owner 面向作业），
+> 治理粒度（lane / ExecutionGate envelope）保持 21 条不变。
+>
+> 落地与本提案的差异：
+> - §5 R1 实算后确认受影响的是 **4 条 lane**（不止 working_cleanup 与
+>   hindsight_advisory_digest，还有 candidate_aggregation 与 fact_judge），已按 lane
+>   `due_interval_minutes` 取窗口并保留原 schedule 回退路径。
+> - §6 R2 落地时发现 `classify_hermes_cron_jobs` 有**三份**拷贝（memory 适配器、seam 适配器、
+>   monitor 内嵌 fallback），生产读的是 seam 那份，三份已全部同步。
+> - 另外发现两处仍在直接创建 per-lane job（`install_memory_os.sh`、`deploy_l3_probe.py`），
+>   会与 group tick 双跑，已分别删除与改为 fail-closed。
+> - §7 的 `execution_gate_index.json` 无裁剪缺陷本次一并修复（`prune_sidecar_index`），
+>   未另开工单。
+
+---
+
+## 1. 现状（以代码为准，非文档）
+
+`plugins/memory/memory_os/cron_registry.py` 注册 **21** 条 spec；
+`scripts/memory_os_owner_cron_onboarding.py:55` 排除 2 条
+（`module_cadence_report` 永久排除、`clearance_cycle` 延后激活），
+因此 active-closure 实际创建 **19 个 Hermes cron job**。
+
+> ⚠️ `CLAUDE.md` 写的 "active-closure（10 jobs）" 是**过期文档**，与代码不符。
+> 本方案落地时须一并修正。
+
+每个 job 的结构完全一致：
+
+```
+Hermes cron job
+  └─ scripts/memory_os_cron_<key>_gate.py      ← 5 行 shim
+       └─ memory_os_execution_gate_runner.py --registry-key <key>
+            ├─ 写 permit 记录   (execution_gate_envelopes.jsonl + index.json)
+            ├─ subprocess.run(helper)          ← 真正干活
+            └─ 写 completion 记录 (同上两个文件)
+```
+
+**关键观察：19 个 job 共用同一个入口** `memory_os_execution_gate_runner.py`，
+差异仅在 `--registry-key`。所以"合并"不需要重写任何 helper，
+只需要在 runner 之上加一层按组遍历的 tick。
+
+### 1.1 全量作业清单
+
+| # | key | schedule | 次/天 | deliver | agent | 语义类别 |
+|---|---|---|---|---|---|---|
+| 1 | `event_stats_refresh` | `7,22,37,52 * * * *` | 96 | local | no | 派生视图 |
+| 2 | `index_sync` | `*/30 * * * *` | 48 | local | no | 派生视图 |
+| 3 | `state_overlay_refresh` | `17,47 * * * *` | 48 | local | no | 派生视图 |
+| 4 | `entity_index_refresh` | `25,55 * * * *` | 48 | local | no | 派生视图 |
+| 5 | `proposal_followups_opsgate` | `*/30 * * * *` | 48 | local | no | 治理队列 |
+| 6 | `hindsight_health_probe` | `33 * * * *` | 24 | local | no | 探针 |
+| 7 | `fact_judge` | `0 */4 * * *` | 6 | local | no | 判断 |
+| 8 | `candidate_aggregation` | `0 */6 * * *` | 4 | local | no | 候选流水线 |
+| 9 | `l3_probe_verification` | `0 */6 * * *` | 4 | local | no | 探针 |
+| 10 | `v3_wandering` | `17 */6 * * *` | 4 | local | no | V3 自然通道 |
+| 11 | `exposure_rollup` | `5 0 * * *` | 1 | local | no | 日界汇总 |
+| 12 | `v3_seed_evidence` | `15 0 * * *` | 1 | local | no | 日界证据 |
+| 13 | `v3_journal_sweep` | `30 3 * * *` | 1 | local | no | 维护 |
+| 14 | `working_cleanup` | `0 3 * * 0` | 0.14 | local | no | 保留期清理 |
+| 15 | `hindsight_advisory_digest` | `20 2 * * 0` | 0.14 | local | no | 周报 |
+| 16 | `owner_review_digest` | `0 9 * * *` | 1 | **owner** | **yes** | owner 面向 |
+| 17 | `memory_sources_feedback_request` | `30 10 * * *` | 1 | **owner** | **yes** | owner 面向 |
+| 18 | `expression_feedback_request` | `0 5 * * 0` | 0.14 | **owner** | **yes** | owner 面向 |
+| 19 | `full_monitor_refresh` | `30 2 * * *` | 1 | **owner** | no | 重量级探针 |
+| — | `module_cadence_report` | （full profile 专用） | — | local | no | 报表 |
+| — | `clearance_cycle` | `*/10 * * * *`（延后） | — | local | no | 治理队列 |
+
+**合计 336.4 次/天**，每次派生 2 个 Python 进程（runner + helper）。
+
+---
+
+## 2. 为什么必须合并：不是审美问题，是已存在的故障面
+
+### 2.1 同分钟并发争锁（实测）
+
+按上表 schedule 展开一天的触发时刻：
+
+```
+00:00 → 5 个 job 同时触发：proposal_followups_opsgate, candidate_aggregation,
+                            fact_judge, index_sync, l3_probe_verification
+12:00 → 同上 5 个
+06:00 / 18:00 → 4 个
+（周日 03:00 另有 working_cleanup 加入）
+```
+
+这 5 个进程会同时对**同一个文件**做"独占加锁 → 全量读 → 全量重写 → fsync"：
+
+- `execution_gate_envelopes.jsonl`（追加，尚可）
+- `execution_gate_index.json`（**全量 JSON 重写**，`memory_os_execution_gate_runner.py:330`）
+
+锁超时 `SIDECAR_LOCK_TIMEOUT_SECONDS = 15.0`（同文件 :33）。
+一旦超时抛 `ExecutionGateInfrastructureError("sidecar_lock_timeout")` → runner 返回 **3**，
+该 lane 当次执行**不产生 completion 记录** → 被 monitor 记为
+`helper_completion_missing`。
+
+这是一条**随数据量增长必然恶化**的路径：index.json 每条 envelope 一个 entry、
+**无任何裁剪逻辑**（见 §7），当前约 336 entry/天。合并后同分钟并发降为 1，
+争锁面直接消失。
+
+### 2.2 作业数量本身的成本
+
+19 条 job 意味着 19 份 schedule 要在 Hermes 侧维护、19 个 5 行 shim 脚本要部署、
+onboarding 要逐个 upsert、monitor 要逐个分类。新增一条 lane 就要新增一个 job，
+这个线性增长是本次要打断的。
+
+---
+
+## 3. 设计核心：把"治理身份"和"调度面"拆成两张表
+
+当前 `MemoryOSCronSpec` 把两件事**揉在一个 dataclass** 里：
+
+| 字段 | 属于 | 合并后 |
+|---|---|---|
+| `key` / `lane_id` / `raw_script` / `helper_kind` / `requires_boundary_report` | **治理身份**（ExecutionGate permit、boundary、risk_class） | **保持 1:1，21 条不变** |
+| `name` / `wrapper_script` / `schedule_arg` / `deliver_role` / `prompt_ref` / `no_agent` | **Hermes 调度面** | **合并，21 → 8** |
+
+**这是整个方案的支点**：只合并调度面，治理粒度一条不动。
+ExecutionGate 每 lane 仍写自己的 permit + completion，
+`lane_id` / `risk_class` / `boundary` 语义零变化，
+下游（monitor、dashboard、StructuralWriteGate 的 scope 校验）几乎不受影响。
+
+### 3.1 建议的数据结构
+
+```python
+@dataclass(frozen=True)
+class MemoryOSCronLaneSpec:          # 治理身份，21 条
+    key: str
+    raw_script: str
+    lane_id: str
+    helper_kind: str
+    requires_boundary_report: bool
+    # ── 新增 ──
+    group_key: str                   # 归属分组
+    due_policy: str                  # "interval" | "calendar"
+    due_interval_minutes: int        # 有效节奏；**monitor 新鲜度窗口的唯一来源**
+    calendar_anchor: str             # due_policy=="calendar" 时的 "HH:MM"（可选 dow）
+    timeout_seconds: int             # 单 member 超时上限
+
+@dataclass(frozen=True)
+class MemoryOSCronGroupSpec:         # Hermes 调度面，8 条
+    key: str
+    name: str                        # 真正创建的 Hermes job 名
+    wrapper_script: str
+    schedule_arg: str
+    deliver_role: str
+    prompt_ref: str
+    no_agent: bool
+    member_keys: tuple[str, ...]
+```
+
+### 3.2 向后兼容：`memory_os_cron_specs()` 保留为派生视图
+
+保留现有函数签名，让每条 lane 的 `name` / `wrapper_script` / `schedule_arg`
+**从其 group 派生**。这样：
+
+- `classify_hermes_cron_jobs()` 里的 `specs_by_name`（`hermes_cron_adapter.py:89`）
+  自然按 name 去重 → `memory_os_owned_expected_count` = **8**，符合实际；
+- `_execution_gate_helper_completion_summary()` 的 `specs_by_lane`
+  （`memory_os_3_200_monitor.py:7173`）仍有 **21** 个 entry，
+  每个指向自己所属 group 的 job name，并新增携带 `due_interval_minutes`。
+
+注册快照 schema 升到 `memory-os.cron_registry.v1`，同时输出 `specs`（派生，兼容）
+与 `groups`（新增）两个数组。
+
+---
+
+## 4. 分组方案
+
+### 4.1 本地 lane → 4 个 tick
+
+| Group | Hermes job | schedule | 成员（due 策略） |
+|---|---|---|---|
+| **G1 派生视图** | `memory-os-tick-derived` | `*/15 * * * *` | `event_stats_refresh`(15m)、`index_sync`(30m)、`state_overlay_refresh`(30m)、`entity_index_refresh`(30m) |
+| **G2 治理队列** | `memory-os-tick-governance` | `*/30 * * * *` | `proposal_followups_opsgate`(30m)、`clearance_cycle`(10m，**仍延后**) |
+| **G3 判断与探针** | `memory-os-tick-evidence` | `0 * * * *` | `hindsight_health_probe`(1h)、`fact_judge`(4h)、`candidate_aggregation`(6h)、`l3_probe_verification`(6h)、`v3_wandering`(6h) |
+| **G4 日界与维护** | `memory-os-tick-daily` | `5 0 * * *` | `exposure_rollup`(**calendar** 00:05)、`v3_seed_evidence`(**calendar** 00:05)、`v3_journal_sweep`(24h)、`working_cleanup`(7d)、`hindsight_advisory_digest`(7d) |
+
+分组依据是**语义类别**（可解释、失败影响面同质），
+group 的 cron 周期取组内最细成员的节奏，
+组内各成员用 `due_policy` 还原自己的有效节奏。
+
+> G2 若维持 `clearance_cycle` 延后状态，`*/30` 即可；
+> 将来激活 `clearance_cycle` 时把 G2 调到 `*/10`，
+> `proposal_followups_opsgate` 靠 `due_interval_minutes=30` 自动隔次跳过。
+> **激活 clearance_cycle 从"新建一个 job"变成"翻一个 lane 开关"**——
+> 这正是拆表带来的收益。
+
+### 4.2 due 策略：为什么需要两种
+
+只有 elapsed（`interval`）一种是不够的。已逐个核对 helper 语义：
+
+| lane | 语义 | 结论 |
+|---|---|---|
+| `exposure_rollup` | `run_exposure_rollup_cycle` docstring：*"Reads memory_sources records since the last **watermark**. Idempotent: same window re-run produces zero-side-effect skip."* | **水位线驱动、幂等**，漂移无害。仍锚定 00:05 只为保持既有观感 |
+| `v3_seed_evidence` | 产出 `natural_date` 日记录，暴露 `valid_day_count` / `consecutive_valid_day_count`，CLI 有 `--target-date` | **按日分区**。漏一天或跨日重复会污染"连续有效天数"→ **必须 calendar 锚定** |
+| `working_cleanup` | `age_days > RETENTION_DAYS`，纯年龄判定 | elapsed 即可 |
+| `hindsight_advisory_digest` | 只写 `generated_at` / `expires_at`，无日期分区 | elapsed 即可 |
+| `v3_journal_sweep` | **未核实**：仅 grep 了 thin-wrapper 脚本（零命中），未读底层模块。`exposure_rollup` 正是"脚本是壳、语义在 `plugins/` 模块里"的先例 | 暂按 elapsed，**P1 实施时须确认底层模块是否按日分区** |
+
+所以 `due_policy` 必须支持 `calendar`，但**实际只有 `v3_seed_evidence` 强制需要**。
+其余成员用 `interval` —— 好处是**宕机后自动补跑**（下一 tick 发现已过期就执行），
+而当前的固定时刻 cron 会直接漏掉这一次。
+
+### 4.3 owner 面向作业：保持 1:1，不合并
+
+`owner_review_digest` / `memory_sources_feedback_request` /
+`expression_feedback_request` 三条 `no_agent=False`，
+各自有独立的 deliver 渠道与 agent prompt（onboarding.py:86-99 三段不同的中文 prompt），
+输出是**直接发给 owner 的一条消息**。合并会把多条 owner 消息揉成一条、
+prompt 互相污染——这是 owner 体验边界，不能为了减 job 数牺牲。
+
+`full_monitor_refresh` 虽是 `no_agent=True`，但目标运行时长 ≤180s，
+是全量 monitor。放进任何 tick 都会让该 tick 长期占用并阻塞同组成员，**保持独立**。
+
+### 4.4 收益
+
+| 指标 | 现状 | 合并后 |
+|---|---|---|
+| Hermes cron job 数 | **19** | **8** |
+| shim 脚本数 | 19 | 8 |
+| cron 触发次数/天 | 336 | **172** |
+| helper 实际执行次数/天 | 336 | 336（**不减**，工作量不变） |
+| 同分钟最大并发进程 | **5** | **1** |
+| index.json 重写次数/天 | 672 | **672（不减）** —— 合并不改变每 lane 两次落盘；真正的收益是并发争锁消失。无界增长是另一个缺陷，见 §7 |
+| 新增一条 lane 的代价 | 新建 job + shim + schedule 参数 | 往 group 里加一行 |
+
+---
+
+## 5. 阻断性前置条件（不做就会打崩生产 monitor）
+
+### R1（阻断）新鲜度窗口必须改为按 lane 取
+
+`scripts/memory_os_3_200_monitor.py:7546`
+
+```python
+def _helper_completion_freshness_window(schedule):
+    interval = _cron_schedule_interval(str(schedule or ""))
+    return max(interval * 2 + grace, minimum)     # minimum = 12h
+```
+
+两处调用（:7469、:7481）传入的都是 `_cron_schedule_display(cron_job)`，
+即**该 lane 所属 cron job 的 schedule**。
+
+按本方案的分组实算（已用上述公式逐条验证），**4 条 lane 的窗口会塌缩**：
+
+| lane | 现窗口 | 合并后窗口 | 后果 |
+|---|---|---|---|
+| `working_cleanup`（7d） | 342h | **54h** | **永久 stale** |
+| `hindsight_advisory_digest`（7d） | 342h | **54h** | **永久 stale** |
+| `candidate_aggregation`（6h） | 18h | **12h** | 略晚即误报 |
+| `fact_judge`（4h） | 14h | **12h** | 略晚即误报 |
+
+前两条是必然常亮的生产 WARN；后两条是边界收窄后的偶发误报。
+（`index_sync` 12h→12h 不变，因为已被 12h 下限兜住。）
+
+**必须改为**：窗口取自 lane 自己的 `due_interval_minutes`
+（calendar 策略则按其周期），而非 group 的 cron 表达式。
+这不是可选清理，是合并的前置条件。
+
+### R2（阻断）19 个旧 job 名必须显式分类
+
+合并后 `memory_os_cron_specs()` 的 `name` 变成 group 名，
+于是 `known_specs_by_name`（`hermes_cron_adapter.py:90`）**不再认识**
+`memory-os-index-sync` 这类旧名字。已升级主机上残留的旧 job 会掉进
+`name.startswith("memory-os-")` 分支 → `unregistered_like`
+→ monitor 报 `execution_gate_memory_os_cron_unregistered_like_job`（FAIL）。
+
+这与 `cron_registry.py:11-32` 已经踩过的坑**完全同型**（当时是 sannai
+community 脚本掉进 `external_unmanaged`）。
+**必须新增 `LEGACY_PER_LANE_CRON_JOB_NAMES` 常量**，把这 19 个旧 name
+归入 `known_optional` / `retired_legacy` 桶，并写明退役理由。
+
+---
+
+## 6. 其余风险与对策
+
+| # | 风险 | 对策 |
+|---|---|---|
+| **R3** | tick 执行时间可能超过 tick 周期，导致重叠双跑 | group 级**非阻塞**文件锁；抢不到锁则以显式 `skipped_overlap` 状态退出 0。**不允许静默 pass**（No Silent Failures），须落一条可被 monitor 看见的计数 |
+| **R4** | `subprocess.run`（runner:114）**当前无 timeout**。1:1 时一个 hang 只拖垮一条 lane，合并后拖垮整组 | 每 member 强制 `timeout_seconds`；超时记 completion（`execution_status="timeout"`）后继续下一个成员。**这是合并的硬性要求，不是附赠优化** |
+| **R5** | 单 lane 停用能力丢失。当前 owner 停一个 Hermes job = 停一条 lane；monitor 靠 `cron_job.enabled is False`（:7446）识别 | 新增 lane 级停用状态文件，tick runner 与 monitor 同时读取；monitor 的 `disabled` 分类改为「group job disabled **或** lane 在停用名单」 |
+| **R6** | `trigger_surface` 若被改写会破坏 natural_cron 溯源 | **已核实**：`resolve_trigger_class()`（`execution_gate.py:25-39`）只读环境变量 `MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID`，与 job 数量无关。tick runner 逐 member 设置该变量即可保持 `natural_cron`。**permit 的 `trigger_surface` 必须保持字面量 `"hermes_cron"`**，不得"顺手清理"成 `hermes_cron_group` |
+| **R7** | 组内某成员失败中断整组 | 逐 member `try/except` + 独立 completion 记录；组退出码做聚合，单成员非零不终止后续成员 |
+
+---
+
+## 7. 顺带发现的相关缺陷（建议单独修，不并入本次范围）
+
+**`execution_gate_index.json` 无任何裁剪机制。**
+
+`memory_os_execution_gate_runner.py:330 _update_sidecar_index()` 每次
+permit / completion 都做一次「加锁 → 全量读 → 全量重写 → fsync」，
+而全项目 grep 不到该文件的 prune / compact / retain 逻辑
+（`plugins/memory/memory_os/execution_gate.py` 内零命中）。
+
+entry 数按每 envelope 一条**无上限增长**：当前 336 条/天 ≈ 12 万条/年，
+重写成本 O(N)，与 §2.1 的 15 秒锁超时叠加。
+
+合并**不降低**该文件的写入次数（每 lane 仍是 permit + completion 两次），
+只消除同分钟并发争锁；**无界增长完全不受影响**。
+建议独立开一个「envelope index 保留期 + 压实」的修复。
+
+---
+
+## 8. 落地分期
+
+| 阶段 | 内容 | 可独立验证 |
+|---|---|---|
+| **P0** | 仅做 R1（新鲜度按 lane）+ R2（旧 job 名分类常量）。此时行为不变，纯属加固 | 全量 pytest；反事实测试：把某 lane 的 due 设为 7d、job schedule 设为日频，无 P0 时该 lane 被判 stale |
+| **P1** | 注册表拆表（lane spec / group spec）、快照 schema v1、`memory_os_cron_specs()` 派生兼容视图 | `test_memory_os_cron_registry.py`、`test_memory_os_hermes_cron_adapter.py` |
+| **P2** | 新增 `scripts/memory_os_cron_group_runner.py`（复用 `run_registry_key()`）+ 4 个 group shim；实现 due 判定、组锁(R3)、超时(R4)、失败隔离(R7)、批量落盘 | `test_memory_os_execution_gate_runner.py` + 新增 group runner 测试 |
+| **P3** | onboarding 改为按 group upsert；旧 19 个 per-lane job 走 `_pause_known_optional_cron_jobs` **暂停而非删除** | `test_memory_os_owner_cron_onboarding.py` |
+| **P4** | 部署 3.200，跑 full monitor 要求 `live_monitor_pass` | `memory_os_3_200_monitor.py --monitor-profile live` |
+
+### 回滚
+
+P3 只**暂停**旧 job，不删除。回滚 = 重新启用 19 个旧 job + 停用 4 个 group job，
+helper 脚本与 lane 注册表全程未动，回滚后行为与今天完全一致。
+
+### 受影响测试面（12 个文件）
+
+`tests/plugins/memory/`：`test_memory_os_cron_registry.py`、
+`test_memory_os_hermes_cron_adapter.py`、`test_memory_os_legacy_right_brain_retirement.py`、
+`test_memory_os_audit_arbitration.py`、`test_memory_os_entity_graph.py`
+
+`tests/scripts/`：`test_memory_os_owner_cron_onboarding.py`（cron 相关断言最密集）、
+`test_memory_os_3_200_monitor.py`、`test_memory_os_cron_adapter_probe.py`、
+`test_memory_os_execution_gate_runner.py`、`test_memory_os_monitor_dashboard_snapshot.py`、
+`test_memory_os_plugin_install.py`、`test_memory_os_state_overlay_refresh.py`
+
+近期已把硬编码 job 集合改成 registry 派生断言，多数应能自动适配；
+`test_memory_os_owner_cron_onboarding.py` 需要按 group 重写预期。
+
+### 文档同步
+
+`CLAUDE.md` 的 "Cron Profile — 默认 active-closure（10 jobs）" 与实际的 19 条不符，
+落地时须一并更正为分组后的 8 条并列出分组表。
+
+---
+
+## 9. 一句话
+
+把 `MemoryOSCronSpec` 拆成「lane 治理身份（21 条不变）」与「group 调度面（8 条）」两张表，
+用一个复用 `run_registry_key()` 的 tick runner 按组遍历、按 lane 开 envelope，
+**Hermes job 19 → 8、同分钟并发 5 → 1**；
+前提是先做掉 R1（monitor 新鲜度改按 lane 取）与 R2（旧 job 名显式分类），
+否则合并当天生产 monitor 就会 WARN 常亮 + FAIL。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1151,6 +1151,116 @@ BC 评审 15 项至此全部完成（P0×3 → BD，P1×4 → BE，P2×3 → BF�
     `start_resolver_auto_approve_envelope` 后的写入无异常保护（与第 2 项同类，白名单外未修）。
   - 主机侧：未触碰 hermes-media / hermes-feiniu。
 
+## BS — Hermes cron 归类合并：19 job → 8 group tick（2026-07-31）
+
+### 做了什么
+
+把 `MemoryOSCronSpec` 拆成两张表，只合并调度面、不动治理粒度：
+
+- **lane 表**（`MEMORY_OS_CRON_LANES`，21 条）＝ 治理身份：`lane_id` / `raw_script` /
+  `helper_kind` / boundary 契约。每 lane 每次运行仍开自己的 ExecutionGate envelope。
+- **group 表**（`MEMORY_OS_CRON_GROUPS`，9 条）＝ Hermes 调度面，真正被
+  `hermes cron create` 创建的东西。
+
+`MEMORY_OS_CRON_SPECS` 是两表的 join，`name`/`wrapper_script`/`schedule_arg` 从 group 派生，
+因此既有消费者全部无改动继续工作，唯一可见差异是多条 spec 共享同一个 `name`。
+
+active-closure：**19 个 Hermes cron job → 8 个**（19 条 lane 不变）。
+新增 `scripts/memory_os_cron_group_runner.py` + 4 个 tick shim。
+
+### 根因（为什么必须合并，不是审美问题）
+
+按 schedule 实算一天的触发时刻：**00:00 与 12:00 各有 5 个 job 同时触发**
+（proposal_followups / candidate_aggregation / fact_judge / index_sync / l3_probe），
+5 个进程同时对 `execution_gate_index.json` 做「独占加锁 → 全量读 → 全量重写 → fsync」，
+锁超时 15s。超时即 `ExecutionGateInfrastructureError("sidecar_lock_timeout")` → runner 返回 3
+→ 该 lane 当次无 completion 记录 → monitor 记 `helper_completion_missing`。
+合并后同分钟并发 5 → 1，触发次数 336/天 → 172/天。
+
+### 阻断性前置条件（两条，先做才安全）
+
+**R1 — monitor 新鲜度窗口必须按 lane 取。**
+`_helper_completion_freshness_window()` 原本取 cron **job** 的 schedule。分组后用公式实算，
+**4 条 lane 的窗口会塌缩**：working_cleanup 342h→54h、hindsight_advisory_digest 342h→54h
+（两条必然永久 stale）、candidate_aggregation 18h→12h、fact_judge 14h→12h（略晚即误报）。
+改为取 lane 自己的 `due_interval_minutes`，缺失/0/非法值回退到原 schedule 行为（绝不产生 0 窗口）。
+
+**R2 — 19 个旧 per-lane job 名必须显式分类。**
+分组后 spec.name 变成 group 名，`known_specs_by_name` 不再认识 `memory-os-index-sync` 这类
+旧名字 → 落入 `unregistered_like` → monitor FAIL
+`execution_gate_memory_os_cron_unregistered_like_job`，每台已升级主机都会红。
+新增 `LEGACY_PER_LANE_CRON_JOBS`，归入 `known_optional` + `superseded_by_group_tick`。
+
+### 顺调用链发现的同类缺陷（Section W 第 5 条的产出）
+
+1. **`classify_hermes_cron_jobs` 有三份拷贝。** 只修 `hermes_cron_adapter.py` 不解决生产问题——
+   `memory_os_cron_adapter_probe.py` 导入的是 `plugins/seam/hermes_memory_os/cron_adapter.py`，
+   而 monitor 优先读该 probe；monitor 自身还有一份内嵌 fallback。三份全部同步修复。
+2. **`memory_os_monitor_dashboard_snapshot.py` 的 CORE/OPTIONAL 集合会重叠。**
+   `tick_evidence` 同时含 core 成员（fact_judge）与 optional 成员（l3_probe_verification），
+   同一 job 名会既算 missing_core 又算 optional_paused。改为「任一成员 core ⇒ 整个 job core」。
+3. **两处仍在直接创建 per-lane job，会导致 lane 双跑：**
+   `install_memory_os.sh` 自建 `memory-os-working-cleanup`（已删除，onboarding 是唯一创建者）；
+   `deploy_l3_probe.py --apply` 自建 `memory-os-l3-probe-verification`（改为 fail-closed
+   `superseded_by_group_tick`，并删掉随之失效的 apply 主体与两个孤儿函数）。
+4. **`execution_gate_index.json` 无任何裁剪**（独立缺陷，本次一并修）：每次 permit/completion
+   全量重写，entry 按 envelope 无上限增长（约 336/天 ≈ 12 万/年）。新增
+   `prune_sidecar_index()` 保留最新 2000 条；安全性依据是 `execution_gate.py` 已有
+   lookup-miss 时从 JSONL 全量重建的恢复路径。正在写入的 envelope 永不被淘汰。
+
+### 一并加固
+
+- `subprocess.run` 原本**没有 timeout**。1:1 时一个 hang 只拖垮一条 lane，合并后拖垮整组。
+  新增每 member `timeout_seconds`，超时记 `execution_status="timeout"` / returncode 124 后继续下一个成员。
+- group 级**非阻塞**锁：抢不到锁以显式 `skipped_overlap` 退出 0，不静默 pass。
+- 成员失败隔离：逐 member try/except + 独立 completion，单成员非零不终止后续成员。
+- lane 级停用 `cron_lane_disabled.json`（补回分组后 owner 丢失的单 lane 停用能力），
+  tick runner 与 monitor 同时读取；文件损坏时 fail-open，绝不静默停掉受治理的 lane。
+- `due_policy="calendar"`：`v3_seed_evidence` 按 `natural_date` 分区并暴露
+  `consecutive_valid_day_count`，elapsed 门控可能跨 UTC 日界漂移导致漏算/重算，故按日锚定。
+  逐个核对过其余 lane：`exposure_rollup` 是水位线驱动且幂等、`working_cleanup` 纯年龄判定，
+  均可用 elapsed。
+- `trigger_surface` 保持字面量 `"hermes_cron"`：已核实 `resolve_trigger_class()` 只读环境变量
+  `MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID`，tick runner 逐 member 设置该变量，natural_cron 溯源不受影响。
+
+### 反事实覆盖
+
+- R1：weekly lane 落在日频 group 时不得判 stale（无修复时窗口 54h → FAIL）。
+- R2：遗留 per-lane job 必须 `unregistered_like == 0`（无修复时为 2 → monitor FAIL）。
+- 超时：member `timeout_seconds=1` + sleep 30 的 stub，必须得到 status=timeout/returncode=124
+  且后续成员仍执行（无 timeout 支持时该 member 会正常返回 0）。
+- 重叠：预先持有 group 锁，必须得到 `skipped_overlap` 且**不产生任何 envelope**。
+- 隔离：前一个成员 exit 9，后一个成员仍须 ok 且两条 completion 都在。
+- due 门控：30 分钟 lane 在 15 分钟 tick 上必须隔次运行；`due_interval_minutes=0`
+  不得退化为「每 tick 都跑」（回退为日频）。
+- calendar：同一 UTC 日内第二次 tick 必须 `already_ran_today`；未到 anchor 必须
+  `before_calendar_anchor`。
+- v0 快照回填：旧快照无 due 元数据时必须回填 lane 表的值，不得得到 0（否则 tick 永远 due、
+  monitor 永远 stale）。
+- 裁剪：正在写入的 envelope 即使时间戳最旧也不得被淘汰。
+- 双跑：`deploy_l3_probe.run_apply()` 必须 blocked 且不产生 jobs.json。
+
+R1/R2 的 revert→FAIL→restore→PASS 已实际验证。
+
+### 测试与门禁
+
+3023（BR 基线）→ **3056 passed / 13 skipped / 0 failed**，净 +33。
+新增 `tests/scripts/test_memory_os_cron_group_runner.py`（14 项）。
+四项静态门全过：import_cycle / write_surface（unclassified=0）/ static_hygiene / public_checkout_probe。
+
+### 回滚
+
+onboarding 只**暂停**旧 19 个 per-lane job，不删除。回滚 = 重新启用旧 job + 停用 8 个 group job；
+lane 注册表与 helper 脚本全程未动，回滚后行为与合并前一致。
+
+### 未做 / 残留
+
+- 尚未部署到 3.200，`live_monitor_pass` 未取得——本次仅 `local_pass` + 静态门。
+- `v3_journal_sweep` 的底层模块未逐行核实是否按日分区，暂按 elapsed（1440 min）处理；
+  若后续确认按日分区，改成 `due_policy="calendar"` 即可，无需动结构。
+
+---
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -1291,3 +1401,16 @@ sannai-community 仓库 README。）
   / 13 skipped（+55），**首次全绿**；静态门全过（import cycle 0 环、write surface
   unclassified 0、static hygiene、public checkout probe --strict exit 0、git diff --check）。
   `oa_` 密钥化、monitor 11 组件采集接线、主机侧退役执行均**有意未做**并在 BR 节登记原因。
+- `38fa4e0..HEAD`：Hermes cron 归类合并——`MemoryOSCronSpec` 拆为 lane 治理身份（21 条不变）
+  与 group 调度面（9 条），active-closure **19 个 cron job → 8 个**，新增
+  `memory_os_cron_group_runner.py` 按 due 门控逐 member 开自己的 ExecutionGate envelope。
+  实测动因：00:00/12:00 各有 5 个 job 同时争 `execution_gate_index.json` 的 15 秒锁
+  （合并后同分钟并发 5→1、触发 336/天→172/天）。两条阻断前置先行：monitor 新鲜度改按 lane
+  `due_interval_minutes` 取（否则 4 条 lane 窗口塌缩、2 条永久 stale）、旧 19 个 per-lane job
+  名显式归入 `superseded_by_group_tick`（否则每台升级主机 monitor FAIL）。顺链修掉
+  `classify_hermes_cron_jobs` 的**三份**拷贝、dashboard CORE/OPTIONAL 集合重叠、
+  `install_memory_os.sh` 与 `deploy_l3_probe.py` 两处会导致 lane 双跑的自建 job，
+  并补上 helper subprocess timeout、group 非阻塞锁、成员失败隔离、lane 级停用，
+  以及独立缺陷 `execution_gate_index.json` 无裁剪（新增 `prune_sidecar_index`，保留 2000 条）。
+  3023 → **3056 passed / 13 skipped / 0 failed**（+33），静态门全过。
+  未部署 3.200，`live_monitor_pass` 未取得。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1244,14 +1244,23 @@ R1/R2 的 revert→FAIL→restore→PASS 已实际验证。
 
 ### 测试与门禁
 
-3023（BR 基线）→ **3056 passed / 13 skipped / 0 failed**，净 +33。
-新增 `tests/scripts/test_memory_os_cron_group_runner.py`（14 项）。
+3023（BR 基线）→ **3058 passed / 13 skipped / 0 failed**，净 +35。
+新增 `tests/scripts/test_memory_os_cron_group_runner.py`（14 项），
+另在 `test_memory_os_l3_probe_repo_root.py` 补 2 项双跑守卫。
 四项静态门全过：import_cycle / write_surface（unclassified=0）/ static_hygiene / public_checkout_probe。
 
 ### 回滚
 
 onboarding 只**暂停**旧 19 个 per-lane job，不删除。回滚 = 重新启用旧 job + 停用 8 个 group job；
 lane 注册表与 helper 脚本全程未动，回滚后行为与合并前一致。
+
+**旧 per-lane gate shim 是回滚基础设施，故意保留、不删除。** 被暂停的旧 job 其 `script` 字段
+指向 `memory_os_cron_<lane>_gate.py`，删掉这些 shim 会让回滚（重新启用旧 job）直接失败。
+因此 `_write_execution_gate_assets()` 只写当前 group 的 wrapper、不清理旧 shim，
+`install_memory_os.sh` 也继续安装 `memory_os_cron_working_cleanup_gate.py`——
+这一条是有意为之，不是清理遗漏。只有旧 job **创建逻辑**被移除
+（`install_memory_os.sh` 的自建 cron 块、`deploy_l3_probe.py --apply`），
+因为那才是导致 lane 双跑的部分。
 
 ### 未做 / 残留
 
@@ -1412,5 +1421,5 @@ sannai-community 仓库 README。）
   `install_memory_os.sh` 与 `deploy_l3_probe.py` 两处会导致 lane 双跑的自建 job，
   并补上 helper subprocess timeout、group 非阻塞锁、成员失败隔离、lane 级停用，
   以及独立缺陷 `execution_gate_index.json` 无裁剪（新增 `prune_sidecar_index`，保留 2000 条）。
-  3023 → **3056 passed / 13 skipped / 0 failed**（+33），静态门全过。
+  3023 → **3058 passed / 13 skipped / 0 failed**（+35），静态门全过。
   未部署 3.200，`live_monitor_pass` 未取得。

--- a/plugins/memory/memory_os/cron_registry.py
+++ b/plugins/memory/memory_os/cron_registry.py
@@ -1,4 +1,27 @@
-"""Memory-OS-owned Hermes cron registry."""
+"""Memory-OS-owned Hermes cron registry.
+
+Two tables, deliberately kept separate (see
+``docs/resolver/hermes-memory-os-cron-consolidation-plan.md``):
+
+``MemoryOSCronLaneDef`` / ``MemoryOSCronSpec``
+    The *governance identity* of a lane: ``lane_id``, ``raw_script``,
+    ``helper_kind`` (risk class) and boundary-report requirement.  One entry
+    per ExecutionGate lane.  This granularity is what the monitor, the
+    envelope journal and StructuralWriteGate scope checks all key off, so it
+    never collapses.
+
+``MemoryOSCronGroupSpec``
+    The *Hermes scheduling surface*: the job that actually gets created via
+    ``hermes cron create``.  Several lanes share one group job, which is fired
+    by a tick wrapper that runs each due member behind its own ExecutionGate
+    permit.
+
+``MEMORY_OS_CRON_SPECS`` is the join of the two: every lane still exposes a
+``name``/``wrapper_script``/``schedule_arg``, but those values are *derived
+from its group* rather than owned per lane.  Existing consumers therefore keep
+working unchanged; the only visible difference is that several specs now share
+one ``name``.
+"""
 
 from __future__ import annotations
 
@@ -31,9 +54,99 @@ RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES = frozenset(
     }
 )
 
+# ── Legacy per-lane cron jobs (superseded by group ticks) ─────────────
+#
+# Before the group consolidation every lane owned its own Hermes cron job
+# named ``memory-os-<lane>`` running a 5-line shim
+# ``memory_os_cron_<lane>_gate.py``.  Those jobs still exist (paused) on
+# already-onboarded hosts.
+#
+# They MUST be listed here.  ``classify_hermes_cron_jobs`` resolves a job by
+# spec name / wrapper script / raw script; after consolidation none of those
+# lookups match a legacy per-lane job any more, so without this table the job
+# falls through to the ``name.startswith("memory-os-")`` branch and lands in
+# ``unregistered_like`` -- which the 3.200 monitor reports as a FAIL
+# (``execution_gate_memory_os_cron_unregistered_like_job``) on every upgraded
+# host.  This is the identical trap the retired sannai community scripts hit
+# above; the fix is the same: name them explicitly.
+LEGACY_PER_LANE_CRON_JOBS = {
+    "memory-os-index-sync": "memory_os_cron_index_sync_gate.py",
+    "memory-os-event-stats-refresh": "memory_os_cron_event_stats_refresh_gate.py",
+    "memory-os-state-overlay-refresh": "memory_os_cron_state_overlay_refresh_gate.py",
+    "memory-os-entity-index-refresh": "memory_os_cron_entity_index_refresh_gate.py",
+    "memory-os-proposal-followups-opsgate": "memory_os_cron_proposal_followups_opsgate_gate.py",
+    "memory-os-clearance-cycle": "memory_os_cron_clearance_cycle_gate.py",
+    "memory-os-hindsight-health-probe": "memory_os_hindsight_health_probe.py",
+    "memory-os-fact-judge": "memory_os_cron_fact_judge_gate.py",
+    "memory-os-candidate-aggregation": "memory_os_cron_candidate_aggregation_gate.py",
+    "memory-os-l3-probe-verification": "memory_os_cron_l3_probe_verification_gate.py",
+    "memory-os-v3-wandering": "memory_os_cron_v3_wandering_gate.py",
+    "memory-os-exposure-rollup": "memory_os_cron_exposure_rollup_gate.py",
+    "memory-os-v3-seed-evidence": "memory_os_cron_v3_seed_evidence_gate.py",
+    "memory-os-v3-journal-sweep": "memory_os_cron_v3_journal_sweep_gate.py",
+    "memory-os-working-cleanup": "memory_os_cron_working_cleanup_gate.py",
+    "memory-os-hindsight-advisory-digest": "memory_os_cron_hindsight_advisory_digest_gate.py",
+}
+LEGACY_PER_LANE_CRON_JOB_NAMES = frozenset(LEGACY_PER_LANE_CRON_JOBS)
+LEGACY_PER_LANE_CRON_SCRIPT_NAMES = frozenset(LEGACY_PER_LANE_CRON_JOBS.values())
+
+DUE_POLICY_INTERVAL = "interval"
+DUE_POLICY_CALENDAR = "calendar"
+
+
+@dataclass(frozen=True)
+class MemoryOSCronGroupSpec:
+    """One Hermes cron job. Fires a tick that runs its due members."""
+
+    key: str
+    name: str
+    wrapper_script: str
+    schedule_arg: str
+    default_schedule: str
+    deliver_role: str
+    prompt_ref: str
+    no_agent: bool
+    member_keys: tuple[str, ...]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "name": self.name,
+            "wrapper_script": self.wrapper_script,
+            "schedule_arg": self.schedule_arg,
+            "default_schedule": self.default_schedule,
+            "deliver_role": self.deliver_role,
+            "prompt_ref": self.prompt_ref,
+            "no_agent": self.no_agent,
+            "member_keys": list(self.member_keys),
+        }
+
+
+@dataclass(frozen=True)
+class MemoryOSCronLaneDef:
+    """Governance identity of a lane, independent of how it is scheduled."""
+
+    key: str
+    raw_script: str
+    lane_id: str
+    helper_kind: str
+    group_key: str
+    due_interval_minutes: int
+    due_policy: str = DUE_POLICY_INTERVAL
+    calendar_anchor: str = ""
+    timeout_seconds: int = 300
+    requires_boundary_report: bool = False
+
 
 @dataclass(frozen=True)
 class MemoryOSCronSpec:
+    """Lane joined with its group.
+
+    ``name``/``wrapper_script``/``schedule_arg``/``deliver_role``/
+    ``prompt_ref``/``no_agent`` are the *group's* values -- several specs
+    legitimately share them.
+    """
+
     key: str
     name: str
     raw_script: str
@@ -45,6 +158,11 @@ class MemoryOSCronSpec:
     prompt_ref: str
     no_agent: bool
     requires_boundary_report: bool = False
+    group_key: str = ""
+    due_policy: str = DUE_POLICY_INTERVAL
+    due_interval_minutes: int = 1440
+    calendar_anchor: str = ""
+    timeout_seconds: int = 300
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -59,285 +177,403 @@ class MemoryOSCronSpec:
             "prompt_ref": self.prompt_ref,
             "no_agent": self.no_agent,
             "requires_boundary_report": self.requires_boundary_report,
+            "group_key": self.group_key,
+            "due_policy": self.due_policy,
+            "due_interval_minutes": self.due_interval_minutes,
+            "calendar_anchor": self.calendar_anchor,
+            "timeout_seconds": self.timeout_seconds,
         }
 
 
-MEMORY_OS_CRON_SPECS: tuple[MemoryOSCronSpec, ...] = (
-    MemoryOSCronSpec(
+# ── Group table: what actually becomes a Hermes cron job ──────────────
+#
+# Four multi-member tick groups collapse 16 local lanes into 4 jobs.  The
+# owner-facing lanes keep a dedicated single-member group each: they render a
+# distinct owner message through their own agent prompt and deliver channel,
+# so merging them would fuse separate owner messages and cross-contaminate
+# prompts.  full_monitor_refresh stays alone because it is the heavyweight
+# (<=180s) full monitor and would block co-tenants of any tick.
+MEMORY_OS_CRON_GROUPS: tuple[MemoryOSCronGroupSpec, ...] = (
+    MemoryOSCronGroupSpec(
+        key="tick_derived",
+        name="memory-os-tick-derived",
+        wrapper_script="memory_os_cron_tick_derived.py",
+        schedule_arg="tick_derived_schedule",
+        default_schedule="*/15 * * * *",
+        deliver_role="local",
+        prompt_ref="empty",
+        no_agent=True,
+        member_keys=("event_stats_refresh", "index_sync", "state_overlay_refresh", "entity_index_refresh"),
+    ),
+    MemoryOSCronGroupSpec(
+        key="tick_governance",
+        name="memory-os-tick-governance",
+        wrapper_script="memory_os_cron_tick_governance.py",
+        schedule_arg="tick_governance_schedule",
+        default_schedule="*/30 * * * *",
+        deliver_role="local",
+        prompt_ref="empty",
+        no_agent=True,
+        member_keys=("proposal_followups_opsgate", "clearance_cycle"),
+    ),
+    MemoryOSCronGroupSpec(
+        key="tick_evidence",
+        name="memory-os-tick-evidence",
+        wrapper_script="memory_os_cron_tick_evidence.py",
+        schedule_arg="tick_evidence_schedule",
+        default_schedule="0 * * * *",
+        deliver_role="local",
+        prompt_ref="empty",
+        no_agent=True,
+        member_keys=(
+            "hindsight_health_probe",
+            "fact_judge",
+            "candidate_aggregation",
+            "l3_probe_verification",
+            "v3_wandering",
+        ),
+    ),
+    MemoryOSCronGroupSpec(
+        key="tick_daily",
+        name="memory-os-tick-daily",
+        wrapper_script="memory_os_cron_tick_daily.py",
+        schedule_arg="tick_daily_schedule",
+        default_schedule="5 0 * * *",
+        deliver_role="local",
+        prompt_ref="empty",
+        no_agent=True,
+        member_keys=(
+            "exposure_rollup",
+            "v3_seed_evidence",
+            "v3_journal_sweep",
+            "working_cleanup",
+            "hindsight_advisory_digest",
+        ),
+    ),
+    # ── Single-member groups: unchanged Hermes jobs ───────────────────
+    MemoryOSCronGroupSpec(
         key="owner_review_digest",
         name="memory-os-owner-review-digest",
-        raw_script="memory_os_owner_review_digest.py",
         wrapper_script="memory_os_cron_owner_review_digest_gate.py",
-        lane_id="owner_review_digest_render",
-        helper_kind="owner_channel_render",
         schedule_arg="owner_review_schedule",
+        default_schedule="0 9 * * *",
         deliver_role="owner",
         prompt_ref="owner_review_agent_prompt",
         no_agent=False,
+        member_keys=("owner_review_digest",),
     ),
-
-    MemoryOSCronSpec(
-        key="module_cadence_report",
-        name="memory-os-module-cadence-report",
-        raw_script="memory_os_module_cadence_report_cron.py",
-        wrapper_script="memory_os_cron_module_cadence_report_gate.py",
-        lane_id="module_cadence_report",
-        helper_kind="local_helper",
-        schedule_arg="module_cadence_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-    ),
-
-    MemoryOSCronSpec(
-        key="proposal_followups_opsgate",
-        name="memory-os-proposal-followups-opsgate",
-        raw_script="memory_os_proposal_followups_ops_gate.py",
-        wrapper_script="memory_os_cron_proposal_followups_opsgate_gate.py",
-        lane_id="proposal_followups_opsgate",
-        helper_kind="local_helper",
-        schedule_arg="proposal_followups_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-    ),
-    MemoryOSCronSpec(
-        key="expression_feedback_request",
-        name="memory-os-expression-feedback-request",
-        raw_script="memory_os_expression_feedback_prompt.py",
-        wrapper_script="memory_os_cron_expression_feedback_request_gate.py",
-        lane_id="expression_feedback_request",
-        helper_kind="owner_channel_render",
-        schedule_arg="expression_feedback_schedule",
-        deliver_role="owner",
-        prompt_ref="expression_feedback_agent_prompt",
-        no_agent=False,
-    ),
-    MemoryOSCronSpec(
+    MemoryOSCronGroupSpec(
         key="memory_sources_feedback_request",
         name="memory-os-memory-sources-feedback-request",
-        raw_script="memory_os_memory_sources_feedback_prompt.py",
         wrapper_script="memory_os_cron_memory_sources_feedback_request_gate.py",
-        lane_id="memory_sources_feedback_request",
-        helper_kind="owner_channel_render",
         schedule_arg="memory_sources_feedback_schedule",
+        default_schedule="30 10 * * *",
         deliver_role="owner",
         prompt_ref="memory_sources_feedback_agent_prompt",
         no_agent=False,
+        member_keys=("memory_sources_feedback_request",),
     ),
-    MemoryOSCronSpec(
-        key="candidate_aggregation",
-        name="memory-os-candidate-aggregation",
-        raw_script="memory_os_candidate_aggregation_lane.py",
-        wrapper_script="memory_os_cron_candidate_aggregation_gate.py",
-        lane_id="candidate_aggregation",
-        helper_kind="bounded_reversible_queue",
-        schedule_arg="candidate_aggregation_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=True,
+    MemoryOSCronGroupSpec(
+        key="expression_feedback_request",
+        name="memory-os-expression-feedback-request",
+        wrapper_script="memory_os_cron_expression_feedback_request_gate.py",
+        schedule_arg="expression_feedback_schedule",
+        default_schedule="0 5 * * 0",
+        deliver_role="owner",
+        prompt_ref="expression_feedback_agent_prompt",
+        no_agent=False,
+        member_keys=("expression_feedback_request",),
     ),
-    MemoryOSCronSpec(
-        key="fact_judge",
-        name="memory-os-fact-judge",
-        raw_script="memory_os_fact_judge_lane.py",
-        wrapper_script="memory_os_cron_fact_judge_gate.py",
-        lane_id="fact_judge",
-        helper_kind="local_helper",
-        schedule_arg="fact_judge_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="index_sync",
-        name="memory-os-index-sync",
-        raw_script="memory_os_index_sync.py",
-        wrapper_script="memory_os_cron_index_sync_gate.py",
-        lane_id="index_sync",
-        helper_kind="local_helper",
-        schedule_arg="index_sync_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="event_stats_refresh",
-        name="memory-os-event-stats-refresh",
-        raw_script="memory_os_event_stats_refresh.py",
-        wrapper_script="memory_os_cron_event_stats_refresh_gate.py",
-        lane_id="event_stats_refresh",
-        helper_kind="local_helper",
-        schedule_arg="event_stats_refresh_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="exposure_rollup",
-        name="memory-os-exposure-rollup",
-        raw_script="memory_os_exposure_rollup.py",
-        wrapper_script="memory_os_cron_exposure_rollup_gate.py",
-        lane_id="exposure_rollup",
-        helper_kind="local_helper",
-        schedule_arg="exposure_rollup_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
+    MemoryOSCronGroupSpec(
         key="full_monitor_refresh",
         name="memory-os-full-monitor-refresh",
-        raw_script="memory_os_full_monitor_refresh.py",
         wrapper_script="memory_os_full_monitor_refresh.py",
-        lane_id="full_monitor_refresh",
-        helper_kind="read_only_probe",
         schedule_arg="full_monitor_refresh_schedule",
+        default_schedule="30 2 * * *",
         deliver_role="owner",
         prompt_ref="empty",
         no_agent=True,
-        requires_boundary_report=False,
+        member_keys=("full_monitor_refresh",),
     ),
-    MemoryOSCronSpec(
-        key="v3_seed_evidence",
-        name="memory-os-v3-seed-evidence",
-        raw_script="memory_os_v3_seed_evidence.py",
-        wrapper_script="memory_os_cron_v3_seed_evidence_gate.py",
-        lane_id="v3_seed_evidence",
-        helper_kind="local_helper",
-        schedule_arg="v3_seed_evidence_schedule",
+    MemoryOSCronGroupSpec(
+        key="module_cadence_report",
+        name="memory-os-module-cadence-report",
+        wrapper_script="memory_os_cron_module_cadence_report_gate.py",
+        schedule_arg="module_cadence_schedule",
+        default_schedule="15 */6 * * *",
         deliver_role="local",
         prompt_ref="empty",
         no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="v3_wandering",
-        name="memory-os-v3-wandering",
-        raw_script="memory_os_v3_wandering.py",
-        wrapper_script="memory_os_cron_v3_wandering_gate.py",
-        lane_id="v3_wandering",
-        helper_kind="local_helper",
-        schedule_arg="v3_wandering_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="v3_journal_sweep",
-        name="memory-os-v3-journal-sweep",
-        raw_script="memory_os_v3_journal_sweep.py",
-        wrapper_script="memory_os_cron_v3_journal_sweep_gate.py",
-        lane_id="v3_journal_sweep",
-        helper_kind="local_helper",
-        schedule_arg="v3_journal_sweep_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="working_cleanup",
-        name="memory-os-working-cleanup",
-        raw_script="cleanup_expired_working.py",
-        wrapper_script="memory_os_cron_working_cleanup_gate.py",
-        lane_id="working_cleanup",
-        helper_kind="local_helper",
-        schedule_arg="working_cleanup_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="l3_probe_verification",
-        name="memory-os-l3-probe-verification",
-        raw_script="memory_os_l3_probe_helper.py",
-        wrapper_script="memory_os_cron_l3_probe_verification_gate.py",
-        lane_id="l3_probe_verification",
-        helper_kind="local_helper",
-        schedule_arg="l3_probe_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="state_overlay_refresh",
-        name="memory-os-state-overlay-refresh",
-        raw_script="memory_os_state_overlay_refresh.py",
-        wrapper_script="memory_os_cron_state_overlay_refresh_gate.py",
-        lane_id="state_overlay_refresh",
-        helper_kind="local_helper",
-        schedule_arg="state_overlay_refresh_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="entity_index_refresh",
-        name="memory-os-entity-index-refresh",
-        raw_script="memory_os_entity_index_refresh.py",
-        wrapper_script="memory_os_cron_entity_index_refresh_gate.py",
-        lane_id="entity_index_refresh",
-        helper_kind="local_helper",
-        schedule_arg="entity_index_refresh_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="hindsight_advisory_digest",
-        name="memory-os-hindsight-advisory-digest",
-        raw_script="memory_os_hindsight_advisory_digest.py",
-        wrapper_script="memory_os_cron_hindsight_advisory_digest_gate.py",
-        lane_id="hindsight_advisory_digest",
-        helper_kind="local_helper",
-        schedule_arg="hindsight_advisory_digest_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="hindsight_health_probe",
-        name="memory-os-hindsight-health-probe",
-        raw_script="memory_os_hindsight_health_probe.py",
-        wrapper_script="memory_os_hindsight_health_probe.py",
-        lane_id="hindsight_health_probe",
-        helper_kind="read_only_probe",
-        schedule_arg="hindsight_health_probe_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
-    ),
-    MemoryOSCronSpec(
-        key="clearance_cycle",
-        name="memory-os-clearance-cycle",
-        raw_script="memory_os_clearance_cycle_helper.py",
-        wrapper_script="memory_os_cron_clearance_cycle_gate.py",
-        lane_id="clearance_cycle",
-        helper_kind="local_helper",
-        schedule_arg="clearance_cycle_schedule",
-        deliver_role="local",
-        prompt_ref="empty",
-        no_agent=True,
-        requires_boundary_report=False,
+        member_keys=("module_cadence_report",),
     ),
 )
 
 
+# ── Lane table: governance identity, one entry per ExecutionGate lane ──
+#
+# ``due_interval_minutes`` is the lane's effective cadence.  It is the ONLY
+# source the monitor may use for completion-freshness windows -- deriving the
+# window from the group's cron expression instead would collapse a weekly
+# lane sharing a daily tick down to a 54h window and report it permanently
+# stale.
+MEMORY_OS_CRON_LANES: tuple[MemoryOSCronLaneDef, ...] = (
+    # G1 derived views -- rebuildable projections, no governance risk
+    MemoryOSCronLaneDef(
+        key="event_stats_refresh",
+        raw_script="memory_os_event_stats_refresh.py",
+        lane_id="event_stats_refresh",
+        helper_kind="local_helper",
+        group_key="tick_derived",
+        due_interval_minutes=15,
+    ),
+    MemoryOSCronLaneDef(
+        key="index_sync",
+        raw_script="memory_os_index_sync.py",
+        lane_id="index_sync",
+        helper_kind="local_helper",
+        group_key="tick_derived",
+        due_interval_minutes=30,
+        timeout_seconds=600,
+    ),
+    MemoryOSCronLaneDef(
+        key="state_overlay_refresh",
+        raw_script="memory_os_state_overlay_refresh.py",
+        lane_id="state_overlay_refresh",
+        helper_kind="local_helper",
+        group_key="tick_derived",
+        due_interval_minutes=30,
+    ),
+    MemoryOSCronLaneDef(
+        key="entity_index_refresh",
+        raw_script="memory_os_entity_index_refresh.py",
+        lane_id="entity_index_refresh",
+        helper_kind="local_helper",
+        group_key="tick_derived",
+        due_interval_minutes=30,
+    ),
+    # G2 governance queues
+    MemoryOSCronLaneDef(
+        key="proposal_followups_opsgate",
+        raw_script="memory_os_proposal_followups_ops_gate.py",
+        lane_id="proposal_followups_opsgate",
+        helper_kind="local_helper",
+        group_key="tick_governance",
+        due_interval_minutes=30,
+    ),
+    MemoryOSCronLaneDef(
+        key="clearance_cycle",
+        raw_script="memory_os_clearance_cycle_helper.py",
+        lane_id="clearance_cycle",
+        helper_kind="local_helper",
+        group_key="tick_governance",
+        due_interval_minutes=10,
+    ),
+    # G3 judgement + probe lanes
+    MemoryOSCronLaneDef(
+        key="hindsight_health_probe",
+        raw_script="memory_os_hindsight_health_probe.py",
+        lane_id="hindsight_health_probe",
+        helper_kind="read_only_probe",
+        group_key="tick_evidence",
+        due_interval_minutes=60,
+    ),
+    MemoryOSCronLaneDef(
+        key="fact_judge",
+        raw_script="memory_os_fact_judge_lane.py",
+        lane_id="fact_judge",
+        helper_kind="local_helper",
+        group_key="tick_evidence",
+        due_interval_minutes=240,
+        timeout_seconds=600,
+    ),
+    MemoryOSCronLaneDef(
+        key="candidate_aggregation",
+        raw_script="memory_os_candidate_aggregation_lane.py",
+        lane_id="candidate_aggregation",
+        helper_kind="bounded_reversible_queue",
+        group_key="tick_evidence",
+        due_interval_minutes=360,
+        timeout_seconds=600,
+        requires_boundary_report=True,
+    ),
+    MemoryOSCronLaneDef(
+        key="l3_probe_verification",
+        raw_script="memory_os_l3_probe_helper.py",
+        lane_id="l3_probe_verification",
+        helper_kind="local_helper",
+        group_key="tick_evidence",
+        due_interval_minutes=360,
+    ),
+    MemoryOSCronLaneDef(
+        key="v3_wandering",
+        raw_script="memory_os_v3_wandering.py",
+        lane_id="v3_wandering",
+        helper_kind="local_helper",
+        group_key="tick_evidence",
+        due_interval_minutes=360,
+    ),
+    # G4 day-boundary + maintenance
+    MemoryOSCronLaneDef(
+        key="exposure_rollup",
+        raw_script="memory_os_exposure_rollup.py",
+        lane_id="exposure_rollup",
+        helper_kind="local_helper",
+        group_key="tick_daily",
+        due_interval_minutes=1440,
+    ),
+    # Date-partitioned: emits a per-``natural_date`` daily record and exposes
+    # consecutive_valid_day_count.  Elapsed-interval gating could drift it
+    # across a UTC day boundary and double-count or skip a day, so it is
+    # anchored to the calendar day instead.
+    MemoryOSCronLaneDef(
+        key="v3_seed_evidence",
+        raw_script="memory_os_v3_seed_evidence.py",
+        lane_id="v3_seed_evidence",
+        helper_kind="local_helper",
+        group_key="tick_daily",
+        due_interval_minutes=1440,
+        due_policy=DUE_POLICY_CALENDAR,
+        calendar_anchor="00:00",
+    ),
+    MemoryOSCronLaneDef(
+        key="v3_journal_sweep",
+        raw_script="memory_os_v3_journal_sweep.py",
+        lane_id="v3_journal_sweep",
+        helper_kind="local_helper",
+        group_key="tick_daily",
+        due_interval_minutes=1440,
+    ),
+    MemoryOSCronLaneDef(
+        key="working_cleanup",
+        raw_script="cleanup_expired_working.py",
+        lane_id="working_cleanup",
+        helper_kind="local_helper",
+        group_key="tick_daily",
+        due_interval_minutes=10080,
+    ),
+    MemoryOSCronLaneDef(
+        key="hindsight_advisory_digest",
+        raw_script="memory_os_hindsight_advisory_digest.py",
+        lane_id="hindsight_advisory_digest",
+        helper_kind="local_helper",
+        group_key="tick_daily",
+        due_interval_minutes=10080,
+    ),
+    # Single-member groups
+    MemoryOSCronLaneDef(
+        key="owner_review_digest",
+        raw_script="memory_os_owner_review_digest.py",
+        lane_id="owner_review_digest_render",
+        helper_kind="owner_channel_render",
+        group_key="owner_review_digest",
+        due_interval_minutes=1440,
+        timeout_seconds=600,
+    ),
+    MemoryOSCronLaneDef(
+        key="memory_sources_feedback_request",
+        raw_script="memory_os_memory_sources_feedback_prompt.py",
+        lane_id="memory_sources_feedback_request",
+        helper_kind="owner_channel_render",
+        group_key="memory_sources_feedback_request",
+        due_interval_minutes=1440,
+        timeout_seconds=600,
+    ),
+    MemoryOSCronLaneDef(
+        key="expression_feedback_request",
+        raw_script="memory_os_expression_feedback_prompt.py",
+        lane_id="expression_feedback_request",
+        helper_kind="owner_channel_render",
+        group_key="expression_feedback_request",
+        due_interval_minutes=10080,
+        timeout_seconds=600,
+    ),
+    MemoryOSCronLaneDef(
+        key="full_monitor_refresh",
+        raw_script="memory_os_full_monitor_refresh.py",
+        lane_id="full_monitor_refresh",
+        helper_kind="read_only_probe",
+        group_key="full_monitor_refresh",
+        due_interval_minutes=1440,
+        timeout_seconds=900,
+    ),
+    MemoryOSCronLaneDef(
+        key="module_cadence_report",
+        raw_script="memory_os_module_cadence_report_cron.py",
+        lane_id="module_cadence_report",
+        helper_kind="local_helper",
+        group_key="module_cadence_report",
+        due_interval_minutes=360,
+    ),
+)
+
+
+def _build_specs() -> tuple[MemoryOSCronSpec, ...]:
+    groups = {group.key: group for group in MEMORY_OS_CRON_GROUPS}
+    missing = sorted({lane.group_key for lane in MEMORY_OS_CRON_LANES} - set(groups))
+    if missing:
+        raise ValueError(f"cron lanes reference unknown group keys: {missing}")
+    lanes_by_key = {lane.key: lane for lane in MEMORY_OS_CRON_LANES}
+    for group in MEMORY_OS_CRON_GROUPS:
+        unknown = sorted(set(group.member_keys) - set(lanes_by_key))
+        if unknown:
+            raise ValueError(f"cron group {group.key} lists unknown member keys: {unknown}")
+        for member in group.member_keys:
+            if lanes_by_key[member].group_key != group.key:
+                raise ValueError(
+                    f"cron lane {member} claims group {lanes_by_key[member].group_key} "
+                    f"but is listed under {group.key}"
+                )
+    specs: list[MemoryOSCronSpec] = []
+    for lane in MEMORY_OS_CRON_LANES:
+        group = groups[lane.group_key]
+        if lane.key not in group.member_keys:
+            raise ValueError(f"cron lane {lane.key} is not listed in group {group.key} member_keys")
+        specs.append(
+            MemoryOSCronSpec(
+                key=lane.key,
+                name=group.name,
+                raw_script=lane.raw_script,
+                wrapper_script=group.wrapper_script,
+                lane_id=lane.lane_id,
+                helper_kind=lane.helper_kind,
+                schedule_arg=group.schedule_arg,
+                deliver_role=group.deliver_role,
+                prompt_ref=group.prompt_ref,
+                no_agent=group.no_agent,
+                requires_boundary_report=lane.requires_boundary_report,
+                group_key=group.key,
+                due_policy=lane.due_policy,
+                due_interval_minutes=lane.due_interval_minutes,
+                calendar_anchor=lane.calendar_anchor,
+                timeout_seconds=lane.timeout_seconds,
+            )
+        )
+    return tuple(specs)
+
+
+MEMORY_OS_CRON_SPECS: tuple[MemoryOSCronSpec, ...] = _build_specs()
+
+
 def memory_os_cron_specs() -> tuple[MemoryOSCronSpec, ...]:
     return MEMORY_OS_CRON_SPECS
+
+
+def memory_os_cron_groups() -> tuple[MemoryOSCronGroupSpec, ...]:
+    return MEMORY_OS_CRON_GROUPS
+
+
+def memory_os_cron_group_by_key(key: str) -> MemoryOSCronGroupSpec | None:
+    for group in MEMORY_OS_CRON_GROUPS:
+        if group.key == key:
+            return group
+    return None
+
+
+def memory_os_cron_group_by_name(name: str) -> MemoryOSCronGroupSpec | None:
+    for group in MEMORY_OS_CRON_GROUPS:
+        if group.name == name:
+            return group
+    return None
 
 
 def memory_os_cron_spec_by_key(key: str) -> MemoryOSCronSpec | None:
@@ -347,19 +583,39 @@ def memory_os_cron_spec_by_key(key: str) -> MemoryOSCronSpec | None:
     return None
 
 
+def memory_os_cron_specs_by_name(name: str) -> tuple[MemoryOSCronSpec, ...]:
+    """All lanes scheduled by the Hermes job called ``name``."""
+    return tuple(spec for spec in MEMORY_OS_CRON_SPECS if spec.name == name)
+
+
 def memory_os_cron_spec_by_name(name: str) -> MemoryOSCronSpec | None:
-    for spec in MEMORY_OS_CRON_SPECS:
-        if spec.name == name:
-            return spec
-    return None
+    """First lane scheduled by ``name``.
+
+    Kept for callers that only need a representative spec (wrapper script,
+    deliver role, schedule arg -- all group-level values shared by every
+    member).  Use :func:`memory_os_cron_specs_by_name` when the full member
+    list matters.
+    """
+    matches = memory_os_cron_specs_by_name(name)
+    return matches[0] if matches else None
 
 
-def cron_registry_snapshot(*, source_commit: str = "", specs: tuple[MemoryOSCronSpec, ...] | None = None) -> dict[str, Any]:
+def cron_registry_snapshot(
+    *,
+    source_commit: str = "",
+    specs: tuple[MemoryOSCronSpec, ...] | None = None,
+    groups: tuple[MemoryOSCronGroupSpec, ...] | None = None,
+) -> dict[str, Any]:
     selected_specs = specs if specs is not None else MEMORY_OS_CRON_SPECS
+    if groups is not None:
+        selected_groups = groups
+    else:
+        selected_groups = groups_for_specs(selected_specs)
     return {
-        "schema_version": "memory-os.cron_registry.v0",
+        "schema_version": "memory-os.cron_registry.v1",
         "source_commit": str(source_commit or ""),
         "specs": [spec.to_json() for spec in selected_specs],
+        "groups": [group.to_json() for group in selected_groups],
     }
 
 
@@ -368,8 +624,9 @@ def write_cron_registry_snapshot(
     *,
     source_commit: str = "",
     specs: tuple[MemoryOSCronSpec, ...] | None = None,
+    groups: tuple[MemoryOSCronGroupSpec, ...] | None = None,
 ) -> dict[str, Any]:
-    snapshot = cron_registry_snapshot(source_commit=source_commit, specs=specs)
+    snapshot = cron_registry_snapshot(source_commit=source_commit, specs=specs, groups=groups)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
     return snapshot
@@ -380,9 +637,30 @@ def specs_from_snapshot(value: dict[str, Any]) -> tuple[MemoryOSCronSpec, ...]:
     for item in value.get("specs", []) if isinstance(value.get("specs"), list) else []:
         if not isinstance(item, dict):
             continue
+        key = str(item.get("key") or "")
+        # v0 snapshots predate the lane/group split and carry no due metadata.
+        # Fall back to the compiled-in lane definition so an old snapshot can
+        # never silently yield a 0-minute interval -- which would make every
+        # lane permanently "due" in the tick runner and permanently stale in
+        # the monitor.
+        fallback = memory_os_cron_spec_by_key(key)
+        try:
+            due_interval = int(item.get("due_interval_minutes") or 0)
+        except (TypeError, ValueError):
+            due_interval = 0
+        if due_interval <= 0:
+            due_interval = fallback.due_interval_minutes if fallback else 1440
+        try:
+            timeout_seconds = int(item.get("timeout_seconds") or 0)
+        except (TypeError, ValueError):
+            timeout_seconds = 0
+        if timeout_seconds <= 0:
+            timeout_seconds = fallback.timeout_seconds if fallback else 300
+        due_policy = str(item.get("due_policy") or "") or (fallback.due_policy if fallback else DUE_POLICY_INTERVAL)
+        calendar_anchor = str(item.get("calendar_anchor") or "") or (fallback.calendar_anchor if fallback else "")
         specs.append(
             MemoryOSCronSpec(
-                key=str(item.get("key") or ""),
+                key=key,
                 name=str(item.get("name") or ""),
                 raw_script=str(item.get("raw_script") or ""),
                 wrapper_script=str(item.get("wrapper_script") or ""),
@@ -393,6 +671,102 @@ def specs_from_snapshot(value: dict[str, Any]) -> tuple[MemoryOSCronSpec, ...]:
                 prompt_ref=str(item.get("prompt_ref") or "empty"),
                 no_agent=bool(item.get("no_agent")),
                 requires_boundary_report=bool(item.get("requires_boundary_report")),
+                group_key=str(item.get("group_key") or "") or (fallback.group_key if fallback else ""),
+                due_policy=due_policy,
+                due_interval_minutes=due_interval,
+                calendar_anchor=calendar_anchor,
+                timeout_seconds=timeout_seconds,
             )
         )
     return tuple(spec for spec in specs if spec.key and spec.name and spec.raw_script and spec.wrapper_script)
+
+
+def groups_from_snapshot(value: dict[str, Any]) -> tuple[MemoryOSCronGroupSpec, ...]:
+    """Group specs recorded in an installed snapshot.
+
+    A v0 snapshot has no ``groups`` array; callers fall back to
+    :func:`groups_for_specs` over its ``specs``.
+    """
+    groups = []
+    for item in value.get("groups", []) if isinstance(value.get("groups"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        members = item.get("member_keys")
+        groups.append(
+            MemoryOSCronGroupSpec(
+                key=str(item.get("key") or ""),
+                name=str(item.get("name") or ""),
+                wrapper_script=str(item.get("wrapper_script") or ""),
+                schedule_arg=str(item.get("schedule_arg") or ""),
+                default_schedule=str(item.get("default_schedule") or ""),
+                deliver_role=str(item.get("deliver_role") or "local"),
+                prompt_ref=str(item.get("prompt_ref") or "empty"),
+                no_agent=bool(item.get("no_agent")),
+                member_keys=tuple(str(member) for member in members if str(member)) if isinstance(members, list) else (),
+            )
+        )
+    return tuple(group for group in groups if group.key and group.name and group.wrapper_script)
+
+
+def lane_disable_state_path(hermes_home: Path | str) -> Path:
+    """Owner-controlled per-lane disable list.
+
+    Before consolidation an owner stopped a single lane by disabling its
+    dedicated Hermes cron job, and the monitor read ``enabled is False`` off
+    that job.  Group ticks make the Hermes job granularity coarser than the
+    lane, so that control is restored here instead: the tick runner skips a
+    listed lane, and the monitor classifies it ``disabled`` rather than
+    reporting missing completion evidence.
+    """
+    return Path(hermes_home) / "memory-os" / "system" / "cron_lane_disabled.json"
+
+
+def read_disabled_lane_keys(hermes_home: Path | str) -> frozenset[str]:
+    """Lane keys the owner has disabled. Unreadable/malformed state disables
+    nothing -- a corrupt file must never silently stop governed lanes."""
+    path = lane_disable_state_path(hermes_home)
+    if not path.exists():
+        return frozenset()
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return frozenset()
+    if isinstance(loaded, dict):
+        entries = loaded.get("disabled_lane_keys")
+    else:
+        entries = loaded
+    if not isinstance(entries, list):
+        return frozenset()
+    return frozenset(str(entry) for entry in entries if str(entry))
+
+
+def groups_for_specs(specs: tuple[MemoryOSCronSpec, ...]) -> tuple[MemoryOSCronGroupSpec, ...]:
+    """Group specs covering ``specs``, with member lists narrowed to them.
+
+    Used by onboarding so a profile that installs a subset of lanes creates a
+    group job whose member list matches what is actually installed (the
+    excluded members must not be run by the tick).
+    """
+    members_by_name: dict[str, set[str]] = {}
+    for spec in specs:
+        members_by_name.setdefault(spec.name, set()).add(spec.key)
+    built: list[MemoryOSCronGroupSpec] = []
+    for group in MEMORY_OS_CRON_GROUPS:
+        members = members_by_name.get(group.name)
+        if not members:
+            continue
+        ordered = tuple(key for key in group.member_keys if key in members)
+        built.append(
+            MemoryOSCronGroupSpec(
+                key=group.key,
+                name=group.name,
+                wrapper_script=group.wrapper_script,
+                schedule_arg=group.schedule_arg,
+                default_schedule=group.default_schedule,
+                deliver_role=group.deliver_role,
+                prompt_ref=group.prompt_ref,
+                no_agent=group.no_agent,
+                member_keys=ordered,
+            )
+        )
+    return tuple(built)

--- a/plugins/memory/memory_os/hermes_cron_adapter.py
+++ b/plugins/memory/memory_os/hermes_cron_adapter.py
@@ -9,11 +9,19 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 from .cron_registry import (
+    LEGACY_PER_LANE_CRON_JOBS,
+    LEGACY_PER_LANE_CRON_JOB_NAMES,
+    LEGACY_PER_LANE_CRON_SCRIPT_NAMES,
     MemoryOSCronSpec,
     RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES,
     RETIRED_MEMORY_OS_CRON_SCRIPTS,
     memory_os_cron_specs,
 )
+
+# Reverse of LEGACY_PER_LANE_CRON_JOBS (script -> canonical legacy job name),
+# used when a legacy per-lane job is identified by its script but its "name"
+# field was not the canonical one (e.g. renamed on the host).
+_LEGACY_PER_LANE_SCRIPT_TO_NAME = {script: name for name, script in LEGACY_PER_LANE_CRON_JOBS.items()}
 
 
 @dataclass(frozen=True)
@@ -121,6 +129,26 @@ def classify_hermes_cron_jobs(jobs: Iterable[dict[str, Any]], specs: Iterable[Me
         if retired_name or retired_script:
             safe["retirement_reason"] = "legacy_right_brain_retired"
             retired_legacy.append(safe)
+            continue
+        # Pre-consolidation per-lane jobs (memory-os-<lane> running
+        # memory_os_cron_<lane>_gate.py) are superseded, not unregistered --
+        # see the LEGACY_PER_LANE_CRON_JOBS comment block in cron_registry.py.
+        # This MUST be checked before the known_spec lookup below: one legacy
+        # wrapper script name, memory_os_hindsight_health_probe.py, happens to
+        # also be the tick_evidence group's hindsight_health_probe *raw_script*,
+        # so known_specs_by_raw would otherwise match it first and tag it with
+        # the generic "not_in_active_installed_snapshot" reason instead of the
+        # more precise "superseded_by_group_tick" one. This can never swallow
+        # an active group job: the specs_by_name-by-name branch above already
+        # resolves any job whose Hermes job name is a live group name, and no
+        # active group's name or wrapper_script collides with the legacy
+        # per-lane tables (the coincidence above is confined to a raw_script,
+        # which is never a Hermes job's own "script" field for an active job).
+        if name in LEGACY_PER_LANE_CRON_JOB_NAMES or script in LEGACY_PER_LANE_CRON_SCRIPT_NAMES:
+            registry_key = name if name in LEGACY_PER_LANE_CRON_JOB_NAMES else _LEGACY_PER_LANE_SCRIPT_TO_NAME.get(script, "")
+            safe["known_registry_key"] = registry_key
+            safe["known_optional_reason"] = "superseded_by_group_tick"
+            known_optional.append(safe)
             continue
         known_spec = known_specs_by_name.get(name) or known_specs_by_wrapper.get(script) or known_specs_by_raw.get(script)
         if known_spec:

--- a/plugins/seam/hermes_memory_os/cron_adapter.py
+++ b/plugins/seam/hermes_memory_os/cron_adapter.py
@@ -13,11 +13,16 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 from plugins.memory.memory_os.cron_registry import (
+    LEGACY_PER_LANE_CRON_JOB_NAMES,
+    LEGACY_PER_LANE_CRON_JOBS,
+    LEGACY_PER_LANE_CRON_SCRIPT_NAMES,
     MemoryOSCronSpec,
     RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES,
     RETIRED_MEMORY_OS_CRON_SCRIPTS,
     memory_os_cron_specs,
 )
+
+_LEGACY_PER_LANE_SCRIPT_TO_NAME = {script: name for name, script in LEGACY_PER_LANE_CRON_JOBS.items()}
 
 
 @dataclass(frozen=True)
@@ -125,6 +130,17 @@ def classify_hermes_cron_jobs(
         if retired_name or retired_script:
             safe["retirement_reason"] = "legacy_right_brain_retired"
             retired_legacy.append(safe)
+            continue
+        # Pre-consolidation per-lane jobs, superseded by a group tick.  They
+        # are recognised, not drift: without this they fall through to the
+        # "memory-os-" prefix branch below into unregistered_like, which the
+        # 3.200 monitor reports as a FAIL on every upgraded host.  Checked
+        # before the known_spec lookup so the reason is the precise
+        # "superseded" one rather than the generic not-installed reason.
+        if name in LEGACY_PER_LANE_CRON_JOB_NAMES or script in LEGACY_PER_LANE_CRON_SCRIPT_NAMES:
+            safe["known_registry_key"] = name or _LEGACY_PER_LANE_SCRIPT_TO_NAME.get(script, "")
+            safe["known_optional_reason"] = "superseded_by_group_tick"
+            known_optional.append(safe)
             continue
         known_spec = known_specs_by_name.get(name) or known_specs_by_wrapper.get(script) or known_specs_by_raw.get(script)
         if known_spec:

--- a/scripts/deploy_l3_probe.py
+++ b/scripts/deploy_l3_probe.py
@@ -52,8 +52,8 @@ DEPLOY_HELPER = HERMES_SCRIPTS / "memory_os_l3_probe_helper.py"
 
 # ── cron job parameters ────────────────────────────────────────────
 JOB_NAME = "memory-os-l3-probe-verification"
-SCHEDULE = "every 360m"
-DELIVER = "origin"
+# The lane moved into this group tick; the standalone job above is legacy.
+SUPERSEDED_BY_GROUP_JOB = "memory-os-tick-evidence"
 HERMES_BIN = os.environ.get("HERMES_BIN", "hermes")
 
 
@@ -104,11 +104,21 @@ def run_plan(hermes_home: Path) -> dict[str, Any]:
         needs.append("install_helper")
     elif not helper_current:
         needs.append("update_helper")
-    if not existing_job:
-        needs.append("create_cron_job")
+    # NOT a needed action any more: the lane is scheduled by the
+    # memory-os-tick-evidence group tick, so the ABSENCE of the standalone
+    # job is the correct post-consolidation state. Reporting it as
+    # "create_cron_job" would tell an operator to do something --apply now
+    # refuses, and doing it by hand would double-run the lane.
+    if existing_job:
+        report["superseded_job_present"] = True
+        report["superseded_by"] = SUPERSEDED_BY_GROUP_JOB
+        needs.append("cleanup_superseded_cron_job")
     if not needs:
         report["status"] = "no_action_needed"
-        report["message"] = "L3 probe is already deployed and current."
+        report["message"] = (
+            "L3 probe helper is current; the lane is scheduled by "
+            f"{SUPERSEDED_BY_GROUP_JOB}."
+        )
     else:
         report["status"] = "action_needed"
         report["needs"] = needs
@@ -132,14 +142,12 @@ def run_dry_run(hermes_home: Path) -> dict[str, Any]:
             "source": str(SOURCE_HELPER) if SOURCE_HELPER.is_file() else "inline",
             "target": str(DEPLOY_HELPER),
         })
-    if "create_cron_job" in needs:
+    if "cleanup_superseded_cron_job" in needs:
         commands.append({
-            "operation": "hermes cron create",
+            "operation": "hermes cron remove",
             "name": JOB_NAME,
-            "schedule": SCHEDULE,
-            "script": DEPLOY_HELPER.name,
-            "no_agent": "true",
-            "deliver": DELIVER,
+            "reason": "superseded_by_group_tick",
+            "superseded_by": SUPERSEDED_BY_GROUP_JOB,
         })
 
     return {**plan, "phase": "dry_run", "commands": commands}

--- a/scripts/deploy_l3_probe.py
+++ b/scripts/deploy_l3_probe.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
-import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -44,7 +42,6 @@ except ImportError:
     _MEMORY_OS_IDENTITY_MARKERS = ["pyproject.toml", "plugins/memory/memory_os/__init__.py"]
 
 from plugins.seam.hermes_memory_os.cron_adapter import HermesCronAdapter
-from plugins.memory.memory_os.cron_registry import memory_os_cron_spec_by_key, write_cron_registry_snapshot
 
 SCHEMA_VERSION = "memory-os.l3_probe_deploy.v0"
 
@@ -52,7 +49,6 @@ SCHEMA_VERSION = "memory-os.l3_probe_deploy.v0"
 HERMES_SCRIPTS = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "scripts"
 SOURCE_HELPER = REPO_ROOT / "scripts" / "memory_os_l3_probe_helper.py"
 DEPLOY_HELPER = HERMES_SCRIPTS / "memory_os_l3_probe_helper.py"
-REGISTRY_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "memory-os" / "system" / "memory_os_cron_registry.json"
 
 # ── cron job parameters ────────────────────────────────────────────
 JOB_NAME = "memory-os-l3-probe-verification"
@@ -156,56 +152,21 @@ def run_apply(hermes_home: Path) -> dict[str, Any]:
         "phase": "apply",
         "hermes_home": str(hermes_home),
     }
-    actions: list[dict[str, Any]] = []
-
-    # Step 1: ensure scripts dir exists
-    HERMES_SCRIPTS.mkdir(parents=True, exist_ok=True)
-
-    # Step 2: deploy helper script
-    if SOURCE_HELPER.is_file():
-        shutil.copy2(SOURCE_HELPER, DEPLOY_HELPER)
-        DEPLOY_HELPER.chmod(DEPLOY_HELPER.stat().st_mode | stat.S_IXUSR)
-        actions.append({
-            "action": "deploy_helper",
-            "source": str(SOURCE_HELPER),
-            "target": str(DEPLOY_HELPER),
-            "status": "copied",
-        })
-    else:
-        # Fallback: write helper inline
-        DEPLOY_HELPER.write_text(_FALLBACK_HELPER, encoding="utf-8")
-        DEPLOY_HELPER.chmod(DEPLOY_HELPER.stat().st_mode | stat.S_IXUSR)
-        actions.append({
-            "action": "deploy_helper",
-            "source": "inline",
-            "target": str(DEPLOY_HELPER),
-            "status": "written",
-        })
-    # Write repo root config so the deployed helper can find probe_l3_prefetch_behavior.py
-    repo_root_file = DEPLOY_HELPER.with_name("l3_probe_repo_root.txt")
-    repo_root_file.write_text(str(REPO_ROOT), encoding="utf-8")
-    # Post-write verify: the path must actually be a Memory-OS repo
-    _verify_written_repo_root(repo_root_file, REPO_ROOT)
-    actions.append({
-        "action": "write_repo_root_config",
-        "path": str(repo_root_file),
-        "repo_root": str(REPO_ROOT),
-    })
-    result["helper_deployed"] = True
-
-    # Step 3: create cron job via Hermes CLI
-    if SOURCE_HELPER.is_file():
-        # Use the onboarder's cron registry snapshot update pattern
-        _ensure_registry_snapshot_exists(hermes_home)
-    else:
-        _ensure_registry_snapshot_exists(hermes_home)
-
-    cron_result = _ensure_cron_job(hermes_home)
-    actions.append(cron_result)
-    result["cron_job"] = cron_result
-
-    result["actions"] = actions
-    result["status"] = "applied" if cron_result.get("status") in ("applied", "already_configured", "updated") else "error"
+    # The l3_probe_verification lane is now a member of the
+    # "memory-os-tick-evidence" group tick, created by
+    # memory_os_owner_cron_onboarding.py. Creating the old standalone
+    # "memory-os-l3-probe-verification" job here as well would run the lane
+    # twice -- once from this job and once from the tick -- with two
+    # independent ExecutionGate envelopes per cycle. Refuse loudly instead.
+    result["status"] = "blocked"
+    result["error_code"] = "superseded_by_group_tick"
+    result["superseded_by"] = "memory-os-tick-evidence"
+    result["detail"] = (
+        "l3_probe_verification is scheduled by the memory-os-tick-evidence group tick. "
+        "Run memory_os_owner_cron_onboarding.py --apply instead. "
+        "Use --cleanup here to remove a leftover standalone job."
+    )
+    result["actions"] = []
     return result
 
 
@@ -313,87 +274,6 @@ def _find_job_by_name(jobs: list[dict[str, Any]], name: str) -> dict[str, Any] |
         if str(job.get("name") or "") == name:
             return job
     return None
-
-
-def _ensure_registry_snapshot_exists(hermes_home: Path) -> dict[str, Any]:
-    """Ensure the cron registry snapshot exists (writes from central MEMORY_OS_CRON_SPECS)."""
-    registry_path = hermes_home / "memory-os" / "system" / "memory_os_cron_registry.json"
-    central_spec = memory_os_cron_spec_by_key("l3_probe_verification")
-    if central_spec is None:
-        return {"status": "error", "reason": "l3_probe_verification not found in central MEMORY_OS_CRON_SPECS"}
-    spec_dict = central_spec.to_json()
-    if registry_path.exists():
-        loaded = json.loads(registry_path.read_text(encoding="utf-8"))
-        specs = loaded.get("specs", [])
-        for spec in specs:
-            if spec.get("key") == "l3_probe_verification":
-                return {"status": "already_registered"}
-        specs.append(spec_dict)
-        registry_path.write_text(
-            json.dumps({**loaded, "specs": specs}, ensure_ascii=False, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
-        return {"status": "registered"}
-    else:
-        write_cron_registry_snapshot(registry_path)
-        return {"status": "created"}
-
-
-def _ensure_cron_job(hermes_home: Path) -> dict[str, Any]:
-    """Create or update the cron job via hermes CLI."""
-    adapter = HermesCronAdapter(hermes_home=hermes_home, hermes_bin=HERMES_BIN)
-    existing = _find_job_by_name(adapter.read_jobs(), JOB_NAME)
-    env = dict(os.environ)
-    env["HERMES_HOME"] = str(hermes_home)
-
-    if existing:
-        job_id = str(existing.get("job_id") or existing.get("id") or "")
-        # Update via hermes cron edit
-        completed = subprocess.run(
-            [HERMES_BIN, "cron", "edit", job_id,
-             "--schedule", SCHEDULE,
-             "--script", DEPLOY_HELPER.name,
-             "--deliver", DELIVER],
-            check=False, text=True, capture_output=True, env=env,
-        )
-        if completed.returncode != 0:
-            return {
-                "action": "update_cron_job",
-                "job_id": job_id,
-                "status": "error",
-                "stderr": (completed.stderr or completed.stdout or "").strip()[:500],
-            }
-        return {
-            "action": "update_cron_job",
-            "job_id": job_id,
-            "status": "updated",
-        }
-
-    # Create new job via hermes cron create
-    completed = subprocess.run(
-        [HERMES_BIN, "cron", "create",
-         "--name", JOB_NAME,
-         "--schedule", SCHEDULE,
-         "--script", DEPLOY_HELPER.name,
-         "--no-agent",
-         "--deliver", DELIVER],
-        check=False, text=True, capture_output=True, env=env,
-    )
-    if completed.returncode != 0:
-        return {
-            "action": "create_cron_job",
-            "status": "error",
-            "stderr": (completed.stderr or completed.stdout or "").strip()[:500],
-        }
-    created = _find_job_by_name(adapter.read_jobs(), JOB_NAME)
-    return {
-        "action": "create_cron_job",
-        "job_id": str((created or {}).get("job_id") or (created or {}).get("id") or ""),
-        "status": "applied",
-    }
-
-
-# ── repo root verification ─────────────────────────────────────────
 
 
 def _verify_written_repo_root(config_file: Path, repo_root: Path) -> None:

--- a/scripts/install_memory_os.sh
+++ b/scripts/install_memory_os.sh
@@ -728,24 +728,13 @@ run_installer() {
 	    fi
 	  done
 
-  # Create working memory cleanup cron (no_agent, watchdog pattern)
-  if command_exists hermes && [[ "${DRY_RUN}" != "1" ]]; then
-    local cron_name="memory-os-working-cleanup"
-    local cron_present=0
-    cron_present=$(hermes cron list 2>/dev/null | grep -c "${cron_name}" || true)
-    if [[ "${cron_present}" -eq 0 ]]; then
-      hermes cron create \
-        --name "${cron_name}" \
-        --schedule "0 3 * * 0" \
-        --script cleanup_expired_working.py \
-        --no-agent \
-        --deliver local 2>/dev/null && \
-        echo "  ✅ Cron '${cron_name}' created (Sun 03:00 CST, 7d retention)" || \
-        echo "  ⚠️  Could not create cron '${cron_name}' (hermes not fully configured?)"
-    else
-      echo "  ✅ Cron '${cron_name}' already exists"
-    fi
-  fi
+  # NOTE: the working-cleanup cron is NOT created here any more.
+  #
+  # working_cleanup is now a member lane of the "memory-os-tick-daily" group
+  # tick, created by memory_os_owner_cron_onboarding.py (run above when
+  # ENABLE_OWNER_CRON_ONBOARDING=1), which is the single owner of Memory-OS
+  # cron creation. Creating a standalone "memory-os-working-cleanup" job here
+  # as well would run the same lane twice on every host that has both.
 }
 
 verify_install() {

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -1344,16 +1344,18 @@ def _run_owner_cron_onboarding(
         expression_feedback_schedule,
         "--memory-sources-feedback-schedule",
         memory_sources_feedback_schedule,
-        "--candidate-aggregation-schedule",
-        "0 */6 * * *",
-        "--fact-judge-schedule",
-        "0 */4 * * *",
-        "--index-sync-schedule",
+        # These lanes are scheduled by their group ticks now. Each lane keeps
+        # its own effective cadence through due gating (due_interval_minutes
+        # in the cron registry), so the tick cadence is the only schedule the
+        # installer needs to supply.
+        "--tick-derived-schedule",
+        "*/15 * * * *",
+        "--tick-governance-schedule",
         "*/30 * * * *",
-        "--working-cleanup-schedule",
-        "0 3 * * 0",
-        "--l3-probe-schedule",
-        "0 */6 * * *",
+        "--tick-evidence-schedule",
+        "0 * * * *",
+        "--tick-daily-schedule",
+        "5 0 * * *",
         "--apply",
     ]
     if owner_approved:

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -7223,6 +7223,14 @@ def execution_gate_cron_summary():
             else:
                 naked.append(safe)
             continue
+        # Pre-consolidation per-lane jobs, superseded by a group tick. Without
+        # this they fall through to the "memory-os-" prefix branch into
+        # unregistered_like, which this same monitor reports as a FAIL.
+        if name in _legacy_per_lane_job_names() or script in _legacy_per_lane_script_names():
+            safe["known_registry_key"] = name
+            safe["known_optional_reason"] = "superseded_by_group_tick"
+            known_optional.append(safe)
+            continue
         known_spec = known_specs_by_name.get(name) or known_specs_by_wrapper.get(script) or known_specs_by_raw.get(script)
         if known_spec:
             safe["known_registry_key"] = str(known_spec.get("key") or "")
@@ -7346,6 +7354,47 @@ def _memory_os_cron_specs_from_snapshot():
         return [dict(item) for item in specs if isinstance(item, dict)]
     return []
 
+def _legacy_per_lane_cron_jobs():
+    """Pre-consolidation per-lane job name -> its legacy wrapper script.
+
+    Mirrors LEGACY_PER_LANE_CRON_JOBS in cron_registry.py.  This monitor also
+    runs as a standalone remote script where the plugin package may not be
+    importable, so it falls back to an inline copy rather than losing the
+    classification and reporting every leftover job as a FAIL.
+    """
+    try:
+        from plugins.memory.memory_os.cron_registry import LEGACY_PER_LANE_CRON_JOBS
+
+        return dict(LEGACY_PER_LANE_CRON_JOBS)
+    except Exception:
+        return {
+            "memory-os-index-sync": "memory_os_cron_index_sync_gate.py",
+            "memory-os-event-stats-refresh": "memory_os_cron_event_stats_refresh_gate.py",
+            "memory-os-state-overlay-refresh": "memory_os_cron_state_overlay_refresh_gate.py",
+            "memory-os-entity-index-refresh": "memory_os_cron_entity_index_refresh_gate.py",
+            "memory-os-proposal-followups-opsgate": "memory_os_cron_proposal_followups_opsgate_gate.py",
+            "memory-os-clearance-cycle": "memory_os_cron_clearance_cycle_gate.py",
+            "memory-os-hindsight-health-probe": "memory_os_hindsight_health_probe.py",
+            "memory-os-fact-judge": "memory_os_cron_fact_judge_gate.py",
+            "memory-os-candidate-aggregation": "memory_os_cron_candidate_aggregation_gate.py",
+            "memory-os-l3-probe-verification": "memory_os_cron_l3_probe_verification_gate.py",
+            "memory-os-v3-wandering": "memory_os_cron_v3_wandering_gate.py",
+            "memory-os-exposure-rollup": "memory_os_cron_exposure_rollup_gate.py",
+            "memory-os-v3-seed-evidence": "memory_os_cron_v3_seed_evidence_gate.py",
+            "memory-os-v3-journal-sweep": "memory_os_cron_v3_journal_sweep_gate.py",
+            "memory-os-working-cleanup": "memory_os_cron_working_cleanup_gate.py",
+            "memory-os-hindsight-advisory-digest": "memory_os_cron_hindsight_advisory_digest_gate.py",
+        }
+
+
+def _legacy_per_lane_job_names():
+    return set(_legacy_per_lane_cron_jobs())
+
+
+def _legacy_per_lane_script_names():
+    return set(_legacy_per_lane_cron_jobs().values())
+
+
 def _memory_os_known_cron_specs():
     try:
         from plugins.memory.memory_os.cron_registry import (
@@ -7438,12 +7487,24 @@ def _execution_gate_helper_completion_summary(specs_by_lane, jobs_by_name=None):
     boundary_not_required = 0
     now = datetime.now(timezone.utc)
     jobs_by_name = jobs_by_name or {}
+    # Owner-controlled per-lane disable list. Group ticks make the Hermes job
+    # granularity coarser than the lane (disabling the job now disables every
+    # member of its group), so per-lane control is restored via this list --
+    # see plugins/memory/memory_os/cron_registry.read_disabled_lane_keys.
+    try:
+        from plugins.memory.memory_os.cron_registry import read_disabled_lane_keys
+
+        disabled_lane_keys = read_disabled_lane_keys(_hermes_home)
+    except Exception:
+        disabled_lane_keys = frozenset()
     for lane in sorted(expected_lanes):
         spec = specs_by_lane.get(lane) if isinstance(specs_by_lane.get(lane), dict) else {}
         job_name = str(spec.get("name") or "")
         cron_job = jobs_by_name.get(job_name) if isinstance(jobs_by_name, dict) else {}
         record = completions.get(lane)
-        if isinstance(cron_job, dict) and cron_job.get("enabled") is False:
+        lane_key = str(spec.get("key") or "")
+        owner_disabled_lane = bool(lane_key) and lane_key in disabled_lane_keys
+        if (isinstance(cron_job, dict) and cron_job.get("enabled") is False) or owner_disabled_lane:
             disabled.append(lane)
             if record:
                 # A disabled job isn't expected to produce FRESH evidence,
@@ -7466,7 +7527,7 @@ def _execution_gate_helper_completion_summary(specs_by_lane, jobs_by_name=None):
             if isinstance(cron_job, dict) and str(cron_job.get("last_status") or "") == "ok":
                 schedule = _cron_schedule_display(cron_job)
                 last_run = _parse_monitor_timestamp(str(cron_job.get("last_run_at") or ""))
-                freshness = _helper_completion_freshness_window(schedule)
+                freshness = _helper_completion_freshness_window(schedule, spec.get("due_interval_minutes"))
                 if last_run is not None and now - last_run <= freshness:
                     # Fresh cron success is useful degraded evidence, but it is
                     # not a completion envelope and carries no boundary proof.
@@ -7478,7 +7539,7 @@ def _execution_gate_helper_completion_summary(specs_by_lane, jobs_by_name=None):
         completed.append(lane)
         schedule = _cron_schedule_display(cron_job) if isinstance(cron_job, dict) else ""
         record_time = _parse_monitor_timestamp(str(record.get("created_at") or ""))
-        freshness = _helper_completion_freshness_window(schedule)
+        freshness = _helper_completion_freshness_window(schedule, spec.get("due_interval_minutes"))
         if record_time and now - record_time > freshness:
             stale.append(lane)
         else:
@@ -7543,8 +7604,27 @@ def _cron_schedule_display(job):
         return str(schedule.get("expr") or schedule.get("display") or "")
     return str(schedule or "")
 
-def _helper_completion_freshness_window(schedule):
-    interval = _cron_schedule_interval(str(schedule or ""))
+def _lane_due_interval_timedelta(due_interval_minutes):
+    try:
+        minutes = int(due_interval_minutes)
+    except (TypeError, ValueError):
+        return None
+    if minutes <= 0:
+        return None
+    return timedelta(minutes=minutes)
+
+def _helper_completion_freshness_window(schedule, due_interval_minutes=None):
+    # Primary source: the LANE's own due_interval_minutes. After group-tick
+    # consolidation the cron job's schedule is the GROUP's cadence, which can
+    # be much faster than a slow lane sharing that tick (e.g. a 7-day lane in
+    # a daily group) -- deriving the window from the job schedule alone
+    # collapses that lane's window and reports it permanently stale. Only
+    # fall back to the group schedule when the lane interval is missing,
+    # zero, or otherwise unusable -- never fall back to a 0-length window,
+    # which would mark every lane permanently stale.
+    interval = _lane_due_interval_timedelta(due_interval_minutes)
+    if interval is None:
+        interval = _cron_schedule_interval(str(schedule or ""))
     minimum = timedelta(hours=12)
     grace = timedelta(hours=6)
     return max(interval * 2 + grace, minimum)

--- a/scripts/memory_os_cron_group_runner.py
+++ b/scripts/memory_os_cron_group_runner.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Memory-OS cron group tick runner.
+
+One Hermes cron job per *group*; this runner fires the group's due member
+lanes, each behind its own ExecutionGate permit via
+``memory_os_execution_gate_runner.run_registry_key_detailed``.
+
+Governance granularity is unchanged: every member still opens and closes its
+own permit/completion envelope with its own ``lane_id`` and ``risk_class``.
+Only the Hermes scheduling surface is consolidated.
+
+Design points that are load-bearing (see
+``docs/resolver/hermes-memory-os-cron-consolidation-plan.md``):
+
+* **Due gating.** The group's cron cadence is the *finest* member cadence.
+  Each member declares ``due_interval_minutes`` and is skipped on ticks where
+  it is not yet due, which reproduces its original effective cadence.  An
+  ``interval`` member also self-heals after downtime (the next tick sees it
+  overdue and runs it), which the old fixed-time cron could not do.
+* **Calendar members.** ``v3_seed_evidence`` is date-partitioned, so elapsed
+  gating could drift it across a UTC day boundary and skip or double-count a
+  day.  ``due_policy="calendar"`` runs it at most once per UTC calendar day,
+  on the first tick at/after its anchor.
+* **Overlap.** A non-blocking group lock means a long tick can never be
+  double-run by the next one.  Losing the lock is reported as an explicit
+  ``skipped_overlap`` status, never a silent pass.
+* **Isolation.** One member failing, timing out, or crashing must not stop the
+  rest of the tick.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from memory_os_execution_gate_runner import (  # noqa: E402
+    ExecutionGateInfrastructureError,
+    run_registry_key_detailed,
+)
+
+SCHEMA_VERSION = "memory-os.cron_group_tick_report.v1"
+LANE_STATE_SCHEMA_VERSION = "memory-os.cron_lane_state.v1"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the due members of a Memory-OS cron group.")
+    parser.add_argument("--group-key", required=True)
+    parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    parser.add_argument("--smoke-mode", choices=("normal", "safe", "render-only", "natural"), default="normal")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run every enabled member regardless of due state (manual/diagnostic use).",
+    )
+    parser.add_argument("--now", default="", help="Override current UTC time (ISO-8601). Testing only.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    now = _parse_iso(str(args.now)) if str(args.now) else datetime.now(timezone.utc)
+    if now is None:
+        sys.stderr.write(f"invalid --now value: {args.now}\n")
+        return 2
+    report = run_group(
+        str(args.group_key),
+        hermes_home=Path(args.hermes_home).expanduser(),
+        smoke_mode=str(args.smoke_mode),
+        force=bool(args.force),
+        now=now,
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return int(report.get("returncode") or 0)
+
+
+def run_group(
+    group_key: str,
+    *,
+    hermes_home: Path,
+    smoke_mode: str = "normal",
+    force: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    now = now or datetime.now(timezone.utc)
+    group, members = _load_group(hermes_home, group_key)
+    if not group:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "error",
+            "group_key": group_key,
+            "error_code": "unknown_cron_group",
+            "returncode": 2,
+            "members": [],
+        }
+
+    lock_path = _group_lock_path(hermes_home, group_key)
+    try:
+        lock = _try_exclusive_lock(lock_path)
+    except OSError as exc:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "error",
+            "group_key": group_key,
+            "error_code": "group_lock_unavailable",
+            "error_detail": str(exc)[:200],
+            "returncode": 3,
+            "members": [],
+        }
+    if lock is None:
+        # A previous tick of this same group is still running.  Reported
+        # explicitly so the monitor can see a tick that is overrunning its
+        # cadence; skipping silently would hide a real capacity problem.
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "skipped_overlap",
+            "group_key": group_key,
+            "group_name": group.get("name", ""),
+            "returncode": 0,
+            "skipped_overlap_count": 1,
+            "members": [],
+        }
+
+    try:
+        disabled = _read_disabled_lane_keys(hermes_home)
+        state = _read_lane_state(hermes_home)
+        lanes = state.setdefault("lanes", {})
+        results: list[dict[str, Any]] = []
+        worst_returncode = 0
+        for spec in members:
+            key = str(spec.get("key") or "")
+            entry = lanes.get(key) if isinstance(lanes.get(key), dict) else {}
+            if key in disabled:
+                results.append({"key": key, "lane_id": spec.get("lane_id", ""), "status": "skipped_disabled"})
+                continue
+            due, reason = _is_due(spec, entry, now=now, force=force)
+            if not due:
+                results.append(
+                    {
+                        "key": key,
+                        "lane_id": spec.get("lane_id", ""),
+                        "status": "skipped_not_due",
+                        "reason": reason,
+                    }
+                )
+                continue
+            started_at = now.isoformat().replace("+00:00", "Z")
+            try:
+                outcome = run_registry_key_detailed(
+                    key,
+                    hermes_home=hermes_home,
+                    smoke_mode=smoke_mode,
+                    timeout_seconds=int(spec.get("timeout_seconds") or 0) or None,
+                )
+            except ExecutionGateInfrastructureError as exc:
+                # Journal/sidecar failure for this member.  Record it and keep
+                # going: the remaining members are independent lanes and must
+                # not be silently dropped because one lane's bookkeeping broke.
+                outcome = {
+                    "status": "infrastructure_error",
+                    "error_code": exc.code,
+                    "returncode": 3,
+                }
+            except Exception as exc:  # noqa: BLE001 - member isolation boundary
+                outcome = {
+                    "status": "error",
+                    "error_code": "member_unhandled_exception",
+                    "error_detail": f"{type(exc).__name__}: {exc}"[:200],
+                    "returncode": 3,
+                }
+            returncode = int(outcome.get("returncode") or 0)
+            worst_returncode = max(worst_returncode, returncode)
+            # Record the attempt (not just successes) so a persistently
+            # failing lane retries at its normal cadence instead of on every
+            # tick.  Failures stay visible through the ExecutionGate journal.
+            lanes[key] = {
+                "last_started_at": started_at,
+                "last_status": str(outcome.get("status") or ""),
+                "last_returncode": returncode,
+                "last_envelope_id": str(outcome.get("execution_gate_envelope_id") or ""),
+            }
+            member_result = {
+                "key": key,
+                "lane_id": spec.get("lane_id", ""),
+                "status": str(outcome.get("status") or ""),
+                "returncode": returncode,
+            }
+            if outcome.get("error_code"):
+                member_result["error_code"] = str(outcome.get("error_code"))
+            if outcome.get("error_detail"):
+                member_result["error_detail"] = str(outcome.get("error_detail"))
+            results.append(member_result)
+        state["schema_version"] = LANE_STATE_SCHEMA_VERSION
+        state["updated_at"] = now.isoformat().replace("+00:00", "Z")
+        state_error = ""
+        try:
+            _write_lane_state(hermes_home, state)
+        except OSError as exc:
+            # Losing the state write means the next tick re-runs members that
+            # already ran.  Surface it rather than passing silently.
+            state_error = str(exc)[:200]
+            worst_returncode = max(worst_returncode, 3)
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "status": "ok" if worst_returncode == 0 else "error",
+            "group_key": group_key,
+            "group_name": group.get("name", ""),
+            "ran_at": now.isoformat().replace("+00:00", "Z"),
+            "member_total": len(members),
+            "member_ran_count": sum(1 for item in results if item.get("status") not in _SKIPPED_STATUSES),
+            "member_skipped_not_due_count": sum(1 for item in results if item.get("status") == "skipped_not_due"),
+            "member_skipped_disabled_count": sum(1 for item in results if item.get("status") == "skipped_disabled"),
+            "member_error_count": sum(1 for item in results if int(item.get("returncode") or 0) != 0),
+            "returncode": worst_returncode,
+            "members": results,
+        }
+        if state_error:
+            report["error_code"] = "lane_state_write_failed"
+            report["error_detail"] = state_error
+        return report
+    finally:
+        _release_lock(lock)
+
+
+_SKIPPED_STATUSES = frozenset({"skipped_not_due", "skipped_disabled"})
+
+
+# ── due evaluation ────────────────────────────────────────────────────
+
+
+def _is_due(spec: dict[str, Any], entry: dict[str, Any], *, now: datetime, force: bool) -> tuple[bool, str]:
+    if force:
+        return True, "forced"
+    last_started = _parse_iso(str(entry.get("last_started_at") or ""))
+    if last_started is None:
+        return True, "no_previous_run"
+    policy = str(spec.get("due_policy") or "interval")
+    if policy == "calendar":
+        anchor_minutes = _anchor_minutes(str(spec.get("calendar_anchor") or "00:00"))
+        if last_started.astimezone(timezone.utc).date() >= now.astimezone(timezone.utc).date():
+            return False, "already_ran_today"
+        if (now.hour * 60 + now.minute) < anchor_minutes:
+            return False, "before_calendar_anchor"
+        return True, "calendar_day_due"
+    try:
+        interval_minutes = int(spec.get("due_interval_minutes") or 0)
+    except (TypeError, ValueError):
+        interval_minutes = 0
+    if interval_minutes <= 0:
+        # A zero/garbage interval must not mean "run every tick".  Treat it as
+        # daily, matching the registry's own fallback.
+        interval_minutes = 1440
+    # Tolerance: cron ticks jitter by seconds, so a lane whose interval is an
+    # exact multiple of the tick would otherwise alternate run/skip.
+    tolerance = timedelta(seconds=30)
+    if now - last_started + tolerance >= timedelta(minutes=interval_minutes):
+        return True, "interval_elapsed"
+    return False, "interval_not_elapsed"
+
+
+def _anchor_minutes(anchor: str) -> int:
+    parts = str(anchor or "").split(":")
+    if len(parts) != 2:
+        return 0
+    try:
+        hours, minutes = int(parts[0]), int(parts[1])
+    except ValueError:
+        return 0
+    if not (0 <= hours <= 23 and 0 <= minutes <= 59):
+        return 0
+    return hours * 60 + minutes
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
+
+
+# ── registry loading ──────────────────────────────────────────────────
+
+
+def _load_group(hermes_home: Path, group_key: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Resolve a group and its member specs.
+
+    Prefers the installed snapshot (which reflects what onboarding actually
+    installed on this host, including profile exclusions) and falls back to
+    the compiled-in registry.
+    """
+    snapshot_path = hermes_home / "memory-os" / "system" / "memory_os_cron_registry.json"
+    loaded: dict[str, Any] = {}
+    if snapshot_path.exists():
+        try:
+            parsed = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            loaded = parsed if isinstance(parsed, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            loaded = {}
+    groups = loaded.get("groups") if isinstance(loaded.get("groups"), list) else []
+    specs = loaded.get("specs") if isinstance(loaded.get("specs"), list) else []
+    group = next(
+        (item for item in groups if isinstance(item, dict) and str(item.get("key") or "") == group_key),
+        {},
+    )
+    if group and specs:
+        by_key = {str(item.get("key") or ""): item for item in specs if isinstance(item, dict)}
+        members = [by_key[key] for key in group.get("member_keys", []) if key in by_key]
+        if members:
+            return group, members
+    return _load_group_from_registry(group_key)
+
+
+def _load_group_from_registry(group_key: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    try:
+        from plugins.memory.memory_os.cron_registry import (
+            memory_os_cron_group_by_key,
+            memory_os_cron_spec_by_key,
+        )
+    except Exception:  # noqa: BLE001 - registry unavailable in installed layout
+        return {}, []
+    group = memory_os_cron_group_by_key(group_key)
+    if not group:
+        return {}, []
+    members = []
+    for key in group.member_keys:
+        spec = memory_os_cron_spec_by_key(key)
+        if spec:
+            members.append(spec.to_json())
+    return group.to_json(), members
+
+
+def _read_disabled_lane_keys(hermes_home: Path) -> frozenset[str]:
+    path = hermes_home / "memory-os" / "system" / "cron_lane_disabled.json"
+    if not path.exists():
+        return frozenset()
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # A corrupt disable list must never silently stop governed lanes.
+        return frozenset()
+    entries = loaded.get("disabled_lane_keys") if isinstance(loaded, dict) else loaded
+    if not isinstance(entries, list):
+        return frozenset()
+    return frozenset(str(entry) for entry in entries if str(entry))
+
+
+# ── lane state ────────────────────────────────────────────────────────
+
+
+def _lane_state_path(hermes_home: Path) -> Path:
+    return hermes_home / "memory-os" / "system" / "cron_lane_state.json"
+
+
+def _read_lane_state(hermes_home: Path) -> dict[str, Any]:
+    path = _lane_state_path(hermes_home)
+    if not path.exists():
+        return {"schema_version": LANE_STATE_SCHEMA_VERSION, "lanes": {}}
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # Unreadable state means "nothing has run"; every member becomes due.
+        # That is the safe direction -- it re-runs idempotent lanes rather
+        # than silently starving them forever.
+        return {"schema_version": LANE_STATE_SCHEMA_VERSION, "lanes": {}}
+    if not isinstance(loaded, dict):
+        return {"schema_version": LANE_STATE_SCHEMA_VERSION, "lanes": {}}
+    if not isinstance(loaded.get("lanes"), dict):
+        loaded["lanes"] = {}
+    return loaded
+
+
+def _write_lane_state(hermes_home: Path, state: dict[str, Any]) -> None:
+    path = _lane_state_path(hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+# ── group lock ────────────────────────────────────────────────────────
+
+
+def _group_lock_path(hermes_home: Path, group_key: str) -> Path:
+    return hermes_home / "memory-os" / "system" / "execution_gate" / f".cron_group_{group_key}.lock"
+
+
+def _try_exclusive_lock(path: Path):
+    """Non-blocking exclusive lock. Returns a handle, or None if already held."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+b")
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        handle.close()
+        return None
+    return handle
+
+
+def _release_lock(handle) -> None:
+    if handle is None:
+        return
+    try:
+        handle.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+    finally:
+        handle.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory_os_cron_tick_daily.py
+++ b/scripts/memory_os_cron_tick_daily.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from memory_os_cron_group_runner import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--group-key", "tick_daily"]))

--- a/scripts/memory_os_cron_tick_derived.py
+++ b/scripts/memory_os_cron_tick_derived.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from memory_os_cron_group_runner import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--group-key", "tick_derived"]))

--- a/scripts/memory_os_cron_tick_evidence.py
+++ b/scripts/memory_os_cron_tick_evidence.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from memory_os_cron_group_runner import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--group-key", "tick_evidence"]))

--- a/scripts/memory_os_cron_tick_governance.py
+++ b/scripts/memory_os_cron_tick_governance.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from memory_os_cron_group_runner import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["--group-key", "tick_governance"]))

--- a/scripts/memory_os_execution_gate_runner.py
+++ b/scripts/memory_os_execution_gate_runner.py
@@ -31,6 +31,14 @@ from typing import Any
 SCHEMA_VERSION = "memory-os.execution_gate_envelope.v0"
 HELPER_REPORT_SCHEMA_VERSION = "memory-os.helper_execution_report.v0"
 SIDECAR_LOCK_TIMEOUT_SECONDS = 15.0
+# Backstop for lanes whose registry entry carries no explicit timeout.
+DEFAULT_HELPER_TIMEOUT_SECONDS = 300
+# Retention for the O(1) sidecar index.  Entries are only consulted while an
+# envelope is live (permit -> completion), so a few days of history is ample;
+# a missed lookup falls back to the full-scan rebuild in execution_gate.py.
+# Without a cap this file grew one entry per envelope forever while being
+# fully rewritten on every permit and completion.
+SIDECAR_INDEX_MAX_ENTRIES = 2000
 
 
 class ExecutionGateInfrastructureError(RuntimeError):
@@ -57,10 +65,37 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def run_registry_key(registry_key: str, *, hermes_home: Path, smoke_mode: str = "normal") -> int:
+    """Run one lane behind an ExecutionGate permit. Returns its exit code."""
+    return int(
+        run_registry_key_detailed(
+            registry_key,
+            hermes_home=hermes_home,
+            smoke_mode=smoke_mode,
+        ).get("returncode")
+        or 0
+    )
+
+
+def run_registry_key_detailed(
+    registry_key: str,
+    *,
+    hermes_home: Path,
+    smoke_mode: str = "normal",
+    timeout_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Run one lane and report the outcome structurally.
+
+    ``timeout_seconds`` bounds the helper subprocess.  Under the old 1:1
+    job-per-lane layout a hung helper cost only its own lane; under group
+    ticks it would block every later member of the tick, so a bound is
+    required rather than optional.  ``None``/0 falls back to the lane's
+    registered ``timeout_seconds``.
+    """
     spec = _load_spec(hermes_home, registry_key)
     if not spec:
         sys.stderr.write(f"unknown Memory-OS cron registry key: {registry_key}\n")
-        return 2
+        return {"status": "unknown_registry_key", "error_code": "unknown_registry_key", "returncode": 2}
+    effective_timeout = int(timeout_seconds or 0) or int(spec.get("timeout_seconds") or 0) or DEFAULT_HELPER_TIMEOUT_SECONDS
     scripts_dir = Path(__file__).resolve().parent
     helper = scripts_dir / spec["raw_script"]
     boundary = {
@@ -82,14 +117,20 @@ def run_registry_key(registry_key: str, *, hermes_home: Path, smoke_mode: str = 
         )
     except ExecutionGateInfrastructureError as exc:
         sys.stderr.write(f"Memory-OS execution gate infrastructure error: {exc.code}\n")
-        return 3
+        return {"status": "infrastructure_error", "error_code": exc.code, "returncode": 3}
+    envelope_id = str(permit["execution_gate_envelope_id"])
     if permit["permit_decision"] != "allowed":
-        return 2
+        return {
+            "status": "permit_blocked",
+            "error_code": str(permit.get("permit_reason") or "permit_blocked"),
+            "execution_gate_envelope_id": envelope_id,
+            "returncode": 2,
+        }
     if not helper.is_file():
         try:
             _append_completion(
                 hermes_home=hermes_home,
-                envelope_id=permit["execution_gate_envelope_id"],
+                envelope_id=envelope_id,
                 lane_id=spec["lane_id"],
                 execution_status="helper_missing",
                 returncode=2,
@@ -100,50 +141,92 @@ def run_registry_key(registry_key: str, *, hermes_home: Path, smoke_mode: str = 
             )
         except ExecutionGateInfrastructureError as exc:
             sys.stderr.write(f"Memory-OS execution gate infrastructure error: {exc.code}\n")
-            return 3
+            return {
+                "status": "infrastructure_error",
+                "error_code": exc.code,
+                "execution_gate_envelope_id": envelope_id,
+                "returncode": 3,
+            }
         sys.stderr.write(f"Memory-OS cron helper missing: {helper.name}\n")
-        return 2
-    report_path = _helper_report_path(hermes_home, str(permit["execution_gate_envelope_id"]))
+        return {
+            "status": "helper_missing",
+            "error_code": "helper_missing",
+            "execution_gate_envelope_id": envelope_id,
+            "returncode": 2,
+        }
+    report_path = _helper_report_path(hermes_home, envelope_id)
     env = {
         **os.environ,
         "HERMES_HOME": str(hermes_home),
-        "MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID": str(permit["execution_gate_envelope_id"]),
+        "MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID": envelope_id,
         "MEMORY_OS_EXECUTION_REPORT_PATH": str(report_path),
         "MEMORY_OS_EXECUTION_SMOKE_MODE": smoke_mode,
     }
-    completed = subprocess.run(
-        [sys.executable, str(helper)],
-        check=False,
-        text=True,
-        capture_output=True,
-        env=env,
-    )
-    helper_report = _read_helper_report(report_path, completed.stdout)
+    timed_out = False
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(helper)],
+            check=False,
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=effective_timeout,
+        )
+        stdout, stderr, returncode = completed.stdout, completed.stderr, completed.returncode
+    except subprocess.TimeoutExpired as exc:
+        # The helper is killed by subprocess.run before this is raised.  Code
+        # 124 matches the timeout convention already used by the monitor's
+        # bounded collection.
+        timed_out = True
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        returncode = 124
+        sys.stderr.write(
+            f"Memory-OS cron helper timeout after {effective_timeout}s: {helper.name}\n"
+        )
+    helper_report = {} if timed_out else _read_helper_report(report_path, stdout)
     observed_boundary = helper_report.get("boundary") if isinstance(helper_report.get("boundary"), dict) else boundary
+    execution_status = "timeout" if timed_out else ("ok" if returncode == 0 else "error")
     try:
         _append_completion(
             hermes_home=hermes_home,
-            envelope_id=permit["execution_gate_envelope_id"],
+            envelope_id=envelope_id,
             lane_id=spec["lane_id"],
-            execution_status="ok" if completed.returncode == 0 else "error",
-            returncode=completed.returncode,
+            execution_status=execution_status,
+            returncode=returncode,
             smoke_mode=smoke_mode,
             boundary=observed_boundary,
             helper_report=helper_report,
-            requires_boundary_report=spec.get("requires_boundary_report", True),
+            # A timed-out helper never got to write its boundary report, so
+            # requiring one would mislabel the timeout as a boundary gap.
+            requires_boundary_report=False if timed_out else spec.get("requires_boundary_report", True),
         )
     except ExecutionGateInfrastructureError as exc:
-        if completed.stdout:
-            sys.stdout.write(completed.stdout)
-        if completed.stderr:
-            sys.stderr.write(completed.stderr)
+        if stdout:
+            sys.stdout.write(stdout)
+        if stderr:
+            sys.stderr.write(stderr)
         sys.stderr.write(f"Memory-OS execution gate infrastructure error: {exc.code}\n")
-        return 3
-    if completed.stdout:
-        sys.stdout.write(completed.stdout)
-    if completed.stderr:
-        sys.stderr.write(completed.stderr)
-    return completed.returncode
+        return {
+            "status": "infrastructure_error",
+            "error_code": exc.code,
+            "execution_gate_envelope_id": envelope_id,
+            "returncode": 3,
+        }
+    if stdout:
+        sys.stdout.write(stdout)
+    if stderr:
+        sys.stderr.write(stderr)
+    result = {
+        "status": execution_status,
+        "execution_gate_envelope_id": envelope_id,
+        "lane_id": spec["lane_id"],
+        "returncode": returncode,
+    }
+    if timed_out:
+        result["error_code"] = "helper_timeout"
+        result["error_detail"] = f"timeout_after_{effective_timeout}s"
+    return result
 
 
 def _load_spec(hermes_home: Path, registry_key: str) -> dict[str, Any] | None:
@@ -166,11 +249,18 @@ def _load_spec(hermes_home: Path, registry_key: str) -> dict[str, Any] | None:
 
 
 def _runner_spec_from_registry_item(item: dict[str, Any]) -> dict[str, Any]:
+    try:
+        timeout_seconds = int(item.get("timeout_seconds") or 0)
+    except (TypeError, ValueError):
+        timeout_seconds = 0
     return {
         "raw_script": str(item.get("raw_script") or ""),
         "lane_id": str(item.get("lane_id") or ""),
         "risk_class": str(item.get("helper_kind") or "local_helper"),
         "requires_boundary_report": bool(item.get("requires_boundary_report")),
+        # 0 means "not declared" -- the caller falls back to
+        # DEFAULT_HELPER_TIMEOUT_SECONDS rather than running unbounded.
+        "timeout_seconds": max(timeout_seconds, 0),
     }
 
 
@@ -361,11 +451,48 @@ def _update_sidecar_index(hermes_home: Path, envelope_id: str, stage: str, recor
                 entry["completion_status"] = record.get("execution_status") or record.get("completion_status")
                 entry["completed_at"] = record.get("created_at")
             loaded[envelope_id] = entry
-            _atomic_write_json(index_path, loaded)
+            _atomic_write_json(index_path, prune_sidecar_index(loaded, envelope_id))
     except ExecutionGateInfrastructureError:
         raise
     except OSError as exc:
         raise ExecutionGateInfrastructureError("sidecar_update_failed") from exc
+
+
+def prune_sidecar_index(
+    index: dict[str, Any],
+    keep_envelope_id: str = "",
+    *,
+    max_entries: int = SIDECAR_INDEX_MAX_ENTRIES,
+) -> dict[str, Any]:
+    """Bound the sidecar index to the newest ``max_entries`` envelopes.
+
+    The index is rewritten in full on every permit and completion, so
+    unbounded growth turns each cron firing into an O(N) read+write+fsync.
+    Dropping an old entry is safe: ``execution_gate.py`` rebuilds missing
+    entries from the JSONL journal on lookup miss, and entries are only
+    consulted while an envelope is live.
+
+    ``keep_envelope_id`` is never evicted -- the envelope being written must
+    survive its own prune regardless of clock skew in the sort key.
+    """
+    if max_entries <= 0 or len(index) <= max_entries:
+        return index
+
+    def sort_key(item: tuple[str, Any]) -> tuple[str, str]:
+        envelope_id, entry = item
+        if not isinstance(entry, dict):
+            return ("", envelope_id)
+        stamp = str(entry.get("permit_created_at") or entry.get("completed_at") or "")
+        # envelope_id is prefixed with a UTC timestamp, so it is a sound
+        # tiebreaker when an entry carries no usable timestamp.
+        return (stamp, envelope_id)
+
+    ordered = sorted(index.items(), key=sort_key)
+    keep_count = max_entries
+    kept = dict(ordered[-keep_count:])
+    if keep_envelope_id and keep_envelope_id not in kept and keep_envelope_id in index:
+        kept[keep_envelope_id] = index[keep_envelope_id]
+    return kept
 
 
 @contextlib.contextmanager

--- a/scripts/memory_os_monitor_dashboard_snapshot.py
+++ b/scripts/memory_os_monitor_dashboard_snapshot.py
@@ -90,12 +90,17 @@ OPTIONAL_MEMORY_OS_CRON_KEYS = frozenset({
     "clearance_cycle",
 })
 _ALL_MEMORY_OS_CRON_SPECS = memory_os_cron_specs()
+# Several lanes now share one Hermes cron job (a group tick), so a job name is
+# CORE when ANY member lane is core, and OPTIONAL only when EVERY member is
+# optional.  Classifying per lane instead would put e.g.
+# "memory-os-tick-evidence" in both sets (core fact_judge alongside optional
+# l3_probe_verification) and double-count it as both missing and paused.
 CORE_MEMORY_OS_CRON = frozenset(
     spec.name for spec in _ALL_MEMORY_OS_CRON_SPECS if spec.key not in OPTIONAL_MEMORY_OS_CRON_KEYS
 )
 OPTIONAL_MEMORY_OS_CRON = frozenset(
     spec.name for spec in _ALL_MEMORY_OS_CRON_SPECS if spec.key in OPTIONAL_MEMORY_OS_CRON_KEYS
-)
+) - CORE_MEMORY_OS_CRON
 # Keep legacy tuple for backward-compatible reference; health now uses the
 # frozensets above so paused optional jobs don't contribute to WARN.
 EXPECTED_CRON_NAMES = tuple(sorted(CORE_MEMORY_OS_CRON))

--- a/scripts/memory_os_owner_cron_onboarding.py
+++ b/scripts/memory_os_owner_cron_onboarding.py
@@ -30,7 +30,9 @@ if str(IMPORT_ROOT) not in sys.path:
     sys.path.insert(0, str(IMPORT_ROOT))
 
 from plugins.memory.memory_os.cron_registry import (
+    LEGACY_PER_LANE_CRON_JOBS,
     RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES,
+    groups_for_specs,
     memory_os_cron_specs,
     write_cron_registry_snapshot,
 )
@@ -109,7 +111,9 @@ CHANNEL_PRIORITY = (
     "sms",
 )
 
-SOURCE_EXECUTION_GATE_RUNNER = Path(__file__).resolve().parent / "memory_os_execution_gate_runner.py"
+SOURCE_SCRIPTS_DIR = Path(__file__).resolve().parent
+SOURCE_EXECUTION_GATE_RUNNER = SOURCE_SCRIPTS_DIR / "memory_os_execution_gate_runner.py"
+SOURCE_CRON_GROUP_RUNNER = SOURCE_SCRIPTS_DIR / "memory_os_cron_group_runner.py"
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -143,6 +147,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--hindsight-advisory-digest-schedule", default="20 2 * * 0")
     parser.add_argument("--hindsight-health-probe-schedule", default="33 * * * *")
     parser.add_argument("--clearance-cycle-schedule", default="*/10 * * * *")
+    # ── Group tick schedules ──────────────────────────────────────────
+    # These are the schedules that are actually installed.  A group's cadence
+    # is its finest member's; each member is additionally gated by its own
+    # due_interval_minutes, so a slower lane still runs at its own rate.
+    #
+    # The per-lane --*-schedule flags above are retained so existing callers
+    # (notably install_memory_os_plugin.py) keep parsing, but for a grouped
+    # lane they no longer control scheduling.  Passing one that differs from
+    # its default raises a deprecation finding rather than being silently
+    # ignored -- see _deprecated_schedule_findings().
+    parser.add_argument("--tick-derived-schedule", default="*/15 * * * *")
+    parser.add_argument("--tick-governance-schedule", default="*/30 * * * *")
+    parser.add_argument("--tick-evidence-schedule", default="0 * * * *")
+    parser.add_argument("--tick-daily-schedule", default="5 0 * * *")
     parser.add_argument(
         "--cron-profile",
         choices=("active-closure", "full"),
@@ -165,7 +183,7 @@ def main(argv: list[str] | None = None) -> int:
 def run_onboarding(args: argparse.Namespace) -> dict[str, Any]:
     hermes_home = Path(args.hermes_home).expanduser().resolve()
     channels = discover_owner_channels(hermes_home)
-    findings: list[dict[str, str]] = []
+    findings: list[dict[str, str]] = _deprecated_schedule_findings(args)
 
     owner_review_deliver = _resolve_deliver(
         requested=str(args.owner_review_deliver),
@@ -200,8 +218,12 @@ def run_onboarding(args: argparse.Namespace) -> dict[str, Any]:
     for spec in operational_specs:
         if not (hermes_home / "scripts" / spec["script"]).is_file():
             findings.append(_finding(f"{spec['name']}_script_missing", "error"))
-        if not (hermes_home / "scripts" / spec["raw_script"]).is_file():
-            findings.append(_finding(f"{spec['name']}_raw_script_missing", "error"))
+        # Every MEMBER helper must exist, not just the representative's --
+        # a group tick whose helper is absent would fail that lane on every
+        # tick with no install-time signal.
+        for raw_script in spec.get("raw_scripts") or [spec["raw_script"]]:
+            if not (hermes_home / "scripts" / raw_script).is_file():
+                findings.append(_finding(f"{raw_script}_raw_script_missing", "error"))
     status = "blocked" if _has_error(findings) else status
     if not _has_error(findings):
         if args.apply:
@@ -289,7 +311,10 @@ def run_onboarding(args: argparse.Namespace) -> dict[str, Any]:
                     "deliver": spec["deliver"],
                     "script": spec["script"],
                     "raw_script": spec["raw_script"],
+                    "raw_scripts": list(spec.get("raw_scripts") or [spec["raw_script"]]),
                     "registry_key": spec["registry_key"],
+                    "group_key": spec.get("group_key", ""),
+                    "member_keys": list(spec.get("member_keys") or []),
                     "no_agent": spec["no_agent"],
                     "status": "dry_run",
                 }
@@ -323,22 +348,49 @@ def run_onboarding(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+def _selected_lane_specs(args: argparse.Namespace) -> tuple[Any, ...]:
+    """Lane specs this profile installs (one per ExecutionGate lane)."""
+    return tuple(
+        spec
+        for spec in memory_os_cron_specs()
+        if str(args.cron_profile) != "active-closure" or spec.key in ACTIVE_CLOSURE_CRON_KEYS
+    )
+
+
 def _operational_specs(args: argparse.Namespace, owner_deliver: str, right_brain_deliver: str) -> list[dict[str, Any]]:
+    """One entry per Hermes cron JOB (i.e. per group), not per lane.
+
+    Several lanes now share one group job, so iterating lanes here would try
+    to upsert the same job once per member.
+    """
+    selected = _selected_lane_specs(args)
+    by_name: dict[str, list[Any]] = {}
+    for spec in selected:
+        by_name.setdefault(spec.name, []).append(spec)
     specs: list[dict[str, Any]] = []
-    for cron_spec in memory_os_cron_specs():
-        if str(args.cron_profile) == "active-closure" and cron_spec.key not in ACTIVE_CLOSURE_CRON_KEYS:
+    for group in groups_for_specs(selected):
+        members = by_name.get(group.name) or []
+        if not members:
             continue
+        representative = members[0]
         specs.append(
             {
-                "_cron_spec": cron_spec,
-                "registry_key": cron_spec.key,
-                "name": cron_spec.name,
-                "schedule": _schedule_for_spec(args, cron_spec.schedule_arg),
-                "deliver": _deliver_for_spec(cron_spec.deliver_role, owner_deliver, right_brain_deliver),
-                "script": cron_spec.wrapper_script,
-                "raw_script": cron_spec.raw_script,
-                "no_agent": cron_spec.no_agent,
-                "prompt": _prompt_for_spec(cron_spec.prompt_ref),
+                "_cron_spec": representative,
+                "_group": group,
+                "_members": list(members),
+                # The representative lane key; kept because reports and
+                # _spec_by_key() address entries by registry_key.
+                "registry_key": representative.key,
+                "group_key": group.key,
+                "member_keys": list(group.member_keys),
+                "name": group.name,
+                "schedule": _schedule_for_spec(args, group.schedule_arg),
+                "deliver": _deliver_for_spec(group.deliver_role, owner_deliver, right_brain_deliver),
+                "script": group.wrapper_script,
+                "raw_script": representative.raw_script,
+                "raw_scripts": [member.raw_script for member in members],
+                "no_agent": group.no_agent,
+                "prompt": _prompt_for_spec(group.prompt_ref),
             }
         )
     return specs
@@ -346,6 +398,45 @@ def _operational_specs(args: argparse.Namespace, owner_deliver: str, right_brain
 
 def _schedule_for_spec(args: argparse.Namespace, schedule_arg: str) -> str:
     return str(getattr(args, schedule_arg))
+
+
+# Per-lane schedule flag -> (its historical default, the group flag that now
+# controls it).  Kept parseable for existing callers, but a caller that sets
+# one to a NON-default value would otherwise have its intent silently
+# discarded, so that case is reported.
+SUPERSEDED_SCHEDULE_ARGS: dict[str, tuple[str, str]] = {
+    "index_sync_schedule": ("*/30 * * * *", "--tick-derived-schedule"),
+    "event_stats_refresh_schedule": ("7,22,37,52 * * * *", "--tick-derived-schedule"),
+    "state_overlay_refresh_schedule": ("17,47 * * * *", "--tick-derived-schedule"),
+    "entity_index_refresh_schedule": ("25,55 * * * *", "--tick-derived-schedule"),
+    "proposal_followups_schedule": ("*/30 * * * *", "--tick-governance-schedule"),
+    "clearance_cycle_schedule": ("*/10 * * * *", "--tick-governance-schedule"),
+    "hindsight_health_probe_schedule": ("33 * * * *", "--tick-evidence-schedule"),
+    "fact_judge_schedule": (DEFAULT_FACT_JUDGE_SCHEDULE, "--tick-evidence-schedule"),
+    "candidate_aggregation_schedule": ("0 */6 * * *", "--tick-evidence-schedule"),
+    "l3_probe_schedule": ("0 */6 * * *", "--tick-evidence-schedule"),
+    "v3_wandering_schedule": ("17 */6 * * *", "--tick-evidence-schedule"),
+    "exposure_rollup_schedule": ("5 0 * * *", "--tick-daily-schedule"),
+    "v3_seed_evidence_schedule": ("15 0 * * *", "--tick-daily-schedule"),
+    "v3_journal_sweep_schedule": ("30 3 * * *", "--tick-daily-schedule"),
+    "working_cleanup_schedule": ("0 3 * * 0", "--tick-daily-schedule"),
+    "hindsight_advisory_digest_schedule": ("20 2 * * 0", "--tick-daily-schedule"),
+}
+
+
+def _deprecated_schedule_findings(args: argparse.Namespace) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for arg_name, (historical_default, group_flag) in sorted(SUPERSEDED_SCHEDULE_ARGS.items()):
+        value = str(getattr(args, arg_name, "") or "")
+        if value and value != historical_default:
+            findings.append(
+                {
+                    "code": f"{arg_name}_superseded_by_group_tick",
+                    "severity": "warn",
+                    "detail": f"lane schedule is now set by {group_flag}; supplied value {value!r} is not applied",
+                }
+            )
+    return findings
 
 
 def _deliver_for_spec(role: str, owner_deliver: str, right_brain_deliver: str) -> str:
@@ -371,30 +462,45 @@ def _prompt_for_spec(prompt_ref: str) -> str:
 def _write_execution_gate_assets(*, hermes_home: Path, specs: list[dict[str, Any]]) -> None:
     scripts_dir = hermes_home / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
-    selected_specs = tuple(spec["_cron_spec"] for spec in specs)
+    # The snapshot records every installed LANE plus the GROUP jobs that
+    # schedule them.  The tick runner reads the group member lists from here,
+    # so a profile-excluded lane (e.g. clearance_cycle) must not appear.
+    selected_specs: tuple[Any, ...] = ()
+    for spec in specs:
+        selected_specs += tuple(spec.get("_members") or (spec["_cron_spec"],))
     write_cron_registry_snapshot(
         hermes_home / "memory-os" / "system" / "memory_os_cron_registry.json",
         specs=selected_specs,
+        groups=tuple(spec["_group"] for spec in specs if spec.get("_group")),
     )
-    runner_target = scripts_dir / "memory_os_execution_gate_runner.py"
-    if SOURCE_EXECUTION_GATE_RUNNER.is_file():
-        shutil.copy2(SOURCE_EXECUTION_GATE_RUNNER, runner_target)
-        runner_target.chmod(runner_target.stat().st_mode | stat.S_IXUSR)
-    else:
-        raise RuntimeError(f"execution gate runner source missing: {SOURCE_EXECUTION_GATE_RUNNER}")
+    for source in (SOURCE_EXECUTION_GATE_RUNNER, SOURCE_CRON_GROUP_RUNNER):
+        if not source.is_file():
+            raise RuntimeError(f"cron runner source missing: {source}")
+        target = scripts_dir / source.name
+        shutil.copy2(source, target)
+        target.chmod(target.stat().st_mode | stat.S_IXUSR)
     for spec in specs:
-        if str(spec["script"]) == str(spec["raw_script"]):
+        script_name = str(spec["script"])
+        if script_name == str(spec["raw_script"]):
+            # The lane's helper IS the cron entrypoint (e.g. full_monitor_refresh).
             continue
-        wrapper = scripts_dir / str(spec["script"])
-        wrapper.write_text(
-            (
-                "#!/usr/bin/env python3\n"
-                "from memory_os_execution_gate_runner import main\n\n"
-                "if __name__ == \"__main__\":\n"
-                f"    raise SystemExit(main([\"--registry-key\", \"{spec['registry_key']}\"]))\n"
-            ),
-            encoding="utf-8",
-        )
+        wrapper = scripts_dir / script_name
+        source_wrapper = SOURCE_SCRIPTS_DIR / script_name
+        if source_wrapper.is_file():
+            # Group tick shims ship in the repo; copy rather than regenerate so
+            # the deployed wrapper always matches the reviewed source.
+            shutil.copy2(source_wrapper, wrapper)
+        else:
+            # Single-lane gate shims are generated per registry key.
+            wrapper.write_text(
+                (
+                    "#!/usr/bin/env python3\n"
+                    "from memory_os_execution_gate_runner import main\n\n"
+                    "if __name__ == \"__main__\":\n"
+                    f"    raise SystemExit(main([\"--registry-key\", \"{spec['registry_key']}\"]))\n"
+                ),
+                encoding="utf-8",
+            )
         wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
 
 
@@ -507,6 +613,14 @@ def _pause_known_optional_cron_jobs(
             "memory-os-right-brain-expression": "right_brain_expression",
             "memory-os-right-brain-expression-outcome": "right_brain_expression_outcome",
         }
+    )
+    # Legacy per-lane jobs from before the group consolidation.  Their names
+    # are no longer any spec's name, so without this they would be left
+    # running alongside the group tick that replaced them -- double-running
+    # every consolidated lane.  Paused, never deleted: re-enabling them is
+    # the rollback path.
+    known_keys_by_name.update(
+        {name: "superseded_by_group_tick" for name in LEGACY_PER_LANE_CRON_JOBS}
     )
     adapter = HermesCronAdapter(hermes_home=hermes_home, hermes_bin=hermes_bin)
     results: list[dict[str, Any]] = []

--- a/tests/plugins/memory/test_memory_os_cron_registry.py
+++ b/tests/plugins/memory/test_memory_os_cron_registry.py
@@ -1,7 +1,10 @@
 import json
 
 from plugins.memory.memory_os.cron_registry import (
+    LEGACY_PER_LANE_CRON_JOB_NAMES,
     cron_registry_snapshot,
+    groups_from_snapshot,
+    memory_os_cron_groups,
     memory_os_cron_spec_by_key,
     memory_os_cron_specs,
     specs_from_snapshot,
@@ -9,18 +12,29 @@ from plugins.memory.memory_os.cron_registry import (
 )
 
 
-def test_hindsight_health_probe_is_registered_as_read_only_self_wrapper():
+def test_hindsight_health_probe_keeps_read_only_lane_identity_inside_tick_group():
+    """The lane's governance identity survives cron-group consolidation.
+
+    Its Hermes job is now the shared evidence tick, but the ExecutionGate
+    identity (lane_id, risk class, boundary contract) must be untouched --
+    that is the whole premise of merging only the scheduling surface.
+    """
     spec = memory_os_cron_spec_by_key("hindsight_health_probe")
 
     assert spec is not None
-    assert spec.name == "memory-os-hindsight-health-probe"
     assert spec.raw_script == "memory_os_hindsight_health_probe.py"
-    assert spec.wrapper_script == spec.raw_script
     assert spec.lane_id == "hindsight_health_probe"
-    assert spec.schedule_arg == "hindsight_health_probe_schedule"
+    assert spec.helper_kind == "read_only_probe"
+    assert spec.requires_boundary_report is False
+    # Scheduling surface is the group's.
+    assert spec.group_key == "tick_evidence"
+    assert spec.name == "memory-os-tick-evidence"
+    assert spec.wrapper_script == "memory_os_cron_tick_evidence.py"
+    assert spec.schedule_arg == "tick_evidence_schedule"
     assert spec.deliver_role == "local"
     assert spec.no_agent is True
-    assert spec.requires_boundary_report is False
+    # Its original hourly cadence is preserved by due gating, not by cron.
+    assert spec.due_interval_minutes == 60
 
 
 def test_full_monitor_refresh_is_registered_as_read_only_self_wrapper():
@@ -45,7 +59,7 @@ def test_cron_registry_snapshot_round_trips_all_specs(tmp_path):
     restored = specs_from_snapshot(loaded)
 
     assert written == cron_registry_snapshot(source_commit="abc123")
-    assert loaded["schema_version"] == "memory-os.cron_registry.v0"
+    assert loaded["schema_version"] == "memory-os.cron_registry.v1"
     assert loaded["source_commit"] == "abc123"
     assert [spec.key for spec in restored] == [spec.key for spec in memory_os_cron_specs()]
     assert all(
@@ -55,6 +69,64 @@ def test_cron_registry_snapshot_round_trips_all_specs(tmp_path):
     )
     assert all(spec.schedule_arg for spec in restored)
     assert all(spec.prompt_ref for spec in restored)
+    # Due metadata must survive the round trip: the monitor derives its
+    # completion-freshness window from due_interval_minutes, and a lost/zeroed
+    # value would mark every lane permanently stale.
+    assert all(spec.due_interval_minutes > 0 for spec in restored)
+    assert all(spec.timeout_seconds > 0 for spec in restored)
+    assert {spec.key: spec.due_interval_minutes for spec in restored} == {
+        spec.key: spec.due_interval_minutes for spec in memory_os_cron_specs()
+    }
+
+
+def test_snapshot_records_groups_covering_every_installed_lane(tmp_path):
+    snapshot_path = tmp_path / "memory-os" / "system" / "memory_os_cron_registry.json"
+
+    write_cron_registry_snapshot(snapshot_path)
+    loaded = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    groups = groups_from_snapshot(loaded)
+
+    assert groups, "snapshot must carry the group table the tick runner reads"
+    grouped_members = {key for group in groups for key in group.member_keys}
+    assert grouped_members == {spec.key for spec in memory_os_cron_specs()}
+    # Every lane's job name must be its group's name.
+    names = {group.name for group in groups}
+    assert {spec.name for spec in memory_os_cron_specs()} == names
+
+
+def test_specs_from_v0_snapshot_backfills_due_metadata(tmp_path):
+    """A pre-consolidation snapshot has no due metadata.
+
+    Without the compiled-in fallback these lanes would restore with a
+    0-minute interval, which makes them permanently 'due' in the tick runner
+    and permanently 'stale' in the monitor.
+    """
+    legacy = {
+        "schema_version": "memory-os.cron_registry.v0",
+        "source_commit": "old",
+        "specs": [
+            {
+                "key": "working_cleanup",
+                "name": "memory-os-working-cleanup",
+                "raw_script": "cleanup_expired_working.py",
+                "wrapper_script": "memory_os_cron_working_cleanup_gate.py",
+                "lane_id": "working_cleanup",
+                "helper_kind": "local_helper",
+                "schedule_arg": "working_cleanup_schedule",
+                "deliver_role": "local",
+                "prompt_ref": "empty",
+                "no_agent": True,
+                "requires_boundary_report": False,
+            }
+        ],
+    }
+
+    restored = specs_from_snapshot(legacy)
+
+    assert len(restored) == 1
+    assert restored[0].due_interval_minutes == 10080
+    assert restored[0].timeout_seconds > 0
+    assert restored[0].group_key == "tick_daily"
 
 
 def test_cron_registry_snapshot_can_write_active_subset(tmp_path):
@@ -66,5 +138,88 @@ def test_cron_registry_snapshot_can_write_active_subset(tmp_path):
     restored = specs_from_snapshot(loaded)
 
     assert written == cron_registry_snapshot(specs=subset)
-    assert [spec.key for spec in restored] == ["owner_review_digest", "proposal_followups_opsgate"]
+    # Order follows the registry's lane table, which is incidental here; the
+    # contract is the SET of installed lanes.
+    assert sorted(spec.key for spec in restored) == ["owner_review_digest", "proposal_followups_opsgate"]
     assert [spec.key for spec in memory_os_cron_specs()] != [spec.key for spec in restored]
+
+
+def test_subset_snapshot_narrows_group_membership_to_installed_lanes(tmp_path):
+    """A profile-excluded lane must not appear in its group's member list.
+
+    The tick runner drives execution off the snapshot's member_keys, so a
+    deferred lane left in that list would start running on the next tick --
+    exactly the silent activation clearance_cycle is being held back from.
+    """
+    snapshot_path = tmp_path / "memory-os" / "system" / "memory_os_cron_registry.json"
+    subset = tuple(spec for spec in memory_os_cron_specs() if spec.key == "proposal_followups_opsgate")
+
+    write_cron_registry_snapshot(snapshot_path, specs=subset)
+    groups = groups_from_snapshot(json.loads(snapshot_path.read_text(encoding="utf-8")))
+
+    governance = [group for group in groups if group.key == "tick_governance"]
+    assert len(governance) == 1
+    assert governance[0].member_keys == ("proposal_followups_opsgate",)
+    assert "clearance_cycle" not in governance[0].member_keys
+
+
+def test_active_closure_profile_installs_eight_hermes_cron_jobs():
+    """The point of the consolidation: 19 lanes -> 8 Hermes jobs.
+
+    Asserted on the DERIVED job count rather than a hand-typed job list, so a
+    newly registered lane joins an existing tick instead of silently adding a
+    cron job.
+    """
+    excluded = {"module_cadence_report", "clearance_cycle"}
+    active = [spec for spec in memory_os_cron_specs() if spec.key not in excluded]
+
+    assert len(active) == 19
+    assert len({spec.name for spec in active}) == 8
+
+
+def test_every_lane_resolves_to_a_group_that_lists_it():
+    groups = {group.key: group for group in memory_os_cron_groups()}
+
+    for spec in memory_os_cron_specs():
+        assert spec.group_key in groups, f"{spec.key} has no group"
+        assert spec.key in groups[spec.group_key].member_keys
+        assert spec.name == groups[spec.group_key].name
+        assert spec.wrapper_script == groups[spec.group_key].wrapper_script
+
+
+def test_legacy_per_lane_job_names_never_collide_with_active_group_jobs():
+    """A legacy name that is also a live group name would get paused as
+    superseded during onboarding, disabling a job that is still in use."""
+    active_names = {spec.name for spec in memory_os_cron_specs()}
+
+    assert not (LEGACY_PER_LANE_CRON_JOB_NAMES & active_names)
+
+
+def test_date_partitioned_lane_uses_calendar_due_policy():
+    """v3_seed_evidence emits one record per natural_date and reports
+    consecutive_valid_day_count; elapsed gating could drift it across a UTC
+    day boundary and skip or double-count a day."""
+    spec = memory_os_cron_spec_by_key("v3_seed_evidence")
+
+    assert spec is not None
+    assert spec.due_policy == "calendar"
+    assert spec.calendar_anchor == "00:00"
+
+
+def test_owner_facing_lanes_keep_dedicated_jobs():
+    """Owner messages must not be fused into a shared tick.
+
+    Each renders a distinct message through its own agent prompt and deliver
+    channel, so a shared tick would merge separate owner messages.
+    """
+    groups = {group.key: group for group in memory_os_cron_groups()}
+
+    for key in (
+        "owner_review_digest",
+        "memory_sources_feedback_request",
+        "expression_feedback_request",
+        "full_monitor_refresh",
+    ):
+        spec = memory_os_cron_spec_by_key(key)
+        assert spec is not None, key
+        assert groups[spec.group_key].member_keys == (key,), key

--- a/tests/plugins/memory/test_memory_os_entity_graph.py
+++ b/tests/plugins/memory/test_memory_os_entity_graph.py
@@ -250,7 +250,12 @@ class TestEntityIndexCronRegistration:
         from plugins.memory.memory_os.cron_registry import memory_os_cron_spec_by_key
         spec = memory_os_cron_spec_by_key("entity_index_refresh")
         assert spec is not None
-        assert spec.name == "memory-os-entity-index-refresh"
+        # Scheduled by the derived-views group tick after cron consolidation;
+        # its lane identity (helper, cadence) is what matters here.
+        assert spec.name == "memory-os-tick-derived"
+        assert spec.group_key == "tick_derived"
+        assert spec.raw_script == "memory_os_entity_index_refresh.py"
+        assert spec.due_interval_minutes == 30
         assert spec.no_agent is True
 
     def test_entity_graph_in_recall_probe(self):

--- a/tests/plugins/memory/test_memory_os_hermes_cron_adapter.py
+++ b/tests/plugins/memory/test_memory_os_hermes_cron_adapter.py
@@ -9,12 +9,16 @@ from plugins.seam.hermes_memory_os.cron_adapter import probe_hermes_cron_capabil
 
 def test_hermes_cron_adapter_classifies_wrapped_naked_and_unregistered_jobs():
     cadence = memory_os_cron_spec_by_key("module_cadence_report")
+    governance = memory_os_cron_spec_by_key("proposal_followups_opsgate")
     assert cadence is not None
+    assert governance is not None
 
     summary = classify_hermes_cron_jobs(
         [
             {"name": cadence.name, "script": cadence.wrapper_script, "enabled": True},
-            {"name": "memory-os-proposal-followups-opsgate", "script": "memory_os_proposal_followups_ops_gate.py"},
+            # "Naked": a live job name running the lane helper DIRECTLY instead
+            # of through its ExecutionGate wrapper, so it produces no permit.
+            {"name": governance.name, "script": governance.raw_script},
             {"name": "memory-os-extra", "script": "memory_os_extra.py"},
             {"name": "hermes-heartbeat", "script": "hermes_heartbeat.py"},
         ],
@@ -25,7 +29,8 @@ def test_hermes_cron_adapter_classifies_wrapped_naked_and_unregistered_jobs():
     assert summary["memory_os_owned_naked_count"] == 1
     assert summary["memory_os_like_unregistered_count"] == 1
     assert summary["hermes_host_owned_count"] == 1
-    assert summary["active_registry_job_count"] == len(memory_os_cron_specs())
+    # One entry per Hermes JOB, not per lane -- several lanes share a group tick.
+    assert summary["active_registry_job_count"] == len({spec.name for spec in memory_os_cron_specs()})
     assert summary["enabled_memory_os_job_count"] == 1
 
 
@@ -68,6 +73,74 @@ def test_hermes_cron_adapter_separates_retired_legacy_from_known_optional_jobs()
             "known_optional_reason": "not_in_active_installed_snapshot",
         }
     ]
+
+
+def test_hermes_cron_adapter_classifies_legacy_per_lane_jobs_as_superseded_known_optional():
+    # Post-consolidation registry: the passed-in "active/installed" specs are
+    # the full (already-onboarded) registry, so every spec.name is now a
+    # group tick name (e.g. "memory-os-tick-evidence"), not a per-lane name.
+    # A leftover pre-consolidation per-lane job -- name "memory-os-<lane>"
+    # running "memory_os_cron_<lane>_gate.py" -- must NOT fall through to
+    # unregistered_like (which the 3.200 monitor treats as a FAIL).
+    specs = memory_os_cron_specs()
+    jobs = [
+        {"name": "memory-os-index-sync", "script": "memory_os_cron_index_sync_gate.py", "enabled": True},
+        {"name": "memory-os-working-cleanup", "script": "memory_os_cron_working_cleanup_gate.py", "enabled": False},
+    ]
+
+    summary = legacy_cron_adapter.classify_hermes_cron_jobs(jobs, specs)
+
+    assert summary["memory_os_like_unregistered_count"] == 0
+    assert summary["memory_os_known_optional_count"] == 2
+    assert summary["enabled_known_optional_outside_active_registry_count"] == 1
+    # Total enabled Memory-OS-owned job count is unaffected by which bucket
+    # an enabled job lands in -- both known_optional and unregistered_like
+    # feed enabled_memory_os_job_count, so reclassifying must not drop it.
+    assert summary["enabled_memory_os_job_count"] == 1
+    reasons = {job["known_registry_key"]: job["known_optional_reason"] for job in summary["known_optional_jobs"]}
+    assert reasons == {
+        "memory-os-index-sync": "superseded_by_group_tick",
+        "memory-os-working-cleanup": "superseded_by_group_tick",
+    }
+
+
+def test_hermes_cron_adapter_legacy_hindsight_probe_job_gets_superseded_reason_not_generic_one():
+    # memory_os_hindsight_health_probe.py is BOTH the legacy per-lane wrapper
+    # script for "memory-os-hindsight-health-probe" AND the current
+    # hindsight_health_probe lane's raw_script (a tick_evidence member). The
+    # known_specs_by_raw lookup would match this script too and tag it
+    # "not_in_active_installed_snapshot" -- the legacy check must win first
+    # so the more precise "superseded_by_group_tick" reason is reported.
+    specs = memory_os_cron_specs()
+    jobs = [
+        {"name": "memory-os-hindsight-health-probe", "script": "memory_os_hindsight_health_probe.py", "enabled": True},
+    ]
+
+    summary = legacy_cron_adapter.classify_hermes_cron_jobs(jobs, specs)
+
+    assert summary["memory_os_like_unregistered_count"] == 0
+    assert summary["memory_os_known_optional_count"] == 1
+    job = summary["known_optional_jobs"][0]
+    assert job["known_optional_reason"] == "superseded_by_group_tick"
+    assert job["known_registry_key"] == "memory-os-hindsight-health-probe"
+
+
+def test_hermes_cron_adapter_active_tick_evidence_job_stays_wrapped_despite_hindsight_raw_script_collision():
+    # The ACTIVE group job for the tick_evidence group (whose members include
+    # the hindsight_health_probe lane) must still resolve via the by-name
+    # branch and land in "wrapped", never in the legacy known_optional bucket.
+    hindsight_lane = memory_os_cron_spec_by_key("hindsight_health_probe")
+    assert hindsight_lane is not None
+    specs = memory_os_cron_specs()
+    jobs = [
+        {"name": hindsight_lane.name, "script": hindsight_lane.wrapper_script, "enabled": True},
+    ]
+
+    summary = legacy_cron_adapter.classify_hermes_cron_jobs(jobs, specs)
+
+    assert summary["memory_os_owned_wrapped_count"] == 1
+    assert summary["memory_os_known_optional_count"] == 0
+    assert summary["memory_os_like_unregistered_count"] == 0
 
 
 def test_hermes_cron_adapters_classify_raw_script_aliases_as_enabled_retired_legacy():
@@ -208,3 +281,46 @@ def test_hermes_cron_adapter_probe_reports_timeout_as_incompatible(monkeypatch):
     assert capabilities.status == "incompatible"
     assert any(item["code"] == "hermes_cron_create_help_unavailable" for item in capabilities.findings)
     assert any(item["code"] == "hermes_cron_edit_help_unavailable" for item in capabilities.findings)
+
+
+def test_seam_adapter_classifies_legacy_per_lane_jobs_as_superseded_not_drift():
+    """Counterfactual for the PRODUCTION classification path.
+
+    memory_os_cron_adapter_probe.py imports classify_hermes_cron_jobs from the
+    seam module, and the 3.200 monitor prefers that probe's report. A leftover
+    pre-consolidation per-lane job must land in known_optional; falling through
+    to unregistered_like makes the monitor FAIL
+    (execution_gate_memory_os_cron_unregistered_like_job) on every upgraded
+    host, since group consolidation means no active spec carries those names.
+    """
+    summary = classify_hermes_cron_jobs(
+        [
+            {"name": "memory-os-index-sync", "script": "memory_os_cron_index_sync_gate.py", "enabled": False},
+            {"name": "memory-os-working-cleanup", "script": "memory_os_cron_working_cleanup_gate.py", "enabled": False},
+        ],
+        memory_os_cron_specs(),
+    )
+
+    assert summary["memory_os_like_unregistered_count"] == 0
+    assert summary["memory_os_known_optional_count"] == 2
+    assert all(
+        job["known_optional_reason"] == "superseded_by_group_tick"
+        for job in summary["known_optional_jobs"]
+    )
+
+
+def test_seam_and_memory_adapters_agree_on_legacy_per_lane_classification():
+    """The two copies of this logic must not diverge -- the seam one is what
+    production reads, the memory one is what most tests exercise."""
+    jobs = [{"name": "memory-os-fact-judge", "script": "memory_os_cron_fact_judge_gate.py", "enabled": False}]
+
+    seam = classify_hermes_cron_jobs(jobs, memory_os_cron_specs())
+    memory = legacy_cron_adapter.classify_hermes_cron_jobs(jobs, memory_os_cron_specs())
+
+    assert seam["memory_os_known_optional_count"] == memory["memory_os_known_optional_count"] == 1
+    assert seam["memory_os_like_unregistered_count"] == memory["memory_os_like_unregistered_count"] == 0
+    assert (
+        seam["known_optional_jobs"][0]["known_optional_reason"]
+        == memory["known_optional_jobs"][0]["known_optional_reason"]
+        == "superseded_by_group_tick"
+    )

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -4217,6 +4217,129 @@ def test_memory_os_cron_specs_missing_snapshot_does_not_use_private_fallback(tmp
         sys.path[:] = original_sys_path
 
 
+def test_helper_completion_freshness_window_uses_lane_interval_not_group_schedule():
+    """After group-tick consolidation the Hermes cron job's schedule is the
+    GROUP's cadence. A lane whose real cadence is slower than its group's
+    tick (e.g. working_cleanup: 7-day cadence sharing the daily tick_daily
+    group, schedule "5 0 * * *") must derive its freshness window from its
+    own due_interval_minutes, not the group schedule -- deriving it from the
+    group schedule alone collapses a ~342h window down to ~54h and reports
+    the lane permanently stale even though it ran on time."""
+    namespace: dict[str, object] = {}
+    _exec_remote_probe_prefix(namespace)
+    freshness_window = namespace["_helper_completion_freshness_window"]
+
+    lane_window = freshness_window("5 0 * * *", 10080)
+    group_only_window = freshness_window("5 0 * * *", None)
+
+    assert lane_window == timedelta(days=7) * 2 + timedelta(hours=6)
+    assert group_only_window == timedelta(hours=24) * 2 + timedelta(hours=6)
+    assert lane_window > group_only_window
+
+    # Missing/zero/garbage due_interval_minutes must fall back to the
+    # schedule-derived window, never collapse to a 0-length window (which
+    # would mark every lane permanently stale).
+    assert freshness_window("5 0 * * *", 0) == group_only_window
+    assert freshness_window("5 0 * * *", -5) == group_only_window
+    assert freshness_window("5 0 * * *", "garbage") == group_only_window
+
+
+def test_execution_gate_helper_completion_summary_weekly_lane_in_daily_group_not_falsely_stale(tmp_path):
+    """Integration-level reproduction of the working_cleanup/
+    hindsight_advisory_digest bug: a completion record 100 hours old is well
+    within the lane's real 7-day (10080-minute) cadence, but would be
+    reported stale under the group's daily schedule alone (~54h window)."""
+    namespace: dict[str, object] = {}
+    _exec_remote_probe_prefix(namespace)
+    now = datetime.now(timezone.utc)
+    system = tmp_path / "memory-os" / "system"
+    system.mkdir(parents=True)
+    completion_record = {
+        "stage": "completion",
+        "lane_id": "working_cleanup",
+        "created_at": (now - timedelta(hours=100)).isoformat(),
+        "execution_status": "ok",
+        "postcheck": {"returncode": 0},
+    }
+    (system / "execution_gate_envelopes.jsonl").write_text(json.dumps(completion_record) + "\n", encoding="utf-8")
+    namespace["_hermes_home"] = str(tmp_path)
+
+    specs_by_lane = {
+        "working_cleanup": {
+            "key": "working_cleanup",
+            "name": "memory-os-tick-daily",
+            "lane_id": "working_cleanup",
+            "due_interval_minutes": 10080,
+        }
+    }
+    jobs_by_name = {
+        "memory-os-tick-daily": {
+            "name": "memory-os-tick-daily",
+            "enabled": True,
+            "schedule": "5 0 * * *",
+        }
+    }
+
+    summary = namespace["_execution_gate_helper_completion_summary"](specs_by_lane, jobs_by_name)
+
+    assert summary["helper_completion_stale_count"] == 0
+    assert summary["helper_completion_not_due_count"] == 1
+    assert "working_cleanup" not in summary["helper_completion_stale_lanes"]
+
+
+def test_execution_gate_helper_completion_summary_respects_per_lane_disable_list(tmp_path):
+    """Group ticks make disabling the Hermes job disable every member lane.
+    Per-lane control is restored via cron_lane_disabled.json
+    (read_disabled_lane_keys) -- a lane listed there must be classified
+    disabled even though its group's cron job is still enabled (other lanes
+    in the group keep running). An existing completion record's recorded
+    boundary evidence must still be counted -- disabling must never erase
+    already-captured evidence."""
+    namespace: dict[str, object] = {}
+    _exec_remote_probe_prefix(namespace)
+    now = datetime.now(timezone.utc)
+    system = tmp_path / "memory-os" / "system"
+    system.mkdir(parents=True)
+    (system / "cron_lane_disabled.json").write_text(
+        json.dumps({"disabled_lane_keys": ["working_cleanup"]}),
+        encoding="utf-8",
+    )
+    completion_record = {
+        "stage": "completion",
+        "lane_id": "working_cleanup",
+        "created_at": (now - timedelta(hours=1)).isoformat(),
+        "execution_status": "ok",
+        "postcheck": {"returncode": 0},
+        "postcheck_boundary_true": True,
+    }
+    (system / "execution_gate_envelopes.jsonl").write_text(json.dumps(completion_record) + "\n", encoding="utf-8")
+    namespace["_hermes_home"] = str(tmp_path)
+
+    specs_by_lane = {
+        "working_cleanup": {
+            "key": "working_cleanup",
+            "name": "memory-os-tick-daily",
+            "lane_id": "working_cleanup",
+            "due_interval_minutes": 10080,
+        }
+    }
+    jobs_by_name = {
+        "memory-os-tick-daily": {
+            "name": "memory-os-tick-daily",
+            "enabled": True,
+            "schedule": "5 0 * * *",
+        }
+    }
+
+    summary = namespace["_execution_gate_helper_completion_summary"](specs_by_lane, jobs_by_name)
+
+    assert summary["helper_completion_disabled_count"] == 1
+    assert summary["helper_completion_disabled_lanes"] == ["working_cleanup"]
+    assert summary["helper_completion_missing_count"] == 0
+    # Evidence already captured before disabling must still be counted.
+    assert summary["helper_boundary_true_count"] == 1
+
+
 def test_classify_snapshot_fails_session_mirror_owner_approved_without_owner_channel_binding():
     snapshot = _healthy_snapshot()
     snapshot["session_mirror"] = {

--- a/tests/scripts/test_memory_os_cron_group_runner.py
+++ b/tests/scripts/test_memory_os_cron_group_runner.py
@@ -1,0 +1,395 @@
+"""Tests for the Memory-OS cron group tick runner.
+
+The consolidation merges 19 Hermes cron jobs into 8 group ticks while keeping
+one ExecutionGate envelope per lane. These tests pin the properties that make
+that safe: per-lane envelopes survive, a member's cadence is preserved by due
+gating rather than by cron, and one member cannot take down the tick.
+"""
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load_group_runner():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "memory_os_cron_group_runner", SCRIPTS_DIR / "memory_os_cron_group_runner.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["memory_os_cron_group_runner"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_snapshot(home: Path, members, group_key="tick_test", group_name="memory-os-tick-test"):
+    """Install a synthetic group whose members are stub helpers."""
+    specs = []
+    for member in members:
+        specs.append(
+            {
+                "key": member["key"],
+                "name": group_name,
+                "raw_script": member["raw_script"],
+                "wrapper_script": "memory_os_cron_tick_test.py",
+                "lane_id": member.get("lane_id", member["key"]),
+                "helper_kind": "local_helper",
+                "schedule_arg": "tick_test_schedule",
+                "deliver_role": "local",
+                "prompt_ref": "empty",
+                "no_agent": True,
+                "requires_boundary_report": False,
+                "group_key": group_key,
+                "due_policy": member.get("due_policy", "interval"),
+                "due_interval_minutes": member.get("due_interval_minutes", 30),
+                "calendar_anchor": member.get("calendar_anchor", ""),
+                "timeout_seconds": member.get("timeout_seconds", 30),
+            }
+        )
+    snapshot = {
+        "schema_version": "memory-os.cron_registry.v1",
+        "source_commit": "test",
+        "specs": specs,
+        "groups": [
+            {
+                "key": group_key,
+                "name": group_name,
+                "wrapper_script": "memory_os_cron_tick_test.py",
+                "schedule_arg": "tick_test_schedule",
+                "default_schedule": "*/15 * * * *",
+                "deliver_role": "local",
+                "prompt_ref": "empty",
+                "no_agent": True,
+                "member_keys": [member["key"] for member in members],
+            }
+        ],
+    }
+    path = home / "memory-os" / "system" / "memory_os_cron_registry.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+
+def _stub_helper(name: str, body: str = "print('ok')\n"):
+    """Write a stub helper into the repo scripts dir the runner resolves from."""
+    path = SCRIPTS_DIR / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def stub_helpers():
+    created = []
+
+    def _make(name, body="print('ok')\n"):
+        created.append(_stub_helper(name, body))
+        return name
+
+    yield _make
+    for path in created:
+        if path.exists():
+            path.unlink()
+
+
+def _envelopes(home: Path):
+    path = home / "memory-os" / "system" / "execution_gate_envelopes.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_each_member_gets_its_own_execution_gate_envelope(tmp_path, stub_helpers):
+    """Governance granularity must survive scheduling consolidation.
+
+    If members shared one envelope, the monitor's per-lane completion,
+    boundary and risk_class accounting would collapse.
+    """
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    stub_helpers("_stub_beta.py")
+    _write_snapshot(
+        home,
+        [
+            {"key": "alpha", "raw_script": "_stub_alpha.py", "lane_id": "alpha_lane"},
+            {"key": "beta", "raw_script": "_stub_beta.py", "lane_id": "beta_lane"},
+        ],
+    )
+
+    report = runner.run_group("tick_test", hermes_home=home)
+
+    assert report["status"] == "ok"
+    assert report["member_ran_count"] == 2
+    records = _envelopes(home)
+    permits = [item for item in records if item["stage"] == "permit"]
+    completions = [item for item in records if item["stage"] == "completion"]
+    assert {item["lane_id"] for item in permits} == {"alpha_lane", "beta_lane"}
+    assert {item["lane_id"] for item in completions} == {"alpha_lane", "beta_lane"}
+    # Distinct envelope ids per lane -- never a shared group envelope.
+    assert len({item["execution_gate_envelope_id"] for item in permits}) == 2
+    assert all(item["trigger_surface"] == "hermes_cron" for item in permits)
+
+
+def test_member_not_due_is_skipped_on_the_next_tick(tmp_path, stub_helpers):
+    """A 30-minute lane inside a 15-minute tick must run every OTHER tick."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    _write_snapshot(home, [{"key": "alpha", "raw_script": "_stub_alpha.py", "due_interval_minutes": 30}])
+    start = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+
+    first = runner.run_group("tick_test", hermes_home=home, now=start)
+    too_soon = runner.run_group("tick_test", hermes_home=home, now=start + timedelta(minutes=15))
+    due_again = runner.run_group("tick_test", hermes_home=home, now=start + timedelta(minutes=30))
+
+    assert first["member_ran_count"] == 1
+    assert too_soon["member_ran_count"] == 0
+    assert too_soon["member_skipped_not_due_count"] == 1
+    assert due_again["member_ran_count"] == 1
+
+
+def test_calendar_member_runs_once_per_utc_day(tmp_path, stub_helpers):
+    """Date-partitioned lanes (v3_seed_evidence) must not drift across the day
+    boundary: elapsed gating could skip or double-count a natural_date."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_seed.py")
+    _write_snapshot(
+        home,
+        [
+            {
+                "key": "seed",
+                "raw_script": "_stub_seed.py",
+                "due_policy": "calendar",
+                "calendar_anchor": "00:00",
+                "due_interval_minutes": 1440,
+            }
+        ],
+    )
+    day1 = datetime(2026, 7, 30, 0, 5, tzinfo=timezone.utc)
+
+    first = runner.run_group("tick_test", hermes_home=home, now=day1)
+    same_day_later = runner.run_group("tick_test", hermes_home=home, now=day1 + timedelta(hours=20))
+    next_day = runner.run_group("tick_test", hermes_home=home, now=day1 + timedelta(days=1))
+
+    assert first["member_ran_count"] == 1
+    assert same_day_later["member_ran_count"] == 0
+    assert same_day_later["members"][0]["reason"] == "already_ran_today"
+    assert next_day["member_ran_count"] == 1
+
+
+def test_calendar_member_waits_for_its_anchor(tmp_path, stub_helpers):
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_seed.py")
+    _write_snapshot(
+        home,
+        [
+            {
+                "key": "seed",
+                "raw_script": "_stub_seed.py",
+                "due_policy": "calendar",
+                "calendar_anchor": "06:00",
+                "due_interval_minutes": 1440,
+            }
+        ],
+    )
+    day1 = datetime(2026, 7, 30, 8, 0, tzinfo=timezone.utc)
+    runner.run_group("tick_test", hermes_home=home, now=day1)
+
+    before_anchor = runner.run_group("tick_test", hermes_home=home, now=day1 + timedelta(hours=21))
+
+    assert before_anchor["member_ran_count"] == 0
+    assert before_anchor["members"][0]["reason"] == "before_calendar_anchor"
+
+
+def test_owner_disabled_lane_is_skipped(tmp_path, stub_helpers):
+    """Per-lane disable replaces the per-job disable owners lost to grouping."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    stub_helpers("_stub_beta.py")
+    _write_snapshot(
+        home,
+        [
+            {"key": "alpha", "raw_script": "_stub_alpha.py"},
+            {"key": "beta", "raw_script": "_stub_beta.py"},
+        ],
+    )
+    disable_path = home / "memory-os" / "system" / "cron_lane_disabled.json"
+    disable_path.write_text(json.dumps({"disabled_lane_keys": ["beta"]}), encoding="utf-8")
+
+    report = runner.run_group("tick_test", hermes_home=home)
+
+    assert report["member_skipped_disabled_count"] == 1
+    assert report["member_ran_count"] == 1
+    ran = {item["key"] for item in report["members"] if item["status"] == "ok"}
+    assert ran == {"alpha"}
+
+
+def test_corrupt_disable_list_does_not_silently_stop_lanes(tmp_path, stub_helpers):
+    """A malformed disable file must fail OPEN. Failing closed would silently
+    halt governed lanes with no operator signal."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    _write_snapshot(home, [{"key": "alpha", "raw_script": "_stub_alpha.py"}])
+    disable_path = home / "memory-os" / "system" / "cron_lane_disabled.json"
+    disable_path.parent.mkdir(parents=True, exist_ok=True)
+    disable_path.write_text("{not json", encoding="utf-8")
+
+    report = runner.run_group("tick_test", hermes_home=home)
+
+    assert report["member_ran_count"] == 1
+
+
+def test_failing_member_does_not_abort_the_rest_of_the_tick(tmp_path, stub_helpers):
+    """Under 1:1 jobs a failure cost one lane. Under a tick it must still
+    cost only one lane."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_boom.py", "import sys\nsys.exit(9)\n")
+    stub_helpers("_stub_after.py")
+    _write_snapshot(
+        home,
+        [
+            {"key": "boom", "raw_script": "_stub_boom.py", "lane_id": "boom_lane"},
+            {"key": "after", "raw_script": "_stub_after.py", "lane_id": "after_lane"},
+        ],
+    )
+
+    report = runner.run_group("tick_test", hermes_home=home)
+
+    assert report["status"] == "error"
+    assert report["member_error_count"] == 1
+    statuses = {item["key"]: item["status"] for item in report["members"]}
+    assert statuses["boom"] == "error"
+    assert statuses["after"] == "ok"
+    # The later member still recorded its own completion envelope.
+    completions = [item for item in _envelopes(home) if item["stage"] == "completion"]
+    assert {item["lane_id"] for item in completions} == {"boom_lane", "after_lane"}
+
+
+def test_hanging_member_times_out_and_later_members_still_run(tmp_path, stub_helpers):
+    """subprocess.run had no timeout before consolidation; a hang would now
+    block every later member of the tick."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_hang.py", "import time\ntime.sleep(30)\n")
+    stub_helpers("_stub_after.py")
+    _write_snapshot(
+        home,
+        [
+            {"key": "hang", "raw_script": "_stub_hang.py", "lane_id": "hang_lane", "timeout_seconds": 1},
+            {"key": "after", "raw_script": "_stub_after.py", "lane_id": "after_lane"},
+        ],
+    )
+
+    report = runner.run_group("tick_test", hermes_home=home)
+
+    statuses = {item["key"]: item for item in report["members"]}
+    assert statuses["hang"]["status"] == "timeout"
+    assert statuses["hang"]["returncode"] == 124
+    assert statuses["after"]["status"] == "ok"
+    completions = {item["lane_id"]: item for item in _envelopes(home) if item["stage"] == "completion"}
+    assert completions["hang_lane"]["execution_status"] == "timeout"
+
+
+def test_overlapping_tick_is_reported_not_silently_skipped(tmp_path, stub_helpers):
+    """A tick that overruns its cadence must be visible, not a silent pass."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    _write_snapshot(home, [{"key": "alpha", "raw_script": "_stub_alpha.py"}])
+    lock_path = runner._group_lock_path(home, "tick_test")
+    held = runner._try_exclusive_lock(lock_path)
+    assert held is not None
+
+    try:
+        report = runner.run_group("tick_test", hermes_home=home)
+    finally:
+        runner._release_lock(held)
+
+    assert report["status"] == "skipped_overlap"
+    assert report["skipped_overlap_count"] == 1
+    assert report["returncode"] == 0
+    assert _envelopes(home) == []
+
+
+def test_unknown_group_key_is_an_error(tmp_path):
+    runner = _load_group_runner()
+
+    report = runner.run_group("no_such_group", hermes_home=tmp_path / "home")
+
+    assert report["status"] == "error"
+    assert report["error_code"] == "unknown_cron_group"
+    assert report["returncode"] == 2
+
+
+def test_zero_due_interval_does_not_mean_run_every_tick(tmp_path, stub_helpers):
+    """A malformed/zero interval must fall back to daily, not to 'always due'.
+
+    Treating 0 as 'run now' would silently convert a weekly lane into a
+    per-tick lane on a snapshot written by an older build.
+    """
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    _write_snapshot(home, [{"key": "alpha", "raw_script": "_stub_alpha.py", "due_interval_minutes": 0}])
+    start = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+
+    runner.run_group("tick_test", hermes_home=home, now=start)
+    soon = runner.run_group("tick_test", hermes_home=home, now=start + timedelta(minutes=20))
+
+    assert soon["member_ran_count"] == 0
+    assert soon["member_skipped_not_due_count"] == 1
+
+
+def test_force_overrides_due_gating(tmp_path, stub_helpers):
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    _write_snapshot(home, [{"key": "alpha", "raw_script": "_stub_alpha.py", "due_interval_minutes": 10080}])
+    start = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+    runner.run_group("tick_test", hermes_home=home, now=start)
+
+    forced = runner.run_group("tick_test", hermes_home=home, now=start + timedelta(minutes=1), force=True)
+
+    assert forced["member_ran_count"] == 1
+
+
+def test_lane_state_survives_across_ticks(tmp_path, stub_helpers):
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    _write_snapshot(home, [{"key": "alpha", "raw_script": "_stub_alpha.py"}])
+
+    runner.run_group("tick_test", hermes_home=home)
+
+    state = json.loads((home / "memory-os" / "system" / "cron_lane_state.json").read_text(encoding="utf-8"))
+    assert state["schema_version"] == "memory-os.cron_lane_state.v1"
+    assert state["lanes"]["alpha"]["last_status"] == "ok"
+    assert state["lanes"]["alpha"]["last_started_at"]
+
+
+def test_failed_member_still_records_attempt_so_it_retries_on_cadence(tmp_path, stub_helpers):
+    """Recording only successes would make a persistently failing lane re-run
+    on every single tick instead of at its own cadence."""
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_boom.py", "import sys\nsys.exit(3)\n")
+    _write_snapshot(home, [{"key": "boom", "raw_script": "_stub_boom.py", "due_interval_minutes": 60}])
+    start = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+
+    runner.run_group("tick_test", hermes_home=home, now=start)
+    soon = runner.run_group("tick_test", hermes_home=home, now=start + timedelta(minutes=5))
+
+    assert soon["member_ran_count"] == 0
+    assert soon["member_skipped_not_due_count"] == 1

--- a/tests/scripts/test_memory_os_execution_gate_runner.py
+++ b/tests/scripts/test_memory_os_execution_gate_runner.py
@@ -433,3 +433,55 @@ def test_execution_gate_sidecar_replace_failure_preserves_previous_index(tmp_pat
 
     assert json.loads(index_path.read_text(encoding="utf-8")) == {"existing": {"completion_count": 1}}
     assert list(index_path.parent.glob(f".{index_path.name}.*.tmp")) == []
+
+
+def _load_runner_module():
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    spec = importlib.util.spec_from_file_location(
+        "memory_os_execution_gate_runner_under_test", scripts_dir / "memory_os_execution_gate_runner.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sidecar_index_is_bounded_and_keeps_newest_entries():
+    """The sidecar index is fully rewritten on every permit AND completion.
+
+    Unbounded growth turned each cron firing into an O(N) read+write+fsync of
+    a file that gained one entry per envelope forever.
+    """
+    module = _load_runner_module()
+    index = {
+        f"xgate_{i:05d}": {"envelope_id": f"xgate_{i:05d}", "permit_created_at": f"2026-07-{(i % 28) + 1:02d}T00:00:00Z"}
+        for i in range(50)
+    }
+
+    pruned = module.prune_sidecar_index(index, max_entries=10)
+
+    assert len(pruned) == 10
+    newest = sorted(index, key=lambda k: (index[k]["permit_created_at"], k))[-10:]
+    assert set(pruned) == set(newest)
+
+
+def test_sidecar_index_prune_never_evicts_the_envelope_being_written():
+    """The live envelope must survive its own prune regardless of clock skew,
+    or its completion record would lose the permit it belongs to."""
+    module = _load_runner_module()
+    index = {
+        f"xgate_{i:05d}": {"envelope_id": f"xgate_{i:05d}", "permit_created_at": "2026-07-30T00:00:00Z"}
+        for i in range(30)
+    }
+    # An entry whose timestamp sorts oldest, i.e. first to be evicted.
+    index["xgate_live"] = {"envelope_id": "xgate_live", "permit_created_at": "1970-01-01T00:00:00Z"}
+
+    pruned = module.prune_sidecar_index(index, "xgate_live", max_entries=5)
+
+    assert "xgate_live" in pruned
+
+
+def test_sidecar_index_prune_is_a_noop_below_the_cap():
+    module = _load_runner_module()
+    index = {"xgate_a": {"envelope_id": "xgate_a"}, "xgate_b": {"envelope_id": "xgate_b"}}
+
+    assert module.prune_sidecar_index(index, max_entries=10) == index

--- a/tests/scripts/test_memory_os_l3_probe_repo_root.py
+++ b/tests/scripts/test_memory_os_l3_probe_repo_root.py
@@ -262,3 +262,27 @@ def test_deploy_l3_probe_imports_shared_markers():
         assert "_MEMORY_OS_IDENTITY_MARKERS" in source or "markers" not in source, (
             f"{func_name} should use _MEMORY_OS_IDENTITY_MARKERS, not hardcoded list"
         )
+
+
+def test_deploy_l3_probe_apply_refuses_now_that_lane_is_in_a_group_tick(tmp_path):
+    """l3_probe_verification is scheduled by memory-os-tick-evidence.
+
+    Without this guard, running deploy_l3_probe.py --apply would create the
+    old standalone "memory-os-l3-probe-verification" job alongside the tick,
+    running the same lane twice per cycle with two ExecutionGate envelopes.
+    """
+    import importlib.util
+
+    deploy_path = Path(__file__).resolve().parents[2] / "scripts" / "deploy_l3_probe.py"
+    spec = importlib.util.spec_from_file_location("deploy_l3_probe_under_test", deploy_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    result = module.run_apply(tmp_path / "home")
+
+    assert result["status"] == "blocked"
+    assert result["error_code"] == "superseded_by_group_tick"
+    assert result["superseded_by"] == "memory-os-tick-evidence"
+    assert result["actions"] == []
+    # No cron job may be created as a side effect.
+    assert not (tmp_path / "home" / "cron" / "jobs.json").exists()

--- a/tests/scripts/test_memory_os_l3_probe_repo_root.py
+++ b/tests/scripts/test_memory_os_l3_probe_repo_root.py
@@ -286,3 +286,34 @@ def test_deploy_l3_probe_apply_refuses_now_that_lane_is_in_a_group_tick(tmp_path
     assert result["actions"] == []
     # No cron job may be created as a side effect.
     assert not (tmp_path / "home" / "cron" / "jobs.json").exists()
+
+
+def _load_deploy_module():
+    import importlib.util
+
+    deploy_path = Path(__file__).resolve().parents[2] / "scripts" / "deploy_l3_probe.py"
+    spec = importlib.util.spec_from_file_location("deploy_l3_probe_plan_test", deploy_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_deploy_l3_probe_plan_does_not_ask_to_create_the_superseded_job(tmp_path, monkeypatch):
+    """Absence of the standalone job is the CORRECT post-consolidation state.
+
+    Reporting "create_cron_job" would tell an operator to do by hand exactly
+    the thing --apply now refuses, double-running the lane against the
+    memory-os-tick-evidence tick.
+    """
+    import json as _json
+
+    module = _load_deploy_module()
+    home = tmp_path / "home"
+    (home / "cron").mkdir(parents=True)
+    (home / "cron" / "jobs.json").write_text(_json.dumps({"jobs": []}), encoding="utf-8")
+
+    plan = module.run_plan(home)
+    dry_run = module.run_dry_run(home)
+
+    assert "create_cron_job" not in plan.get("needs", [])
+    assert all(cmd.get("operation") != "hermes cron create" for cmd in dry_run.get("commands", []))

--- a/tests/scripts/test_memory_os_monitor_dashboard_snapshot.py
+++ b/tests/scripts/test_memory_os_monitor_dashboard_snapshot.py
@@ -155,23 +155,21 @@ def test_execution_gate_snapshot_uses_canonical_stage_and_boundary_fields(tmp_pa
     assert snapshot["permanent_approvals"] == 0
 
 
+def _core_cron_names() -> list[str]:
+    """Core job names, derived from the registry rather than hand-typed.
+
+    A hand-typed list silently rots whenever the cron surface changes (it did
+    when per-lane jobs were consolidated into group ticks), which makes the
+    fixture assert against a job set no host actually has.
+    """
+    return sorted(_load_module().CORE_MEMORY_OS_CRON)
+
+
 def _write_jobs(home: Path) -> None:
     jobs = []
-    core_names = [
-        "memory-os-owner-review-digest",
-        "memory-os-proposal-followups-opsgate",
-        "memory-os-index-sync",
-        "memory-os-candidate-aggregation",
-        "memory-os-fact-judge",
-        "memory-os-state-overlay-refresh",
-        "memory-os-entity-index-refresh",
-        "memory-os-full-monitor-refresh",
-        "memory-os-memory-sources-feedback-request",
-    ]
-    optional_names = [
-        "memory-os-expression-feedback-request",
+    core_names = _core_cron_names()
+    optional_names = sorted(_load_module().OPTIONAL_MEMORY_OS_CRON) + [
         "memory-os-right-brain-expression",
-        "memory-os-module-cadence-report",
         "memory-os-right-brain-expression-outcome",
     ]
     for index, name in enumerate(core_names + optional_names, start=1):
@@ -296,8 +294,8 @@ def test_dashboard_snapshot_maps_read_only_evidence_without_writing_reports(tmp_
     serialized = json.dumps(snapshot, ensure_ascii=False)
 
     assert snapshot["schema_version"] == "memory-os.monitor_dashboard_snapshot.v0"
-    assert snapshot["cron"]["enabled"] == 9  # 9 core cron jobs enabled
-    assert snapshot["cron"]["core_total"] == 9
+    assert snapshot["cron"]["enabled"] == len(_core_cron_names())  # all core cron jobs enabled
+    assert snapshot["cron"]["core_total"] == len(_core_cron_names())
     assert snapshot["cron"]["optional_total"] == 2
     assert {item["key"]: item["unit"] for item in snapshot["kpis"]}["cron_ok"] == "enabled jobs"
     assert snapshot["ownerReview"]["counts"]["action_required_shown"] == 1
@@ -765,13 +763,22 @@ def test_dashboard_exposes_shared_artifact_identity_and_count_conflict(tmp_path)
     assert "source conflict · raw trend hidden" in dashboard_js
 
 
+def _job_name_for_lane(key):
+    """The Hermes job that schedules a lane (its group tick after consolidation)."""
+    from plugins.memory.memory_os.cron_registry import memory_os_cron_spec_by_key
+
+    spec = memory_os_cron_spec_by_key(key)
+    assert spec is not None, key
+    return spec.name
+
+
 def test_v3_crons_are_part_of_core_monitor_contract():
     module = _load_module()
-    assert {
-        "memory-os-v3-seed-evidence",
-        "memory-os-v3-wandering",
-        "memory-os-v3-journal-sweep",
-    }.issubset(module.CORE_MEMORY_OS_CRON)
+    names = {
+        _job_name_for_lane(key)
+        for key in ("v3_seed_evidence", "v3_wandering", "v3_journal_sweep")
+    }
+    assert names.issubset(module.CORE_MEMORY_OS_CRON)
 
 
 def test_no_agent_origin_job_is_not_misclassified_as_agent_work():
@@ -789,11 +796,11 @@ def test_no_agent_origin_job_is_not_misclassified_as_agent_work():
 
 def test_state_overlay_and_entity_index_are_part_of_core_monitor_contract():
     module = _load_module()
-    assert {
-        "memory-os-state-overlay-refresh",
-        "memory-os-entity-index-refresh",
-        "memory-os-full-monitor-refresh",
-    }.issubset(module.CORE_MEMORY_OS_CRON)
+    names = {
+        _job_name_for_lane(key)
+        for key in ("state_overlay_refresh", "entity_index_refresh", "full_monitor_refresh")
+    }
+    assert names.issubset(module.CORE_MEMORY_OS_CRON)
 
 
 def test_expression_feedback_is_optional_when_expression_is_disabled():
@@ -832,34 +839,43 @@ def test_hindsight_and_clearance_cron_are_not_left_unclassified():
     The two hindsight jobs are unconditionally onboarded on active-closure
     hosts, so their absence must WARN -- they belong in CORE.
 
-    clearance-cycle is classified OPTIONAL for exactly as long as
-    active-closure onboarding defers it (see ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
-    in memory_os_owner_cron_onboarding.py). Calling a job we deliberately do
-    not install CORE would raise a permanent missing_core WARN for its
-    expected absence. What matters either way is that it is CLASSIFIED --
-    the original bug was that all three fell through to the untracked
-    "other" bucket, so their disappearance could never be noticed.
+    Deferral of a lane (clearance_cycle) is now enforced at LANE level -- the
+    lane is left out of its group's member_keys in the installed snapshot --
+    rather than by withholding a whole cron job. Its group tick
+    (memory-os-tick-governance) is still installed for its core co-member
+    proposal_followups_opsgate, so classifying that job CORE raises no
+    spurious missing_core WARN.
+
+    The invariant that must hold either way: every CORE job name is actually
+    installed by active-closure onboarding, or the monitor WARNs forever.
     """
     module = _load_module()
     for name in (
-        "memory-os-hindsight-advisory-digest",
-        "memory-os-hindsight-health-probe",
+        _job_name_for_lane("hindsight_advisory_digest"),
+        _job_name_for_lane("hindsight_health_probe"),
     ):
         assert name in module.CORE_MEMORY_OS_CRON, name
         assert name not in module.OPTIONAL_MEMORY_OS_CRON, name
 
-    assert "memory-os-clearance-cycle" in module.OPTIONAL_MEMORY_OS_CRON
-    assert "memory-os-clearance-cycle" not in module.CORE_MEMORY_OS_CRON
+    # Nothing may be classified both CORE and OPTIONAL -- a group tick mixing
+    # core and optional members would otherwise be counted as both missing
+    # and paused.
+    assert not (module.CORE_MEMORY_OS_CRON & module.OPTIONAL_MEMORY_OS_CRON)
 
-    # The two classifications must stay in lockstep: a job excluded from the
-    # active-closure install must not be CORE, or the monitor WARNs forever.
+    # Every CORE job must be one active-closure onboarding actually installs.
+    from plugins.memory.memory_os.cron_registry import memory_os_cron_specs
+
     onboarding = _load_onboarding_module()
-    for spec_key, job_name in (("clearance_cycle", "memory-os-clearance-cycle"),):
-        if spec_key in onboarding.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS:
-            assert job_name not in module.CORE_MEMORY_OS_CRON, (
-                f"{job_name} is excluded from active-closure onboarding but "
-                "classified CORE, which would WARN on its expected absence"
-            )
+    installed_names = {
+        spec.name
+        for spec in memory_os_cron_specs()
+        if spec.key not in onboarding.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
+    }
+    missing = module.CORE_MEMORY_OS_CRON - installed_names
+    assert not missing, (
+        f"{sorted(missing)} classified CORE but not installed by active-closure "
+        "onboarding, which would WARN on their expected absence"
+    )
 
 
 def test_retired_right_brain_is_removed_from_active_cron_surface(tmp_path):

--- a/tests/scripts/test_memory_os_owner_cron_onboarding.py
+++ b/tests/scripts/test_memory_os_owner_cron_onboarding.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 
-from plugins.memory.memory_os.cron_registry import memory_os_cron_specs
+from plugins.memory.memory_os.cron_registry import memory_os_cron_spec_by_key, memory_os_cron_specs
 
 
 def _load_module():
@@ -136,6 +136,29 @@ raise SystemExit(2)
     return launcher
 
 
+def _registry_script_names() -> list[str]:
+    """Every script onboarding expects on the host, derived from the registry.
+
+    Covers each lane's helper (raw_script) plus each group's cron entrypoint
+    (wrapper_script), so adding a lane or a group tick never silently leaves
+    this fixture short.
+    """
+    names: list[str] = []
+    for spec in memory_os_cron_specs():
+        names.extend([spec.raw_script, spec.wrapper_script])
+    # Retired right-brain scripts: not in the registry any more, but several
+    # tests place them on the host to assert they get paused/retired.
+    names.extend(
+        [
+            "memory_os_right_brain_expression.py",
+            "memory_os_cron_right_brain_expression_gate.py",
+            "memory_os_right_brain_expression_outcome_cron.py",
+            "memory_os_cron_right_brain_expression_outcome_gate.py",
+        ]
+    )
+    return sorted(dict.fromkeys(names))
+
+
 def _home_with_helpers(
     tmp_path: Path,
     *,
@@ -146,52 +169,12 @@ def _home_with_helpers(
     scripts = home / "scripts"
     scripts.mkdir(parents=True)
     omitted = omit_helpers or set()
-    for helper in (
-        "memory_os_owner_review_digest.py",
-        "memory_os_cron_owner_review_digest_gate.py",
-        "memory_os_right_brain_expression.py",
-        "memory_os_cron_right_brain_expression_gate.py",
-        "memory_os_module_cadence_report_cron.py",
-        "memory_os_cron_module_cadence_report_gate.py",
-        "memory_os_right_brain_expression_outcome_cron.py",
-        "memory_os_cron_right_brain_expression_outcome_gate.py",
-        "memory_os_proposal_followups_ops_gate.py",
-        "memory_os_cron_proposal_followups_opsgate_gate.py",
-        "memory_os_expression_feedback_prompt.py",
-        "memory_os_cron_expression_feedback_request_gate.py",
-        "memory_os_memory_sources_feedback_prompt.py",
-        "memory_os_cron_memory_sources_feedback_request_gate.py",
-        "memory_os_candidate_aggregation_lane.py",
-        "memory_os_cron_candidate_aggregation_gate.py",
-        "memory_os_fact_judge_lane.py",
-        "memory_os_cron_fact_judge_gate.py",
-        "memory_os_index_sync.py",
-        "memory_os_cron_index_sync_gate.py",
-        "cleanup_expired_working.py",
-        "memory_os_cron_working_cleanup_gate.py",
-        "memory_os_l3_probe_helper.py",
-        "memory_os_cron_l3_probe_verification_gate.py",
-        "memory_os_event_stats_refresh.py",
-        "memory_os_cron_event_stats_refresh_gate.py",
-        "memory_os_exposure_rollup.py",
-        "memory_os_cron_exposure_rollup_gate.py",
-        "memory_os_full_monitor_refresh.py",
-        "memory_os_v3_seed_evidence.py",
-        "memory_os_cron_v3_seed_evidence_gate.py",
-        "memory_os_v3_journal_sweep.py",
-        "memory_os_cron_v3_journal_sweep_gate.py",
-        "memory_os_v3_wandering.py",
-        "memory_os_cron_v3_wandering_gate.py",
-        "memory_os_state_overlay_refresh.py",
-        "memory_os_cron_state_overlay_refresh_gate.py",
-        "memory_os_entity_index_refresh.py",
-        "memory_os_cron_entity_index_refresh_gate.py",
-        "memory_os_hindsight_advisory_digest.py",
-        "memory_os_cron_hindsight_advisory_digest_gate.py",
-        "memory_os_hindsight_health_probe.py",
-        "memory_os_clearance_cycle_helper.py",
-        "memory_os_cron_clearance_cycle_gate.py",
-    ):
+    # Derived from the registry rather than hand-listed: a hand-typed script
+    # list silently rots whenever the cron surface changes (it did when
+    # per-lane jobs were consolidated into group ticks), and the resulting
+    # "script_missing" finding blocks onboarding for a reason unrelated to
+    # what the test is actually asserting.
+    for helper in _registry_script_names():
         if helper in omitted:
             continue
         scripts.joinpath(helper).write_text("#!/usr/bin/env python3\n", encoding="utf-8")
@@ -256,31 +239,32 @@ def test_onboarding_dry_run_selects_detected_channel_and_does_not_create_jobs(tm
     }
     assert len(report["operational_cron_jobs"]) == len(expected_names)
     assert {job["name"] for job in report["operational_cron_jobs"]} == expected_names
-    index_sync = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-index-sync"][0]
-    assert index_sync["script"] == "memory_os_cron_index_sync_gate.py"
-    assert index_sync["raw_script"] == "memory_os_index_sync.py"
-    assert index_sync["deliver"] == "local"
-    assert index_sync["no_agent"] is True
-    exposure_rollup = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-exposure-rollup"][0]
-    assert exposure_rollup["schedule"] == "5 0 * * *"
-    assert exposure_rollup["script"] == "memory_os_cron_exposure_rollup_gate.py"
-    assert exposure_rollup["raw_script"] == "memory_os_exposure_rollup.py"
-    assert exposure_rollup["deliver"] == "local"
-    assert exposure_rollup["no_agent"] is True
-    full_monitor = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-full-monitor-refresh"][0]
+    # Each lane is now scheduled by its GROUP job. Assert the mapping via the
+    # registry so this cannot drift back into per-lane job assumptions.
+    jobs_by_name = {job["name"]: job for job in report["operational_cron_jobs"]}
+    for lane_key, expected_group_job, expected_schedule in (
+        ("index_sync", "memory-os-tick-derived", "*/15 * * * *"),
+        ("exposure_rollup", "memory-os-tick-daily", "5 0 * * *"),
+        ("hindsight_advisory_digest", "memory-os-tick-daily", "5 0 * * *"),
+        ("hindsight_health_probe", "memory-os-tick-evidence", "0 * * * *"),
+    ):
+        spec = memory_os_cron_spec_by_key(lane_key)
+        assert spec is not None, lane_key
+        assert spec.name == expected_group_job, lane_key
+        job = jobs_by_name[expected_group_job]
+        assert job["schedule"] == expected_schedule, lane_key
+        assert job["deliver"] == "local", lane_key
+        assert job["no_agent"] is True, lane_key
+        # The lane's own helper must be listed among the tick's members.
+        assert spec.raw_script in job["raw_scripts"], lane_key
+
+    # full_monitor_refresh keeps a dedicated job (heavyweight, owner-delivered).
+    full_monitor = jobs_by_name["memory-os-full-monitor-refresh"]
     assert full_monitor["schedule"] == "30 2 * * *"
     assert full_monitor["script"] == "memory_os_full_monitor_refresh.py"
     assert full_monitor["raw_script"] == "memory_os_full_monitor_refresh.py"
     assert full_monitor["deliver"] == "discord"
     assert full_monitor["no_agent"] is True
-    hindsight = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-hindsight-advisory-digest"][0]
-    assert hindsight["schedule"] == "20 2 * * 0"
-    assert hindsight["script"] == "memory_os_cron_hindsight_advisory_digest_gate.py"
-    assert hindsight["raw_script"] == "memory_os_hindsight_advisory_digest.py"
-    hindsight_health = [job for job in report["operational_cron_jobs"] if job["name"] == "memory-os-hindsight-health-probe"][0]
-    assert hindsight_health["schedule"] == "33 * * * *"
-    assert hindsight_health["script"] == "memory_os_hindsight_health_probe.py"
-    assert hindsight_health["raw_script"] == "memory_os_hindsight_health_probe.py"
     # clearance_cycle is a real registered spec whose helper and gate scripts
     # the installer already deploys, but its activation is DEFERRED (see the
     # comment on ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS): enabling it in the same
@@ -302,7 +286,8 @@ def test_onboarding_fail_closed_when_active_closure_wrapper_script_missing(tmp_p
     home = _home_with_helpers(
         tmp_path,
         platforms={"telegram": [{"id": "owner", "type": "dm", "name": "owner"}]},
-        omit_helpers={"memory_os_cron_index_sync_gate.py"},
+        # The cron entrypoint for index_sync is now its group tick wrapper.
+        omit_helpers={"memory_os_cron_tick_derived.py"},
     )
     args = module.build_parser().parse_args(
         [
@@ -320,7 +305,7 @@ def test_onboarding_fail_closed_when_active_closure_wrapper_script_missing(tmp_p
     report = module.run_onboarding(args)
 
     assert report["status"] == "blocked"
-    assert any(item["code"] == "memory-os-index-sync_script_missing" for item in report["findings"])
+    assert any(item["code"] == "memory-os-tick-derived_script_missing" for item in report["findings"])
     assert not report["operational_cron_jobs"]
 
 
@@ -380,32 +365,13 @@ def test_onboarding_apply_creates_owner_review_and_right_brain_cron_jobs(tmp_pat
     assert report["selected_owner_review_deliver"] == "telegram"
     assert report["selected_owner_review_channel"] == "telegram"
     assert report["cron_profile"] == "full"
-    assert len(report["operational_cron_jobs"]) == 21
+    # Full profile installs one job per GROUP, not per lane.
+    assert len(report["operational_cron_jobs"]) == len({spec.name for spec in memory_os_cron_specs()})
     jobs = json.loads(home.joinpath("cron", "jobs.json").read_text(encoding="utf-8"))["jobs"]
     by_name = {job["name"]: job for job in jobs}
-    assert set(by_name) == {
-        "memory-os-owner-review-digest",
-        "memory-os-module-cadence-report",
-        "memory-os-proposal-followups-opsgate",
-        "memory-os-expression-feedback-request",
-        "memory-os-memory-sources-feedback-request",
-        "memory-os-candidate-aggregation",
-        "memory-os-fact-judge",
-        "memory-os-index-sync",
-        "memory-os-event-stats-refresh",
-        "memory-os-exposure-rollup",
-        "memory-os-full-monitor-refresh",
-        "memory-os-v3-seed-evidence",
-        "memory-os-v3-wandering",
-        "memory-os-v3-journal-sweep",
-        "memory-os-state-overlay-refresh",
-        "memory-os-entity-index-refresh",
-        "memory-os-hindsight-advisory-digest",
-        "memory-os-hindsight-health-probe",
-        "memory-os-working-cleanup",
-        "memory-os-l3-probe-verification",
-        "memory-os-clearance-cycle",
-    }
+    # One Hermes job per group, derived from the registry so the expected set
+    # cannot drift from what onboarding actually installs.
+    assert set(by_name) == {spec.name for spec in memory_os_cron_specs()}
     assert by_name["memory-os-owner-review-digest"]["deliver"] == "telegram"
     assert by_name["memory-os-owner-review-digest"]["script"] == "memory_os_cron_owner_review_digest_gate.py"
     assert by_name["memory-os-owner-review-digest"]["no_agent"] is False
@@ -413,19 +379,23 @@ def test_onboarding_apply_creates_owner_review_and_right_brain_cron_jobs(tmp_pat
     assert by_name["memory-os-module-cadence-report"]["deliver"] == "local"
     assert by_name["memory-os-module-cadence-report"]["script"] == "memory_os_cron_module_cadence_report_gate.py"
     assert by_name["memory-os-module-cadence-report"]["no_agent"] is True
-    assert by_name["memory-os-hindsight-advisory-digest"]["deliver"] == "local"
-    assert by_name["memory-os-hindsight-advisory-digest"]["script"] == "memory_os_cron_hindsight_advisory_digest_gate.py"
-    assert by_name["memory-os-hindsight-advisory-digest"]["no_agent"] is True
-    assert by_name["memory-os-hindsight-advisory-digest"]["schedule_display"] == "20 2 * * 0"
-    assert by_name["memory-os-hindsight-health-probe"]["deliver"] == "local"
-    assert by_name["memory-os-hindsight-health-probe"]["script"] == "memory_os_hindsight_health_probe.py"
-    assert by_name["memory-os-hindsight-health-probe"]["no_agent"] is True
-    assert by_name["memory-os-hindsight-health-probe"]["schedule_display"] == "33 * * * *"
+    # Grouped lanes are scheduled by their tick, not by a per-lane job.
+    assert by_name["memory-os-tick-daily"]["deliver"] == "local"
+    assert by_name["memory-os-tick-daily"]["script"] == "memory_os_cron_tick_daily.py"
+    assert by_name["memory-os-tick-daily"]["no_agent"] is True
+    assert by_name["memory-os-tick-daily"]["schedule_display"] == "5 0 * * *"
+    assert memory_os_cron_spec_by_key("hindsight_advisory_digest").name == "memory-os-tick-daily"
+    assert by_name["memory-os-tick-evidence"]["deliver"] == "local"
+    assert by_name["memory-os-tick-evidence"]["script"] == "memory_os_cron_tick_evidence.py"
+    assert by_name["memory-os-tick-evidence"]["no_agent"] is True
+    assert by_name["memory-os-tick-evidence"]["schedule_display"] == "0 * * * *"
+    assert memory_os_cron_spec_by_key("hindsight_health_probe").name == "memory-os-tick-evidence"
     assert home.joinpath("scripts", "memory_os_hindsight_health_probe.py").read_text(encoding="utf-8") == "#!/usr/bin/env python3\n"
 
-    assert by_name["memory-os-proposal-followups-opsgate"]["deliver"] == "local"
-    assert by_name["memory-os-proposal-followups-opsgate"]["script"] == "memory_os_cron_proposal_followups_opsgate_gate.py"
-    assert by_name["memory-os-proposal-followups-opsgate"]["no_agent"] is True
+    assert by_name["memory-os-tick-governance"]["deliver"] == "local"
+    assert by_name["memory-os-tick-governance"]["script"] == "memory_os_cron_tick_governance.py"
+    assert by_name["memory-os-tick-governance"]["no_agent"] is True
+    assert memory_os_cron_spec_by_key("proposal_followups_opsgate").name == "memory-os-tick-governance"
     assert by_name["memory-os-expression-feedback-request"]["deliver"] == "telegram"
     assert by_name["memory-os-expression-feedback-request"]["script"] == "memory_os_cron_expression_feedback_request_gate.py"
     assert by_name["memory-os-expression-feedback-request"]["no_agent"] is False
@@ -572,10 +542,10 @@ def test_active_closure_onboarding_pauses_known_optional_memory_os_jobs(tmp_path
     jobs = json.loads(jobs_path.read_text(encoding="utf-8"))["jobs"]
     by_name = {job["name"]: job for job in jobs}
     assert by_name["memory-os-owner-review-digest"]["enabled"] is True
-    assert by_name["memory-os-proposal-followups-opsgate"]["enabled"] is True
-    assert by_name["memory-os-index-sync"]["enabled"] is True
-    assert by_name["memory-os-index-sync"]["script"] == "memory_os_cron_index_sync_gate.py"
-    assert by_name["memory-os-index-sync"]["no_agent"] is True
+    assert by_name["memory-os-tick-governance"]["enabled"] is True
+    assert by_name["memory-os-tick-derived"]["enabled"] is True
+    assert by_name["memory-os-tick-derived"]["script"] == "memory_os_cron_tick_derived.py"
+    assert by_name["memory-os-tick-derived"]["no_agent"] is True
     # Right-brain expression stays optional (not in active-closure) and gets paused
     assert by_name["memory-os-right-brain-expression"]["enabled"] is False
     assert by_name["renamed-right-brain-outcome"]["enabled"] is False

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -477,15 +477,18 @@ def test_installer_can_run_owner_cron_onboarding_with_auto_channel(tmp_path):
     by_name = {job["name"]: job for job in jobs}
     assert set(by_name) == expected_cron_names
     assert by_name["memory-os-owner-review-digest"]["deliver"] == "discord"
-    assert by_name["memory-os-proposal-followups-opsgate"]["deliver"] == "local"
-    assert by_name["memory-os-index-sync"]["deliver"] == "local"
-    assert by_name["memory-os-index-sync"]["script"] == "memory_os_cron_index_sync_gate.py"
-    assert by_name["memory-os-index-sync"]["no_agent"] is True
-    assert by_name["memory-os-hindsight-advisory-digest"]["deliver"] == "local"
-    assert by_name["memory-os-hindsight-advisory-digest"]["script"] == "memory_os_cron_hindsight_advisory_digest_gate.py"
-    assert by_name["memory-os-hindsight-advisory-digest"]["no_agent"] is True
-    assert by_name["memory-os-hindsight-advisory-digest"]["schedule_display"] == "20 2 * * 0"
-    assert home.joinpath("scripts", "memory_os_cron_hindsight_advisory_digest_gate.py").is_file()
+    # Grouped lanes are scheduled by their tick job; the installer must deploy
+    # the tick wrapper AND every member helper.
+    assert by_name["memory-os-tick-governance"]["deliver"] == "local"
+    assert by_name["memory-os-tick-derived"]["deliver"] == "local"
+    assert by_name["memory-os-tick-derived"]["script"] == "memory_os_cron_tick_derived.py"
+    assert by_name["memory-os-tick-derived"]["no_agent"] is True
+    assert by_name["memory-os-tick-daily"]["deliver"] == "local"
+    assert by_name["memory-os-tick-daily"]["script"] == "memory_os_cron_tick_daily.py"
+    assert by_name["memory-os-tick-daily"]["no_agent"] is True
+    assert by_name["memory-os-tick-daily"]["schedule_display"] == "5 0 * * *"
+    assert home.joinpath("scripts", "memory_os_cron_tick_daily.py").is_file()
+    assert home.joinpath("scripts", "memory_os_cron_group_runner.py").is_file()
     assert home.joinpath("scripts", "memory_os_hindsight_advisory_digest.py").is_file()
     hindsight_health_probe = home.joinpath("scripts", "memory_os_hindsight_health_probe.py")
     source_hindsight_health_probe = Path(__file__).resolve().parents[2].joinpath(
@@ -522,35 +525,21 @@ def test_installer_can_run_full_owner_cron_profile_when_requested(tmp_path):
 
     assert report["owner_cron_profile"] == "full"
     assert report["owner_cron_onboarding_report"]["cron_profile"] == "full"
-    assert len(report["owner_cron_onboarding_report"]["operational_cron_jobs"]) == 21
+    # One job per group, derived from the registry.
+    from plugins.memory.memory_os.cron_registry import memory_os_cron_specs as _specs
+
+    assert len(report["owner_cron_onboarding_report"]["operational_cron_jobs"]) == len(
+        {spec.name for spec in _specs()}
+    )
 
     jobs = json.loads(home.joinpath("cron", "jobs.json").read_text(encoding="utf-8"))["jobs"]
-    assert {job["name"] for job in jobs} == {
-        "memory-os-owner-review-digest",
-        "memory-os-module-cadence-report",
-        "memory-os-proposal-followups-opsgate",
-        "memory-os-expression-feedback-request",
-        "memory-os-memory-sources-feedback-request",
-        "memory-os-candidate-aggregation",
-        "memory-os-fact-judge",
-        "memory-os-index-sync",
-        "memory-os-working-cleanup",
-        "memory-os-l3-probe-verification",
-        "memory-os-event-stats-refresh",
-        "memory-os-exposure-rollup",
-        "memory-os-full-monitor-refresh",
-        "memory-os-v3-seed-evidence",
-        "memory-os-v3-wandering",
-        "memory-os-v3-journal-sweep",
-        "memory-os-state-overlay-refresh",
-        "memory-os-entity-index-refresh",
-        "memory-os-hindsight-advisory-digest",
-        "memory-os-hindsight-health-probe",
-        "memory-os-clearance-cycle",
-    }
+    assert {job["name"] for job in jobs} == {spec.name for spec in _specs()}
     by_name = {job["name"]: job for job in jobs}
-    assert by_name["memory-os-hindsight-advisory-digest"]["schedule_display"] == "20 2 * * 0"
-    assert home.joinpath("scripts", "memory_os_cron_hindsight_advisory_digest_gate.py").is_file()
+    assert by_name["memory-os-tick-daily"]["schedule_display"] == "5 0 * * *"
+    # The lane's cron entrypoint is now its group tick, backed by the shared
+    # group runner; the per-lane gate shim is no longer generated.
+    assert home.joinpath("scripts", "memory_os_cron_tick_daily.py").is_file()
+    assert home.joinpath("scripts", "memory_os_cron_group_runner.py").is_file()
 
 
 def test_installer_runs_owner_cron_onboarding_after_shell_enable(tmp_path, monkeypatch):

--- a/tests/scripts/test_memory_os_state_overlay_refresh.py
+++ b/tests/scripts/test_memory_os_state_overlay_refresh.py
@@ -258,7 +258,10 @@ class TestStateOverlayCronRegistration:
         )
         spec = memory_os_cron_spec_by_key("state_overlay_refresh")
         assert spec is not None, "state_overlay_refresh must be in MEMORY_OS_CRON_SPECS"
-        assert spec.name == "memory-os-state-overlay-refresh"
+        # Scheduled by the derived-views group tick after cron consolidation.
+        assert spec.name == "memory-os-tick-derived"
+        assert spec.group_key == "tick_derived"
+        assert spec.due_interval_minutes == 30
         assert spec.raw_script == "memory_os_state_overlay_refresh.py"
         assert spec.no_agent is True
         assert spec.helper_kind == "local_helper"


### PR DESCRIPTION
## 结论

**active-closure：19 个 Hermes cron job → 8 个**，21 条 lane 的治理粒度完全不变。

把 `MemoryOSCronSpec` 拆成两张表，**只合并调度面**：

| 表 | 数量 | 含义 |
|---|---|---|
| lanes | 21 | 治理身份：`lane_id` / `raw_script` / `helper_kind` / boundary 契约。每 lane 每次运行仍开自己的 ExecutionGate envelope |
| groups | 9 | Hermes 调度面 —— 真正被 `hermes cron create` 创建的东西 |

`MEMORY_OS_CRON_SPECS` 是两表的 join，`name`/`wrapper_script`/`schedule_arg` 从 group 派生，因此既有消费者无改动继续工作。

## 为什么必须合并（实测，非审美）

按旧 schedule 展开一天的触发时刻：**00:00 与 12:00 各有 5 个 job 同时触发**，5 个进程同时对 `execution_gate_index.json` 做「独占加锁 → 全量读 → 全量重写 → fsync」，锁超时 15 秒。超时即 runner 返回 3、该 lane 无 completion 记录 → monitor 记 `helper_completion_missing`。

同分钟并发 **5 → 1**，触发次数 **336/天 → 172/天**。

## 分组

| Group job | Schedule | Members |
|---|---|---|
| `memory-os-tick-derived` | `*/15 * * * *` | event_stats_refresh, index_sync, state_overlay_refresh, entity_index_refresh |
| `memory-os-tick-governance` | `*/30 * * * *` | proposal_followups_opsgate（clearance_cycle 仍延后） |
| `memory-os-tick-evidence` | `0 * * * *` | hindsight_health_probe, fact_judge, candidate_aggregation, l3_probe_verification, v3_wandering |
| `memory-os-tick-daily` | `5 0 * * *` | exposure_rollup, v3_seed_evidence, v3_journal_sweep, working_cleanup, hindsight_advisory_digest |
| owner 面向 ×4 | 各自原 schedule | 保持 1:1，不合并 |

各 lane 用 `due_interval_minutes` 保持自己的有效节奏；owner 面向作业各有独立 agent prompt 与 deliver 渠道，合并会把多条 owner 消息揉成一条，故保持独立。

## 两条阻断性前置（已一并落地）

**R1 — monitor 新鲜度窗口改按 lane 取。** 原本取 cron **job** 的 schedule。实算确认分组后 **4 条 lane 窗口会塌缩**：working_cleanup、hindsight_advisory_digest 342h→54h（**必然永久 stale**），candidate_aggregation 18h→12h，fact_judge 14h→12h。缺失/0/非法值回退原行为，绝不产生 0 窗口。

**R2 — 19 个旧 job 名显式分类。** 否则落入 `unregistered_like` → 每台已升级主机 monitor **FAIL**。

## 顺调用链发现并修复的同类缺陷

1. **`classify_hermes_cron_jobs` 有三份拷贝** —— 只修 memory 适配器不解决生产问题：adapter probe 导入的是 **seam** 那份，monitor 还有一份内嵌 fallback。三份已同步。
2. **dashboard CORE/OPTIONAL 集合会重叠** —— tick 同时含 core 与 optional 成员时，同一 job 既算 missing_core 又算 optional_paused。改为「任一成员 core ⇒ 整个 job core」。
3. **两处仍在直接创建 per-lane job，会导致 lane 双跑** —— `install_memory_os.sh` 自建 working-cleanup（已删除）、`deploy_l3_probe.py --apply`（改 fail-closed）。
4. **`execution_gate_index.json` 无任何裁剪**（独立缺陷，一并修）—— 每次 permit/completion 全量重写，entry 无上限增长（约 12 万/年）。新增 `prune_sidecar_index()` 保留最新 2000 条；安全性依据是 `execution_gate.py` 已有 lookup-miss 时从 JSONL 全量重建的路径。

## 分组带来的必要加固

- `subprocess.run` 原本**没有 timeout**：1:1 时一个 hang 只拖垮一条 lane，合并后拖垮整组 → 每 member timeout，超时记 124 后继续。
- group 级**非阻塞**锁：抢不到以显式 `skipped_overlap` 退出 0，不静默 pass。
- 成员失败隔离：单成员非零不终止后续成员。
- lane 级停用 `cron_lane_disabled.json`：补回 owner 丢失的单 lane 停用能力；文件损坏 fail-open。
- `due_policy="calendar"`：`v3_seed_evidence` 按 `natural_date` 分区，elapsed 门控可能跨 UTC 日界漏算/重算。已逐个核对 `exposure_rollup`（水位线、幂等）与 `working_cleanup`（纯年龄）可用 elapsed。
- `trigger_surface` 保持 `"hermes_cron"`：已核实 `resolve_trigger_class()` 只读环境变量，natural_cron 溯源不受影响。

## 验证

- **3023 → 3058 passed / 13 skipped / 0 failed**（净 +35），新增 `test_memory_os_cron_group_runner.py`（14 项），另补 2 项双跑守卫
- 静态门全过：import cycle、write surface（`unclassified=0`）、static hygiene、public checkout probe `--strict`、`git diff --check`
- R1/R2 已实测 revert→FAIL→restore→PASS

## 回滚

onboarding 只**暂停**旧 19 个 per-lane job，**不删除**。回滚 = 重新启用旧 job + 停用 8 个 group job；lane 注册表与 helper 脚本全程未动。

## 未做

- **尚未部署 3.200**，`live_monitor_pass` 未取得 —— 本次仅 `local_pass` + 静态门。
- `v3_journal_sweep` 底层模块未逐行核实是否按日分区，暂按 elapsed；若确认按日分区，改 `due_policy` 即可，无需动结构。


## 追加提交 `e8bc35c`

`deploy_l3_probe.py` 的 `--apply` 已 fail-closed，但 `run_plan`/`run_dry_run` 仍在报「需要 create_cron_job」并打印 `hermes cron create` —— 那正是 `--apply` 拒绝执行、手动执行会导致 lane 双跑的动作。现改为：残留旧 job 时报 `cleanup_superseded_cron_job`，dry-run 输出 `hermes cron remove`。

另在清单 BS 明确记录：**旧 per-lane gate shim 是有意保留的回滚基础设施**——被暂停的旧 job `script` 字段指向它们，删掉会让回滚失败。本次只移除了旧 job 的**创建**路径。
