### PR TITLE
Code review of 6273e8b: keep the recall lane live without silently resuming output mutation

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1437,6 +1437,170 @@ BU 的 installed-layout 测试本机全绿，CI 却红在反事实那条：
 
 ---
 
+## BV — 对 `6273e8b` 的代码评审与修复（2026-07-31）
+
+本机对齐 GitHub 后发现 `6273e8b`（keep recall and onboarding lanes live）尚未被任何评审节
+覆盖——清单最后一条记录停在 `3dbbb9b..HEAD`（BU.1）。逐项复审得 13 项发现：修 10 项、
+有意保留 1 项、显式记录不做 2 项。
+
+### 0. 该提交打破了 Windows 本机全绿基线，且推送前未被发现
+
+评审前实测基线：3077 passed / **1 failed** / 13 skipped，唯一失败的就是它自己新增的
+`test_execution_gate_asset_install_is_idempotent_in_installed_layout`——
+`assert stat().st_mode & 0o100` 在 Windows 上恒为 0（`chmod` 的执行位在 Windows 无效，
+`st_mode` 实测 `0o100666`）。CI 是 Linux 故绿、本机红，与 BU.1 的「CI 空过、本机绿」
+**互为镜像**，同属"跨环境测试不验证自己的前提"。BR 刚拿到的「首次全绿」被这一条打掉。
+改为 `_assert_executable_bit()`，`os.name == "nt"` 时跳过（沿用本文件已有的 nt 分支惯例）。
+
+**这首先是一条流程发现，不只是可移植性疏忽**：一条本机必红的测试被推送上了 main，
+说明 Definition of Done 第 4 步（"绝不允许只跑自己新增/修改的测试就推送"）在本次没有执行，
+或只在 Linux 一侧执行。本清单存在的意义正是记录这类流程缺口——`st_mode` 的技术解释是次要的。
+
+### 1. `apply_canary` 上「关闭开关过期 = 静默恢复输出改写」（最重一项）
+
+本提交把 `prefetch_facade_enabled` 的解析默认值从 `False` 翻成 `True`，理由是「durable mode
+才是权威，不该被临时 override 的过期拖死」。这对 `shadow` 成立——它是 output-neutral 的，
+只落 metadata-only 的 Recall Plan。
+
+但 `apply_canary` **会往 live prefetch 追加 `Recall Facade (unified)` 段**
+（`prefetch.py:636`）。而 `resolve_knobs` 对 active + provisional + **已过期** 的记录是
+`continue` 跳过、回落到调用方默认值（`knob_overrides.py:491`）。于是在 `mode=apply_canary`
+的主机上，Owner 挂的一条 provisional `false` 关闭开关一旦到期——无文件写入、无重启、
+无任何 Owner 动作——输出改写就静默恢复。**这正是本提交所修 bug 的镜像**；它自己的
+`test_expired_false_kill_switch_reenables_without_file_change` 断言的就是这个"到期即恢复"，
+只是仅覆盖了 `shadow`。
+
+新增 `_recall_facade_switch_default(mode)`：`shadow → True`（保住观测车道，即本提交本意），
+`apply_canary → False`（输出改写必须有显式且未过期的正向授权）。该默认值一并纳入缓存指纹，
+防止跨模式串用缓存。生产 3.200 当前为 `shadow`，本项无生产行为影响。
+
+### 2. kill switch 的存储路径自行拼装 = fail-open
+
+`__init__.py` 手工拼 `roots.memory_os_root/"system"/"knob_overrides.jsonl"`，绕开
+`_override_store_path()`。两者一旦分叉，`stat()` 抛 `FileNotFoundError` → 旧代码直接
+`resolved = True` 返回，**根本不调用解析器**，即 Owner 的 kill switch 被无视。
+一个未被强制的耦合，失败方向却是 fail-open——治理开关最不能容忍的方向。
+
+改为走新增的公开访问器 `knob_overrides.override_store_path()`，并**删掉「文件不存在 →
+直接 True」的短路**：文件不存在只是「没有 override」，答案仍须由解析器套用默认值给出
+（`_validate_recall_facade_override_store` 相应改为容忍不存在的 store，否则会把
+"无 override" 误判成校验失败而 fail-closed，反向踩坑）。
+
+### 3. 两个抑制错误计数器不走项目的 `error_record` 契约
+
+`_recall_facade_init_errors` 全仓库**只写不读**，注释却写着 "recorded as suppressed count
+for monitor visibility"——不实。`_recall_facade_knob_errors` 只出现在 status，
+而 monitor 对 `recall_facade` 零命中。同一特性里相邻的 `prefetch.py:640` 反而是对的
+（`build_error_record(component="prefetch_facade", ...)` 汇入 `suppressed_error_count`）。
+
+本次：两个计数器都在 status 暴露（新增 `init_error_count`）、修正不实注释。
+**monitor 接线有意未做**并登记为遗留——新增一个 WARN 码需要分类表注册 +
+`fail_if_production` 判定 + clean-host 分档，属独立一轮；与 BR 记录的
+「monitor 11 组件采集接线」同族缺口。
+
+### 4. status 无法区分「被 Owner 关掉」与「mode 本来就 off」
+
+`kill_switch_enabled` 在 `mode=off` 时同样渲染 `false`，读起来像「有人把车道杀了」；
+`effective_enabled` 则是它的纯重复字段。新增 `mode_live` 让两种状态可分辨，
+`effective_enabled` 改为显式合取。（`effective_enabled` 在构造上仍与 `kill_switch_enabled`
+数值相等，真正消歧的是 `mode_live`；该字段属已落地 schema，未删。）
+
+### 5. `_roots is None` 分支污染 init 哨兵
+
+该分支把 `_recall_facade_initialized` 置 True。哨兵语义是「构造已跑过」，在这里置真会让
+roots 事后注入之后 facade **永久返回 None**——一个哨兵表达两件事（Section W 规则 4）。
+已去掉置真。
+
+### 5.1 缓存的 facade 会被以另一个 arbitration mode 交付出去
+
+顺着第 5 项的调用链继续查出来的：`RetrieverFacade` 在**构造时**固化
+`_arbitration_mode`，而 `_recall_facade_initialized` 会在重新应用模式之前短路返回缓存对象。
+于是 `shadow` 下构造好的 facade 会被交给 `apply_canary` 的调用方（反之亦然），
+**跑的车道与 config 声明的不一致**。实测复现：翻转 mode 后拿到的对象
+`_arbitration_mode` 仍是 `shadow`。
+
+（本次为 `apply_canary` 引入的按模式取默认值已让 *开关缓存* 在模式翻转时失效——
+`default_enabled` 是指纹的一部分——但 *facade 对象* 本身不受该指纹保护，是独立的一条。）
+
+新增 `_recall_facade_mode` 记录构造时的模式，两处 `initialized` 短路都加上模式一致判断。
+
+### 6. onboarding 的 wrapper 分支无覆盖
+
+`_write_execution_gate_assets` 有**两处** `_copy_asset_if_distinct` 调用（runner 循环 +
+group tick wrapper 分支），而新测试传 `specs=[]`，只跑到第一处。反事实实测：把 wrapper
+那处改回 `shutil.copy2`，全套仍绿。新增
+`test_group_tick_wrapper_install_is_idempotent_in_installed_layout` 覆盖第二处——
+反事实下 Windows 报 `PermissionError [WinError 32]`、Linux 报 `SameFileError`，
+同一个自我复制缺陷。
+
+### 7. 150ms 到期测试是墙钟 flaky
+
+`test_expired_false_kill_switch_reenables_without_file_change` 的 150ms 窗口要覆盖一次
+治理 JSONL 写入 + provider 构造 + `stat` + 全量 `read_text` + 反向重扫，才轮到**第一条**
+断言。在产生过 BO 抖动的 mount-isolated GHA runner 上过窄；一旦超时，解析回落到新默认值
+`True`，`assert ... is None` 直接失败。窗口放宽到 3s，sleep 由实测已耗时反推。
+
+### 8. 有意保留：严格校验取全账本口径
+
+`_validate_recall_facade_override_store` 对**任意**坏行/非 dict 记录抛错，包括与本旋钮
+无关的记录；而解析器自己的 `_read_jsonl` 是**静默跳过**的。这条不对称真实存在，
+但**保留 fail-closed**：坏行无法归属到具体旋钮，把它当治理存储损坏比静默跳过更安全；
+且改它等于推翻本提交刚落地的 `test_malformed_json_kill_switch_store_fails_closed`。
+已在 docstring 写明这是有意与解析器不同，可见性由第 3 项兜底。
+
+### 9. 记录不做：缓存的热路径前提弱于其自述
+
+`prefetch()` 在 `_ensure_recall_facade()` 之前**已经**有两次未缓存的全账本 `resolve_knob()`
+（`lane_low_clue_recall_enabled`、`session_scoped_recent_events`）。为省下第三次读而引入
+~90 行缓存机制（stat 指纹 + RLock + 到期追踪 + 严格校验 + 路径重复 + fail-open 分支），
+其热路径理由因此**明显弱于自述**——缓存确实省掉了每次 prefetch 的一次读，
+但"governed file I/O 不能上热路径"这个前提在同一函数里已经被违反两次。
+`resolve_knobs()` 本就是为「一次读、N 个旋钮」而存在，
+把三者合并会把热路径 I/O 从 2 次降到 1 次，并顺带删掉缓存、锁与第 2 项的路径重复。
+**本次未做**：这是对热路径的设计改动、牵涉另外两个旋钮各自的既有测试，应单独一轮。
+
+### 反事实覆盖
+
+第 1、2、5、5.1、6 项各用 revert→fail→restore→pass 实测：
+
+- 去掉 `_recall_facade_switch_default` 的模式判别（恒 True）→
+  `test_expired_false_kill_switch_does_not_reenable_output_mutating_canary` FAIL。
+- 恢复手工拼路径 + 「文件缺失→True」短路 →
+  `test_kill_switch_is_read_from_the_resolver_owned_store_path` FAIL。
+- 恢复 `_roots is None` 的哨兵置真 →
+  `test_roots_injected_after_a_rootless_call_still_builds_the_facade` FAIL。
+- 去掉两处模式一致判断 →
+  `test_cached_facade_is_not_served_under_a_different_arbitration_mode` FAIL
+  （报出交付的是 `shadow` facade）。
+- wrapper 分支改回 `shutil.copy2` → 新增的 wrapper 测试 FAIL。
+
+（过程教训：第 5.1 项的第一次反事实是**假通过**——patch 脚本因缩进前缀互为子串而
+`assert count == 1` 中断、根本没改文件，测试自然仍绿。反事实必须确认补丁真的落了盘，
+否则"通过"证明的是补丁没生效，不是修复没必要。）
+
+另修掉该测试类原有**两条空过测试**：裸 `MemoryOSProvider()` 的 `_roots is None` 会在任何
+mode/knob 逻辑之前返回，`test_facade_initialized_once_and_cached` 断言的是 `None is None`，
+`test_facade_returns_none_when_knob_disabled` 从未走到旋钮、其 docstring
+（"Default: prefetch_facade_enabled=False"）在本提交后已是错的。两条均补注 roots 与 mode
+后才真正成立，后者改名为 `test_facade_returns_none_when_no_durable_mode_configured`
+（覆盖"config 完全不提这条车道"，与已有的显式 `mode: off` 用例区分）。
+
+### 同类模式全项目扫描（Section W 规则 5）
+
+- 手工拼 `knob_overrides.jsonl` 路径：仅 `knob_overrides.py` 自身（属主）与
+  `memory_os_vector_retrieval_benchmark.py:489`（写自建 fixture store，非 watcher），无同类缺陷。
+- 测试里断言执行位：仅本次修正的一处。
+- 亚秒级 sleep/到期：另两处（`test_memory_os_legacy_right_brain_retirement.py:347`、
+  `test_memory_os_monitor_perf.py:23`）失败方向安全——前者断言 writer **仍被阻塞**，
+  机器越慢越成立。
+
+### 测试与门禁
+
+3077 passed + 1 failed → **3085 passed / 13 skipped / 0 failed**（净 +7 测试：prefetch 6 + onboarding 1，
+另修好 1 条 Windows 红）。五项静态门全过：import cycle 165 模块 / 0 环、
+write surface 154/154 unclassified 0、static hygiene、public checkout probe --strict exit 0、
+`git diff --check` 干净。
+
 ---
 
 ## 待办
@@ -1622,3 +1786,21 @@ sannai-community 仓库 README。）
   正向断言由"无遮蔽报错"改为"traceback 出现 runtime 树路径"。
   已用一次性 venv 复刻 CI 条件验证：旧版在其中复现出与 CI 一致的失败、新版 6 项全过。
   3065 → **3066 passed / 13 skipped / 0 failed**，五项静态门全过。
+- `6273e8b..（BV，本节）`：对 `6273e8b` 的代码评审与修复，12 项发现修 9 项。最重一项是
+  **`apply_canary` 上「关闭开关过期即静默恢复输出改写」**——该提交把解析默认值翻成 `True`
+  以救活 `shadow` 观测车道，但 `apply_canary` 会往 live prefetch 追加
+  `Recall Facade (unified)` 段，于是 provisional `false` 一到期就无声恢复输出改写，
+  正是它所修 bug 的镜像；改为按模式取默认值（`shadow → True`、`apply_canary → False`）。
+  另修：kill switch 路径自行拼装 + 「文件缺失→直接 True」的 **fail-open**（改走
+  `override_store_path()` 且不再短路）；`_recall_facade_init_errors` 只写不读且注释不实；
+  status 无法区分「被 Owner 关掉」与「mode 本来 off」（新增 `mode_live`）；
+  `_roots is None` 污染 init 哨兵致 roots 后注入后永久返回 None；缓存的 facade 会被以
+  另一个 arbitration mode 交付（对象构造时固化模式，`initialized` 短路先于模式判断）；
+  onboarding wrapper 分支零覆盖（反事实实测可回退）；150ms 到期测试墙钟 flaky。
+  **并查实该提交把 Windows 本机全绿基线打破了**——它自己新增的 onboarding 测试断言
+  `st_mode & 0o100`，在 Windows 恒为 0，CI（Linux）绿而本机红，与 BU.1 互为镜像；
+  这首先是一条流程发现（本机必红的测试被推上 main，DoD 第 4 步未执行）。
+  有意保留 1 项（严格校验的全账本 fail-closed 口径），
+  显式记录不做 2 项（monitor 对 `recall_facade` 的采集接线；`prefetch()` 三个旋钮合并为一次
+  `resolve_knobs()` 以真正消除热路径重复读）。3077 passed + 1 failed →
+  **3085 passed / 13 skipped / 0 failed**（净 +7），五项静态门全过。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1524,6 +1524,15 @@ roots 事后注入之后 facade **永久返回 None**——一个哨兵表达两
 
 新增 `_recall_facade_mode` 记录构造时的模式，两处 `initialized` 短路都加上模式一致判断。
 
+**5.1 的修复自身引入了一个新暴露，在合并前自审中发现并修掉**：原实现里
+`self._recall_facade` 一生只赋值一次（`initialized` 置真后永不重建），所以"半注册状态"
+不可能被观察到；加了模式变更重建之后，`self._recall_facade` 会被**就地替换**，而另一线程
+可能正持着上一次构造留下的 `initialized=True` 在锁外读它——于是读到一个尚未 register 完
+的 facade。改为先构建到局部变量、注册完成后再按 `facade → mode → initialized` 的顺序发布
+（模式先于哨兵，保证看到 `initialized=True` 的读者不会读到过期模式）。
+教训：**给一个"只写一次"的字段加上重建路径，等于把它变成共享可变状态**，
+原本成立的免锁读假设会随之失效。
+
 ### 6. onboarding 的 wrapper 分支无覆盖
 
 `_write_execution_gate_assets` 有**两处** `_copy_asset_if_distinct` 调用（runner 循环 +

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -81,10 +81,18 @@ class MemoryOSProvider(MemoryProvider):
         # ── Phase 3: Retriever Facade (provider-level cache, constraint 1) ─
         self._recall_facade: RetrieverFacade | None = None
         self._recall_facade_initialized = False
-        self._recall_facade_knob_fingerprint: tuple[bool, int, int, int] | None = None
+        # Mode the cached facade was constructed with. The facade freezes its
+        # arbitration mode at construction, so serving it under a different
+        # mode would silently run the wrong lane.
+        self._recall_facade_mode = ""
+        # Fingerprint carries the resolution default too: the default is
+        # mode-derived, so a cache entry resolved under one mode must never be
+        # served to another.
+        self._recall_facade_knob_fingerprint: tuple[bool, int, int, int, bool] | None = None
         self._recall_facade_enabled_cache = False
         self._recall_facade_knob_expiry_epoch: float | None = None
         self._recall_facade_knob_errors = 0
+        self._recall_facade_init_errors = 0
         self._recall_facade_lock = threading.RLock()
 
     @property
@@ -188,8 +196,11 @@ class MemoryOSProvider(MemoryProvider):
         """
         if self._roots is None:
             # A provider that has not been opened has no injected store context.
-            # Keep the optional facade disabled instead of reading ambient ~/.hermes.
-            self._recall_facade_initialized = True
+            # Keep the optional facade disabled instead of reading ambient
+            # ~/.hermes -- but do NOT latch ``_recall_facade_initialized``: that
+            # sentinel means "construction already ran", and latching it here
+            # would pin the facade to None for the rest of the process even
+            # after roots are injected.
             self._recall_facade = None
             return None
 
@@ -201,21 +212,26 @@ class MemoryOSProvider(MemoryProvider):
             # invalid mode.
             return None
 
-        # The durable mode keeps the lane live when a provisional enable
-        # override expires; an explicit active false override remains a
-        # call-time kill switch.
-        if not self._recall_facade_kill_switch_enabled():
+        # The durable mode keeps the OBSERVATION lane live when a provisional
+        # enable override expires; an explicit active false override remains a
+        # call-time kill switch. ``apply_canary`` is deliberately excluded from
+        # that durable default -- see _recall_facade_switch_default().
+        if not self._recall_facade_kill_switch_enabled(
+            default_enabled=self._recall_facade_switch_default(arbitration_mode),
+        ):
             return None
-        if self._recall_facade_initialized:
+        if self._recall_facade_initialized and self._recall_facade_mode == arbitration_mode:
             return self._recall_facade
 
         with self._recall_facade_lock:
             # A switch write may race the first check while this thread waits
             # for another initializer. Re-evaluate under the same lock before
             # constructing or returning the cached object.
-            if not self._recall_facade_kill_switch_enabled():
+            if not self._recall_facade_kill_switch_enabled(
+                default_enabled=self._recall_facade_switch_default(arbitration_mode),
+            ):
                 return None
-            if self._recall_facade_initialized:
+            if self._recall_facade_initialized and self._recall_facade_mode == arbitration_mode:
                 return self._recall_facade
 
             from .retrievers.crystallized import CrystallizedRetriever
@@ -240,13 +256,35 @@ class MemoryOSProvider(MemoryProvider):
                 try:
                     self._recall_facade.register(retriever_class())
                 except Exception:
-                    # fail-open: registration failure must not block startup;
-                    # recorded as suppressed count for monitor visibility
-                    self._recall_facade_init_errors = getattr(self, "_recall_facade_init_errors", 0) + 1
+                    # fail-open: registration failure must not block startup.
+                    # Surfaced as recall_facade.init_error_count in
+                    # _tool_status_report(); no monitor component aggregates
+                    # that block yet (see BV note in the stabilization checklist).
+                    self._recall_facade_init_errors += 1
+            self._recall_facade_mode = arbitration_mode
             self._recall_facade_initialized = True  # set after successful init
             return self._recall_facade
 
-    def _recall_facade_kill_switch_enabled(self) -> bool:
+    @staticmethod
+    def _recall_facade_switch_default(arbitration_mode: str) -> bool:
+        """Default for ``prefetch_facade_enabled`` under a given durable mode.
+
+        ``shadow`` is output-neutral: it only builds and persists the
+        metadata-only Recall Plan, so the durable mode is allowed to keep the
+        observation lane live once a provisional enable override expires --
+        that is the regression this lane's fix exists to prevent.
+
+        ``apply_canary`` is NOT output-neutral: it appends a live
+        ``Recall Facade (unified)`` section to prefetch output. Defaulting it
+        to enabled would mean a provisional *disable* override silently
+        resumes output mutation the moment it expires, with no file write, no
+        restart and no owner action -- the same silent-flip failure mirrored
+        onto the mutating mode. Output mutation therefore requires explicit,
+        unexpired positive authority.
+        """
+        return arbitration_mode == "shadow"
+
+    def _recall_facade_kill_switch_enabled(self, *, default_enabled: bool) -> bool:
         """Resolve the call-time facade switch once per store revision.
 
         The override ledger can grow large, so rescanning it on every prefetch
@@ -254,15 +292,23 @@ class MemoryOSProvider(MemoryProvider):
         the nearest relevant expiry preserves live writes and time-based expiry
         while unchanged stores use the cached strict-boolean result. Unreadable
         or malformed stores fail closed and increment the visible error count.
+
+        *default_enabled* is the mode-derived resolution default and is part of
+        the cache key -- see :meth:`_recall_facade_switch_default`.
         """
         if self._roots is None:
             return False
         with self._recall_facade_lock:
-            path = self._roots.memory_os_root / "system" / "knob_overrides.jsonl"
+            # Path ownership stays with knob_overrides: rebuilding it here
+            # would let the two drift, and a wrong path stats as "missing",
+            # which must never be a shortcut around reading the real switch.
+            from .knob_overrides import override_store_path, resolve_knob
+
+            path = override_store_path(self._roots)
             try:
                 stat_result = path.stat()
             except FileNotFoundError:
-                fingerprint = (False, 0, 0, 0)
+                fingerprint = (False, 0, 0, 0, default_enabled)
             except OSError:
                 self._recall_facade_knob_errors += 1
                 return False
@@ -272,6 +318,7 @@ class MemoryOSProvider(MemoryProvider):
                     int(stat_result.st_ino),
                     int(stat_result.st_size),
                     int(stat_result.st_mtime_ns),
+                    default_enabled,
                 )
 
             now_epoch = datetime.now(timezone.utc).timestamp()
@@ -286,28 +333,25 @@ class MemoryOSProvider(MemoryProvider):
                 return self._recall_facade_enabled_cache
 
             expiry_epoch: float | None = None
-            if not fingerprint[0]:
-                resolved: object = True
-            else:
-                from .knob_overrides import resolve_knob
-
-                try:
-                    expiry_epoch = self._validate_recall_facade_override_store(
-                        path,
-                        now_epoch=now_epoch,
-                    )
-                    resolved = resolve_knob(
-                        "prefetch_facade_enabled",
-                        default=True,
-                        roots=self._roots,
-                    )
-                except Exception:
-                    # This is a governance boundary on the live prefetch path:
-                    # unexpected reader/parser failures disable the optional
-                    # facade instead of breaking prefetch or enabling canary.
-                    resolved = False
-                    expiry_epoch = None
-                    self._recall_facade_knob_errors += 1
+            try:
+                # A missing store is "no overrides", not "enabled": the answer
+                # still comes from the resolver applying *default_enabled*.
+                expiry_epoch = self._validate_recall_facade_override_store(
+                    path,
+                    now_epoch=now_epoch,
+                )
+                resolved: object = resolve_knob(
+                    "prefetch_facade_enabled",
+                    default=default_enabled,
+                    roots=self._roots,
+                )
+            except Exception:
+                # This is a governance boundary on the live prefetch path:
+                # unexpected reader/parser failures disable the optional
+                # facade instead of breaking prefetch or enabling canary.
+                resolved = False
+                expiry_epoch = None
+                self._recall_facade_knob_errors += 1
 
             enabled = type(resolved) is bool and resolved is True
             if type(resolved) is not bool:
@@ -323,8 +367,18 @@ class MemoryOSProvider(MemoryProvider):
         *,
         now_epoch: float,
     ) -> float | None:
-        """Strictly validate the ledger and return its nearest facade expiry."""
+        """Strictly validate the ledger and return its nearest facade expiry.
+
+        A store that does not exist yet is "no overrides recorded", not a
+        validation failure -- the resolver applies the caller's default.
+        Strictness is deliberately whole-ledger: a line that will not parse
+        cannot be attributed to a knob, so it is treated as corruption of the
+        governance store rather than silently skipped the way the resolver's
+        own tolerant reader does.
+        """
         nearest_expiry: float | None = None
+        if not path.exists():
+            return None
         for raw_line in path.read_text(encoding="utf-8").splitlines():
             if not raw_line.strip():
                 continue
@@ -1098,9 +1152,17 @@ class MemoryOSProvider(MemoryProvider):
             recall_arbitration_raw if isinstance(recall_arbitration_raw, dict) else {}
         )
         recall_arbitration_mode = str(recall_arbitration_cfg.get("mode") or "off")
+        recall_facade_mode_live = recall_arbitration_mode in {"shadow", "apply_canary"}
+        # ``kill_switch_enabled`` alone cannot distinguish "the owner disabled
+        # the lane" from "the durable mode is off, nobody touched the switch" --
+        # both render false. ``mode_live`` is reported alongside it so a reader
+        # can tell those apart. The resolution stays gated on a live mode so an
+        # off lane keeps costing zero governed reads on the prefetch hot path.
         recall_facade_switch_enabled = (
-            self._recall_facade_kill_switch_enabled()
-            if recall_arbitration_mode in {"shadow", "apply_canary"}
+            self._recall_facade_kill_switch_enabled(
+                default_enabled=self._recall_facade_switch_default(recall_arbitration_mode),
+            )
+            if recall_facade_mode_live
             else False
         )
         return {
@@ -1135,10 +1197,12 @@ class MemoryOSProvider(MemoryProvider):
             "recall_observation_window": recall_observation_window,
             "recall_facade": {
                 "arbitration_mode": recall_arbitration_mode,
+                "mode_live": recall_facade_mode_live,
                 "initialized": self._recall_facade_initialized,
                 "kill_switch_enabled": recall_facade_switch_enabled,
-                "effective_enabled": bool(recall_facade_switch_enabled),
+                "effective_enabled": recall_facade_mode_live and recall_facade_switch_enabled,
                 "knob_error_count": self._recall_facade_knob_errors,
+                "init_error_count": self._recall_facade_init_errors,
             },
             "crystallized_candidates_label": "review candidates only; not approved crystallized memory",
             "crystallized_records": public_counts["crystallized_records"],

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -240,7 +240,11 @@ class MemoryOSProvider(MemoryProvider):
             from .retrievers.state_overlay import StateOverlayRetriever
             from .retrievers.temporal import TemporalRetriever
 
-            self._recall_facade = RetrieverFacade(
+            # Build into a local and publish only once fully registered. A
+            # mode change rebuilds, so assigning self._recall_facade first
+            # would expose a half-registered object to a reader still holding
+            # the previous (true) _recall_facade_initialized outside the lock.
+            facade = RetrieverFacade(
                 arbitration_mode=arbitration_mode,
                 freshness_guard_mode=str(arbitration_cfg.get("freshness_guard_mode") or "shadow"),
                 conflict_resolution_mode=str(arbitration_cfg.get("conflict_resolution_mode") or "shadow"),
@@ -254,16 +258,19 @@ class MemoryOSProvider(MemoryProvider):
             )
             for retriever_class in retrievers:
                 try:
-                    self._recall_facade.register(retriever_class())
+                    facade.register(retriever_class())
                 except Exception:
                     # fail-open: registration failure must not block startup.
                     # Surfaced as recall_facade.init_error_count in
                     # _tool_status_report(); no monitor component aggregates
                     # that block yet (see BV note in the stabilization checklist).
                     self._recall_facade_init_errors += 1
+            # Publication order matters: mode before the sentinel, so a reader
+            # that sees initialized=True never reads a stale mode.
+            self._recall_facade = facade
             self._recall_facade_mode = arbitration_mode
             self._recall_facade_initialized = True  # set after successful init
-            return self._recall_facade
+            return facade
 
     @staticmethod
     def _recall_facade_switch_default(arbitration_mode: str) -> bool:

--- a/plugins/memory/memory_os/knob_overrides.py
+++ b/plugins/memory/memory_os/knob_overrides.py
@@ -369,6 +369,13 @@ OVERRIDABLE_KNOBS: dict[str, dict[str, Any]] = {
         "ab_metric": None,
     },
     # ── Phase 3: Retriever Facade integration knobs ─────────────────────
+    # NOTE: ``default`` here is the registry/owner-digest metadata default (the
+    # off state, also used by owner_actions for `prior` rendering when a record
+    # carries no prior_value). It is NOT the value the provider resolves with:
+    # MemoryOSProvider._recall_facade_switch_default() derives the resolution
+    # default from recall_arbitration.mode — True under output-neutral
+    # ``shadow`` so the observation lane survives an expired enable override,
+    # False under output-mutating ``apply_canary``.
     "prefetch_facade_enabled": {
         "module": "prefetch",
         "default": False,
@@ -434,6 +441,17 @@ def _override_store_path(roots: MemoryOSRoots | None = None, *,
             _ambient_fallback_warned = True
         roots = MemoryOSRoots.from_profile()
     return roots.memory_os_root / "system" / "knob_overrides.jsonl"
+
+
+def override_store_path(roots: MemoryOSRoots | None = None) -> Path:
+    """Public accessor for the knob-override store path.
+
+    Callers that watch the store (e.g. the provider's facade kill-switch
+    cache) must resolve it through this module rather than rebuilding the
+    path, so a watcher can never end up stat-ing a different file than the
+    resolver reads.
+    """
+    return _override_store_path(roots)
 
 
 # ── Read ────────────────────────────────────────────────────────────────

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -2242,28 +2242,66 @@ class TestPrefetchFacadeIntegration:
     """Phase 3: Retriever Facade → prefetch integration (mode + kill-switch gated)."""
 
     def test_facade_initialized_once_and_cached(self, tmp_path, monkeypatch):
-        """Facade is initialized only once per provider (constraint 1: no repeated init)."""
+        """Facade is initialized only once per provider (constraint 1: no repeated init).
+
+        Roots and a live durable mode are both required for this to assert
+        anything: a bare provider has ``_roots is None`` and returns before any
+        construction, which made ``f1 is f2`` a ``None is None`` tautology.
+        """
         import warnings
 
         from plugins.memory.memory_os import MemoryOSProvider
         from plugins.memory.memory_os import knob_overrides
+        from plugins.memory.memory_os.roots import MemoryOSRoots
 
         monkeypatch.setattr(knob_overrides, "_ambient_fallback_warned", False)
         provider = MemoryOSProvider()
+        provider._roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        provider._config = {"recall_arbitration": {"mode": "shadow"}}
         with warnings.catch_warnings():
+            # Resolution must pass roots through; an ambient ~/.hermes fallback
+            # would raise here instead of silently reading the wrong store.
             warnings.simplefilter("error", RuntimeWarning)
             f1 = provider._ensure_recall_facade()
             f2 = provider._ensure_recall_facade()
+        assert f1 is not None, "a live shadow mode must construct the facade"
         # Same object reference — cached at provider level
         assert f1 is f2, "Facade must be cached (provider-level), not rebuilt"
 
-    def test_facade_returns_none_when_knob_disabled(self, tmp_path):
-        """Default: prefetch_facade_enabled=False → facade is None."""
+    def test_facade_returns_none_when_no_durable_mode_configured(self, tmp_path):
+        """No ``recall_arbitration`` key at all → facade is None.
+
+        Distinct from an explicit ``mode: off``: this covers config that never
+        mentions the lane. Roots are injected so the assertion exercises the
+        mode gate rather than returning early on a missing store context.
+        """
         from plugins.memory.memory_os import MemoryOSProvider
+        from plugins.memory.memory_os.roots import MemoryOSRoots
 
         provider = MemoryOSProvider()
+        provider._roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        provider._config = {}
+
         facade = provider._ensure_recall_facade()
-        assert facade is None, f"Facade should be None when knob disabled, got {facade}"
+        assert facade is None, f"Facade should be None with no durable mode, got {facade}"
+
+    def test_roots_injected_after_a_rootless_call_still_builds_the_facade(self, tmp_path):
+        """A rootless call must not latch the "already constructed" sentinel.
+
+        ``_recall_facade_initialized`` means "construction already ran". The
+        rootless early-return used to set it, which pinned the facade to None
+        for the remaining life of the provider even once roots arrived.
+        """
+        from plugins.memory.memory_os import MemoryOSProvider
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        provider = MemoryOSProvider()
+        provider._config = {"recall_arbitration": {"mode": "shadow"}}
+        assert provider._ensure_recall_facade() is None
+
+        provider._roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+
+        assert provider._ensure_recall_facade() is not None
 
     def test_shadow_arbitration_config_keeps_observation_lane_live_after_enable_override_expires(self, tmp_path):
         """A durable shadow mode must not depend on a provisional enable override.
@@ -2412,6 +2450,14 @@ class TestPrefetchFacadeIntegration:
         assert provider._recall_facade_knob_errors == 1
 
     def test_expired_false_kill_switch_reenables_without_file_change(self, tmp_path):
+        """Shadow mode returns on expiry — the durable mode is the authority.
+
+        The expiry window has to cover a governed JSONL write, provider
+        construction, a stat, a full ledger read and a reversed rescan before
+        the *first* assert. A sub-second window makes the first assert fail on
+        a loaded CI runner (see BO); the window is wall-clock generous and the
+        sleep is derived from it.
+        """
         import time
         from datetime import datetime, timedelta, timezone
 
@@ -2419,14 +2465,16 @@ class TestPrefetchFacadeIntegration:
         from plugins.memory.memory_os.knob_overrides import register_override
         from plugins.memory.memory_os.roots import MemoryOSRoots
 
+        expires_in_seconds = 3.0
         roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        registered_at = datetime.now(timezone.utc)
         register_override(
             "prefetch_facade_enabled",
             False,
             prior=True,
             proposed_by="test",
             approved_via="test",
-            expires_at=(datetime.now(timezone.utc) + timedelta(seconds=0.15)).isoformat(),
+            expires_at=(registered_at + timedelta(seconds=expires_in_seconds)).isoformat(),
             roots=roots,
         )
         provider = MemoryOSProvider()
@@ -2434,9 +2482,156 @@ class TestPrefetchFacadeIntegration:
         provider._config = {"recall_arbitration": {"mode": "shadow"}}
         assert provider._ensure_recall_facade() is None
 
-        time.sleep(0.2)
+        elapsed = (datetime.now(timezone.utc) - registered_at).total_seconds()
+        time.sleep(max(0.1, expires_in_seconds - elapsed + 0.2))
 
         assert provider._ensure_recall_facade() is not None
+
+    def test_expired_false_kill_switch_does_not_reenable_output_mutating_canary(self, tmp_path):
+        """apply_canary must not resume output mutation when a disable expires.
+
+        ``shadow`` is output-neutral, so the durable mode may keep it live once
+        a provisional override expires. ``apply_canary`` appends a live
+        ``Recall Facade (unified)`` section to prefetch output, so the same
+        default would mean output mutation silently resumes on expiry — no file
+        write, no restart, no owner action. It requires explicit, unexpired
+        positive authority instead.
+        """
+        import time
+        from datetime import datetime, timedelta, timezone
+
+        from plugins.memory.memory_os import MemoryOSProvider
+        from plugins.memory.memory_os.knob_overrides import register_override
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        expires_in_seconds = 3.0
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        registered_at = datetime.now(timezone.utc)
+        register_override(
+            "prefetch_facade_enabled",
+            False,
+            prior=True,
+            proposed_by="test",
+            approved_via="test",
+            expires_at=(registered_at + timedelta(seconds=expires_in_seconds)).isoformat(),
+            roots=roots,
+        )
+        provider = MemoryOSProvider()
+        provider._roots = roots
+        provider._config = {"recall_arbitration": {"mode": "apply_canary"}}
+        assert provider._ensure_recall_facade() is None
+
+        elapsed = (datetime.now(timezone.utc) - registered_at).total_seconds()
+        time.sleep(max(0.1, expires_in_seconds - elapsed + 0.2))
+
+        assert provider._ensure_recall_facade() is None, (
+            "an expired disable must not silently re-enable output mutation"
+        )
+
+    def test_apply_canary_runs_on_explicit_unexpired_enable_override(self, tmp_path):
+        """The canary is not disabled outright — explicit positive authority runs it."""
+        from plugins.memory.memory_os import MemoryOSProvider
+        from plugins.memory.memory_os.knob_overrides import register_override
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        register_override(
+            "prefetch_facade_enabled",
+            True,
+            prior=False,
+            proposed_by="test",
+            approved_via="test",
+            expires_at="2099-01-01T00:00:00+00:00",
+            roots=roots,
+        )
+        provider = MemoryOSProvider()
+        provider._roots = roots
+        provider._config = {"recall_arbitration": {"mode": "apply_canary"}}
+
+        facade = provider._ensure_recall_facade()
+
+        assert facade is not None
+        assert facade._arbitration_mode == "apply_canary"
+
+    def test_cached_facade_is_not_served_under_a_different_arbitration_mode(self, tmp_path):
+        """The facade freezes its mode at construction — the cache must track it.
+
+        ``_recall_facade_initialized`` alone would hand back a shadow-built
+        facade to an apply_canary caller (and vice versa), silently running the
+        wrong lane against a config that says otherwise.
+        """
+        from plugins.memory.memory_os import MemoryOSProvider
+        from plugins.memory.memory_os.knob_overrides import register_override
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        register_override(
+            "prefetch_facade_enabled",
+            True,
+            prior=False,
+            proposed_by="test",
+            approved_via="test",
+            expires_at="2099-01-01T00:00:00+00:00",
+            roots=roots,
+        )
+        provider = MemoryOSProvider()
+        provider._roots = roots
+        provider._config = {"recall_arbitration": {"mode": "shadow"}}
+        shadow_facade = provider._ensure_recall_facade()
+        assert shadow_facade is not None
+        assert shadow_facade._arbitration_mode == "shadow"
+
+        provider._config = {"recall_arbitration": {"mode": "apply_canary"}}
+        canary_facade = provider._ensure_recall_facade()
+
+        assert canary_facade is not None
+        assert canary_facade._arbitration_mode == "apply_canary", (
+            "a cached facade must not be served under a mode it was not built for"
+        )
+
+    def test_kill_switch_is_read_from_the_resolver_owned_store_path(self, tmp_path, monkeypatch):
+        """The switch watcher resolves the store path through knob_overrides.
+
+        A watcher that rebuilds the path itself can drift from the resolver,
+        and a path that stats as "missing" used to short-circuit straight to
+        enabled — so drift would silently ignore the owner's kill switch rather
+        than fail closed. This pins the weaker, directly observable property:
+        the switch is read from whatever store the resolver owns, not from a
+        path derived independently from ``roots``.
+        """
+        from plugins.memory.memory_os import MemoryOSProvider
+        from plugins.memory.memory_os import knob_overrides
+        from plugins.memory.memory_os.knob_overrides import register_override
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        relocated_root = tmp_path / "relocated-system"
+        relocated_root.mkdir(parents=True, exist_ok=True)
+        relocated_store = relocated_root / "knob_overrides.jsonl"
+        monkeypatch.setattr(
+            knob_overrides,
+            "_override_store_path",
+            lambda roots=None, *, _store_root=None: relocated_store,
+        )
+        register_override(
+            "prefetch_facade_enabled",
+            False,
+            prior=True,
+            proposed_by="test",
+            approved_via="test",
+            expires_at="2099-01-01T00:00:00+00:00",
+            roots=roots,
+        )
+        assert relocated_store.is_file()
+        assert not (roots.memory_os_root / "system" / "knob_overrides.jsonl").exists()
+
+        provider = MemoryOSProvider()
+        provider._roots = roots
+        provider._config = {"recall_arbitration": {"mode": "shadow"}}
+
+        assert provider._ensure_recall_facade() is None, (
+            "the owner's disable lives in the resolver-owned store and must be honoured"
+        )
 
     def test_facade_is_constructed_once_under_concurrent_prefetch(self, tmp_path, monkeypatch):
         import importlib
@@ -2496,8 +2691,39 @@ class TestPrefetchFacadeIntegration:
         provider.shutdown()
 
         assert report["recall_facade"]["arbitration_mode"] == "shadow"
+        assert report["recall_facade"]["mode_live"] is True
         assert report["recall_facade"]["kill_switch_enabled"] is False
         assert report["recall_facade"]["effective_enabled"] is False
+
+    def test_status_distinguishes_mode_off_from_an_owner_disabled_switch(self, tmp_path):
+        """``kill_switch_enabled: false`` alone is ambiguous — ``mode_live`` resolves it.
+
+        With no durable mode the switch renders false even though the owner
+        never touched it, which reads as "someone killed the lane". Reporting
+        ``mode_live`` alongside it lets a reader tell the two states apart.
+        """
+        from plugins.memory.memory_os import MemoryOSProvider
+
+        provider = MemoryOSProvider()
+        provider.initialize(
+            "session-1",
+            hermes_home=str(tmp_path),
+            platform="telegram",
+            agent_identity="memoryos-test",
+        )
+        provider._config["recall_arbitration"] = {"mode": "off"}
+
+        report = provider._tool_status_report()
+        provider.shutdown()
+
+        assert report["recall_facade"]["arbitration_mode"] == "off"
+        assert report["recall_facade"]["mode_live"] is False
+        assert report["recall_facade"]["kill_switch_enabled"] is False
+        assert report["recall_facade"]["effective_enabled"] is False
+        # Suppressed-failure counters are owner-visible even though no monitor
+        # component aggregates this block yet.
+        assert report["recall_facade"]["knob_error_count"] == 0
+        assert report["recall_facade"]["init_error_count"] == 0
 
     def test_unchanged_kill_switch_store_is_not_rescanned_on_every_prefetch(self, tmp_path, monkeypatch):
         from plugins.memory.memory_os import MemoryOSProvider, knob_overrides

--- a/tests/scripts/test_memory_os_owner_cron_onboarding.py
+++ b/tests/scripts/test_memory_os_owner_cron_onboarding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import stat
 import sys
 from pathlib import Path
 
@@ -163,6 +164,18 @@ def _registry_script_names() -> list[str]:
     return sorted(dict.fromkeys(names))
 
 
+def _assert_executable_bit(path: Path) -> None:
+    """Assert the user execute bit, where the platform actually has one.
+
+    Windows has no POSIX execute bit: ``chmod(mode | S_IXUSR)`` is a no-op
+    there and ``st_mode`` comes back ``0o100666``. Asserting it unconditionally
+    makes the test pass on Linux CI and fail on every Windows checkout.
+    """
+    if os.name == "nt":
+        return
+    assert path.stat().st_mode & stat.S_IXUSR
+
+
 def test_execution_gate_asset_install_is_idempotent_in_installed_layout(tmp_path, monkeypatch):
     """Running the deployed onboarding script must not copy a file onto itself."""
     module = _load_module()
@@ -180,8 +193,50 @@ def test_execution_gate_asset_install_is_idempotent_in_installed_layout(tmp_path
 
     assert execution_runner.read_text(encoding="utf-8") == "# execution\n"
     assert group_runner.read_text(encoding="utf-8") == "# group\n"
-    assert execution_runner.stat().st_mode & 0o100
-    assert group_runner.stat().st_mode & 0o100
+    _assert_executable_bit(execution_runner)
+    _assert_executable_bit(group_runner)
+
+
+def test_group_tick_wrapper_install_is_idempotent_in_installed_layout(tmp_path, monkeypatch):
+    """The wrapper branch copies from SOURCE_SCRIPTS_DIR — same self-copy hazard.
+
+    ``_write_execution_gate_assets`` has two copy sites: the runner loop and
+    the group-tick wrapper branch. Covering only the first leaves the second
+    free to regress back to a bare ``shutil.copy2``, which raises
+    ``SameFileError`` in the installed layout where source and target are the
+    same path.
+    """
+    module = _load_module()
+    hermes_home = tmp_path / "home"
+    scripts_dir = hermes_home / "scripts"
+    scripts_dir.mkdir(parents=True)
+    execution_runner = scripts_dir / "memory_os_execution_gate_runner.py"
+    group_runner = scripts_dir / "memory_os_cron_group_runner.py"
+    execution_runner.write_text("# execution\n", encoding="utf-8")
+    group_runner.write_text("# group\n", encoding="utf-8")
+    wrapper = scripts_dir / "memory_os_tick_derived.py"
+    wrapper.write_text("# tick wrapper\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "SOURCE_EXECUTION_GATE_RUNNER", execution_runner)
+    monkeypatch.setattr(module, "SOURCE_CRON_GROUP_RUNNER", group_runner)
+    # Installed layout: the onboarding script lives in the same scripts/ dir
+    # it installs into, so the wrapper source resolves to the wrapper target.
+    monkeypatch.setattr(module, "SOURCE_SCRIPTS_DIR", scripts_dir)
+    monkeypatch.setattr(module, "write_cron_registry_snapshot", lambda *a, **k: None)
+
+    module._write_execution_gate_assets(
+        hermes_home=hermes_home,
+        specs=[{
+            "script": "memory_os_tick_derived.py",
+            "raw_script": "memory_os_event_stats_refresh.py",
+            "registry_key": "tick_derived",
+            "_members": ("event_stats_refresh",),
+            "_group": None,
+        }],
+    )
+
+    assert wrapper.read_text(encoding="utf-8") == "# tick wrapper\n"
+    _assert_executable_bit(wrapper)
 
 
 def _home_with_helpers(


### PR DESCRIPTION
Review of `6273e8b` — the only commit past the stabilization checklist's last entry (`3dbbb9b..HEAD`, BU.1). **13 findings: 10 fixed, 1 kept by design, 2 recorded as not-done.** Full write-up in checklist section BV.

## The one that matters

`6273e8b` flipped `prefetch_facade_enabled`'s resolution default from `False` to `True`, so a durable `recall_arbitration.mode=shadow` keeps the observation lane alive after a provisional enable override expires. Correct for `shadow` — it is output-neutral.

But `resolve_knobs` skips an active+provisional+**expired** record and falls through to the caller's default (`knob_overrides.py:491`), and `apply_canary` **appends a live `Recall Facade (unified)` section to prefetch output** (`prefetch.py:636`). So on an `apply_canary` host, an owner's provisional `false` kill switch silently resumed output mutation the moment it expired — no file write, no restart, no owner action. That is the exact mirror of the bug the commit fixes, and its own `test_expired_false_kill_switch_reenables_without_file_change` asserts the re-enable is *desired* — but only covers `shadow`.

Fix: `_recall_facade_switch_default(mode)` — `shadow → True`, `apply_canary → False`. Output mutation requires explicit, unexpired positive authority. Production (3.200) is on `shadow`, so no production behaviour change.

## Also fixed

| | |
|---|---|
| **fail-open kill switch** | The watcher hand-built the override store path and treated a missing file as "enabled" *without calling the resolver*. Path drift would have silently ignored the owner's switch. Now goes through `knob_overrides.override_store_path()`, no missing-file shortcut. |
| **dead error counter** | `_recall_facade_init_errors` was written in one place and read nowhere, while its comment claimed "recorded as suppressed count for monitor visibility". Both counters are now in `status`. |
| **ambiguous status** | `kill_switch_enabled: false` rendered identically for "owner killed it" and "mode is off". Added `mode_live`. |
| **poisoned sentinel** | The `_roots is None` branch latched `_recall_facade_initialized`, pinning the facade to `None` for the process even after roots arrived. |
| **stale cached mode** | A `shadow`-built facade was served to an `apply_canary` caller — `RetrieverFacade` freezes its mode at construction. |
| **uncovered copy site** | `_write_execution_gate_assets` has two `_copy_asset_if_distinct` calls; the new test passed `specs=[]` and only reached the first. Reverting the second to `shutil.copy2` left the suite green. |
| **flaky timing** | A 150 ms expiry window had to cover a governed JSONL write + provider construction + stat + full read before the *first* assert. |

## The commit broke the Windows-local green baseline

Measured baseline at `6273e8b`: **3077 passed / 1 failed / 13 skipped**. The single failure was the commit's own new test — `assert stat().st_mode & 0o100`, which is always 0 on Windows (`chmod`'s exec bit is a no-op there; `st_mode` is `0o100666`). Linux CI green, every Windows checkout red — the mirror of BU.1, and it undid the first-ever all-green Windows run from BR.

This is first of all a **process finding**: a locally-red test reached `main`, so Definition-of-Done step 4 either did not run or ran on Linux only.

## Kept by design

`_validate_recall_facade_override_store` raises on *any* unparseable line, including records for unrelated knobs, while the resolver's own `_read_jsonl` silently skips them. The asymmetry is real, but a line that will not parse cannot be attributed to a knob, so treating it as governance-store corruption is the safer posture — and changing it would overturn the commit's just-landed `test_malformed_json_kill_switch_store_fails_closed`. Now documented as deliberate.

## Recorded as not-done

1. **No monitor consumer for the `recall_facade` status block.** Adding a WARN code needs classification-table registration, a `fail_if_production` decision and clean-host tiering — its own cycle. Same family as BR's monitor-collection gap.
2. **The cache's hot-path premise is weaker than it claims.** `prefetch()` already performs two uncached full-ledger `resolve_knob()` calls immediately before `_ensure_recall_facade()`. Folding all three into one `resolve_knobs()` would cut hot-path reads from 2 to 1 *and* delete the cache, the lock and the duplicated path. Deferred: it is a hot-path design change touching two other knobs' existing tests.

## Verification

- **3077 passed + 1 failed → 3085 passed / 13 skipped / 0 failed** (+7 tests), Windows local.
- Five static gates: import cycle 165 modules / 0 cycles · write surface 154/154, unclassified 0 · static hygiene · public checkout probe `--strict` exit 0 · `git diff --check` clean.
- All five behavioural fixes verified by revert→fail→restore→pass.
- Section W rule 5 sweep for each defect class (hand-built store paths, exec-bit assertions, sub-second expiry windows) — no other instances.
