### PR TITLE
fix(memory-os): repair suite isolation, consolidate owner write authority, close 192e056 review

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1612,6 +1612,178 @@ write surface 154/154 unclassified 0、static hygiene、public checkout probe --
 
 ---
 
+## BW — 接手 WIP checkpoint `192e056`：套件隔离修复 + Owner 写入权威收口（2026-08-01）
+
+`5bf0022`/`192e056` 两个提交以 WIP 身份推上 main，自述「完整套件 3015 passed / 102 errors，
+错误集中在 `tests/system_modularization/`，代表性测试单独跑过，建议先查共享根因」。
+本节接手该 checkpoint。
+
+### 0. 102 个 error 是**一个**根因，不是 102 个缺陷（P0）
+
+`tests/system_modularization/test_memory_os_agent_os_shell.py` 的
+`_clear_imported_memory_os_modules()` 从 `sys.modules` 弹掉 `plugins`、`plugins.memory`、
+`plugins.memory.memory_os`，**却把它们已导入的子模块留在原地**。这不是「没导入」而是一个洞：
+
+- `from plugins.memory.memory_os.crystallized import X` 仍然成功（叶子模块在缓存里）；
+- `import plugins.memory.memory_os.crystallized as x` 却失败——该字节码走
+  `IMPORT_NAME`（fromlist 为空）拿到重新导入的**裸** `plugins`，再 `IMPORT_FROM memory`
+  做 `getattr(plugins, "memory")`，而新父包上没有这个属性，`sys.modules['plugins.memory']`
+  的兜底也已被弹掉 → `ImportError: cannot import name 'memory' from 'plugins'`。
+
+本提交新增的 `tests/conftest.py` 恰好在**每条测试的 setup**里跑这两行（第 24 行 `from`
+成功、第 28 行 `import ... as` 失败），于是**排在该文件之后的每条测试**全部 error。
+这也解释了为什么代表性测试单独跑是绿的——它从来不是那些测试的缺陷。
+
+三个环境独立复现同一条结论：
+
+| 环境 | 结果 |
+|---|---|
+| GitHub Actions（Linux，`192e056`） | 3011 passed / 13 skipped / **102 errors** |
+| 交接方 Linux 隔离全量 | 3015 passed / 9 skipped / **102 errors** |
+| 本机 Windows 全量（修复前基线） | 3010 passed / **1 failed** / 13 skipped / **102 errors** |
+
+**并纠正交接说明的两点**：① 该 checkpoint 的 GitHub CI 是**红的**（run 30697011570，
+`verify: failure`）——交接方本机 `gh` 未登录故未能核验，不是「未知」而是「已失败」；
+② 交接清单未提到的**第 4 条本机失败**：
+`test_write_capability_imports_are_restricted_to_governed_production_callers`
+用正斜杠字面量比对 Windows 原生分隔符，与 BK 记录的同一类缺陷（改 `.as_posix()`）。
+又一条本机必红的测试被推上 main，DoD 第 4 步再次未执行——与 BV 第 0 节同族的流程发现。
+
+修法不是「把弹出的名字补全」：**全量清除会把类身份也换掉**——其他测试文件在 collection 期
+已绑定 `CrystallizedMemoryService` 等类对象，重新导入会产生第二份副本，
+`monkeypatch.setattr(类, ...)` 就会打在没人使用的对象上，**失败方式从响亮变成静默**。
+改为 autouse fixture 在每条测试前后**快照并还原模块对象本身**（而非清名字），
+`sys.path` 一并还原；删除 `_clear_imported_memory_os_modules()` 本体，避免再被调用。
+
+### 1. Owner 写入权威两份实现，跑在生产上的是弱的那份（P1）
+
+`owner_actions.py` 与 `crystallized.py` 各有一份 `_validate_consumed_owner_write_context`。
+查实：**`owner_actions` 那份没有任何 caller（死代码）**，真正守生产永久写的是
+`crystallized` 那份，而它是两份里**弱的**——相对 `owner_actions` 版本缺了四项：
+
+1. 不校验 context 的 `source` 属于 recorded digest（`recorded_digest` /
+   `latest_recorded_digest` / `latest_owner_home_digest`）；
+2. 不校验 `action_type` 属于 canonical-write 白名单；
+3. 不校验 token hash 是完整 SHA-256（长度 64）；
+4. 消费账本比对时**不比 `action_token_hash`**，且用的是另一个字段
+   （`owner_write_context_id` 而非 `reply_ingress_id`）。
+
+新增 `plugins/memory/memory_os/owner_write_authority.py`：只依赖 roots/store/JSONL 原语，
+不 import `owner_actions`/`crystallized`（两者反过来 import 它），
+**不导出任何永久写 capability 单例**。两份重复实现全部删除，
+`owner_actions` 与 `crystallized` 同走这一份。顺带把
+`OWNER_CANONICAL_WRITE_ACTION_TYPES`、两个 ledger path helper、`_safe_channel`
+也收敛为单一定义（`owner_actions` 以 import 别名保留原有模块内名字，调用点零改动）。
+import cycle 门：166 模块 / 0 环。
+
+### 2. 测试授权由「全局默认给」改为「显式申请」（P1）
+
+原 `tests/conftest.py` 用 autouse fixture 给**全仓库每条测试**发永久写权威——
+一个丢了 Owner 绑定的生产 caller 照样能全绿，因为 fixture 悄悄补上了它没能自证的授权。
+改为具名 fixture `crystallized_test_write_authority`，默认 fail-closed；
+实测确定需要它的 **21 个文件**各加一行 module 级 `pytestmark` 声明。
+
+值得记录的是**哪些文件不需要**：`test_memory_os_external_evidence_owner_action.py`、
+`test_memory_os_candidate_clusters.py` 等 Owner ingress/安全用例在去掉全局授权后**依然全绿**，
+证明它们本来就走真实 recorded-digest 路径，不靠 fixture 补授权。
+另加 `test_canonical_write_authority_fixture_is_opt_in_rather_than_autouse()` 钉住
+「这条 fixture 不得再变回 autouse」——否则文件里那两条 fail-closed 用例会开始因错误的原因通过。
+
+### 3. `approve_external_evidence` 出现在每条候选上（P1）
+
+两处缺陷叠加，交接说明只猜到后一半：
+
+- `_review_actions()` 的 candidate 分支**无条件**塞进 `approve_external_evidence`；
+- `_digest_item()` 按**白名单**重建 bounded item，名单里没有 `external_review_eligible`
+  → 走该渲染路径时标记丢失，于是**真·tainted 候选反而掉进普通候选分支**。
+
+两处都修。关键证据：修掉前一处之后，既有的
+`test_approve_external_evidence_crystallizes_tainted_candidate` **立刻失败**——
+说明它此前一直**因为那个无条件 token 才通过**，从未真正走到
+`external_review_eligible` 分支。这是一条真实的生产缺陷：在 `_digest_item` 渲染路径上，
+tainted 候选拿到的是 `approve_candidate`，而普通 approve 对 tainted 候选是被拒的
+（`test_ordinary_approve_cannot_approve_tainted_candidate`），即 Owner 在该路径上
+**根本无法批准 tainted 候选**（fail-closed，非越权，但治理面是坏的）。
+新增两条**精确集合**断言（而非 `in`/`not in`），双向覆盖：普通候选
+`== {approve_candidate, reject_candidate}`、tainted 候选
+`== {approve_external_evidence, reject_candidate}`。
+
+### 4. `candidate_cluster` 移出 `LIVING_MEMORY_TARGET_TYPES` 是对的，但漏了一份拷贝（P1）
+
+结论：**移除正确**。该集合现在只剩 `crystallized_record` /
+`provisional_crystallized_record` / `permanent_memory_promotion`——全是**已写入的记录级**目标；
+而 candidate_cluster 是「提议写入」，与 `candidate` 同类，
+**`candidate` 从来就不在这个集合里**。旧的 membership 才是不一致的那个。
+
+但 `scripts/memory_os_3_200_monitor.py` 里那份**内嵌 fallback 拷贝**仍列着
+`candidate_cluster`。该 fallback 只在 provider 不可导入时生效（clean host、远程探针），
+所以它**不会报错**，只会让同一条 item 在不同主机上被分到不同类——比报错更坏。
+已同步并新增 `test_monitor_living_memory_fallback_matches_owner_actions()` 用 AST 取出
+字面量与真集合逐一比对，钉死漂移。（同 CLAUDE.md 记载的
+`classify_hermes_cron_jobs` 三份拷贝同族风险。）
+
+### 5. 对 `192e056` 全部 27 个文件的 caller/adoption/security 复审（另 5 项发现）
+
+不只看最后改动的 owner_actions/crystallized，逐个生产文件复审得：
+
+1. **`scripts/memory_os_candidate_backfill_409.py` 已被打断**——本提交把
+   `append_candidate_triage()` 改为空 envelope 即 `PermissionError`，docstring 写着
+   「operator backfill 必须开显式 governed envelope」，但仓库里唯一的 operator backfill
+   脚本没同步改：`--apply` 现在必崩。补 `--execution-gate-envelope-id`
+   （env 默认 `MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID`，与仓库既有 6 个脚本同一惯例）
+   并在 apply 前显式 fail-closed 返回 2，实测无 envelope → exit 2、有 envelope → exit 0。
+2. **`crystallization_gate._gate_error_result()` 与同函数其余路径 error_record 形状打架**——
+   前者 `{"code": ...}`、后者 `{"error_code": ...}`，同一个 `error_records` 字段两种形状；
+   当前消费者只读 `status` 故未崩，但下一个迭代记录的消费者会在**恰好是失败的那些路径**上
+   读不到 `error_code`。统一为 `{candidate_id, error_code, component}`，新增双路径精确集合断言。
+3. **`read_candidate_queue()` 静默丢弃 schema 非法行**——能解析成 JSON 但不是可用候选的行
+   被 `continue` 掉且不记 error record。而聚合车道只在「读到错误」时跳过队列压缩，
+   压缩是全量重写：这类行会先被静默丢弃、再被下一次压缩**永久抹掉**，全程无痕。
+   四个校验分支各补 `error_record`（含 component/operation/severity/recoverable）。
+4. **被拒的 canonical write 授权不留任何痕迹**——该路径用 `persist_error=False`，
+   这本身是对的（不能让未授权调用方往 owner-action 账本里追加），但它同时意味着
+   伪造 token 的探测**在任何地方都不可见**。改为在 audit 通道记一条
+   `owner_canonical_write_authorization_rejected`（有界字段，绝不记 token 本体），
+   既保住 `read_owner_action_records(...) == []` 这条既有不变量，又留下证据。
+5. **`_resolver_candidate_gate_result()` 对每条候选都跑**——含被判 reject 的，
+   每次开两个 sqlite 连接 + 一次 FTS 查询，而其结果只在 approve 分支被读。
+   三处改为按 `verdict.get("approve")` 惰性求值，行为不变。
+
+### 有意未做（登记）
+
+- `scripts/memory_os_blank_host_smoke.py` 被本提交从「永久写」改为「provisional 写 +
+  probe capability」（因为永久写现在需要 recorded digest）。这是**必要的**，但
+  blank-host smoke 因此**不再覆盖永久 canonical write 路径**——登记为覆盖缺口，
+  补齐需要 smoke 自建完整 recorded digest，属独立一轮。
+- `execution_gate._rebuild_gate_index_from_records()` 现在 `del records` 忽略入参、
+  改为持锁重读账本，函数名与签名已名不副实；且它在**每次 permit resolve 成功后**都被调用，
+  即每次 resolve 多一次全账本读 + 索引全量重写。BS/BT 记录过
+  `execution_gate_index.json` 的 15 秒锁争用，虽已由 `prune_sidecar_index()`（保留 2000 条）
+  与 BU 的 tick 错峰把同分钟并发压到 1，仍登记为需要观察的热路径成本。
+
+### 反事实覆盖
+
+- 关掉 `restore_memory_os_import_state` 的 autouse →
+  `test_installed_runtime_import_leaves_no_hole_in_the_real_plugins_package` FAIL，
+  且暴露出比「洞」更坏的一种状态：`sys.modules["plugins"]` 指向 `tmp_path` 里的**假树**。
+- 去掉 `_review_actions` 的无条件 external token → 既有
+  `test_approve_external_evidence_crystallizes_tainted_candidate` FAIL（见第 3 节）。
+- 未声明 `crystallized_test_write_authority` 的永久写 →
+  `CrystallizedApprovalError`，由带 `require_explicit_crystallized_capability` 的两条既有
+  用例 + 新增的 opt-in 钉子用例共同守住。
+- `_gate_error_result` 形状统一后，两条既有断言旧形状的用例立刻 FAIL 并已同步
+  （Section W 规则 2 的现场：改了什么就 grep 什么）。
+
+### 测试与门禁
+
+修复前（`192e056`，本机 Windows）3010 passed / 1 failed / 102 errors / 13 skipped
+→ 修复后 **3119 passed / 13 skipped / 0 failed / 0 errors**。
+五项静态门全过：import cycle 166 模块 / 0 环、write surface 153/153 unclassified 0、
+static hygiene、public checkout probe --strict exit 0、`git diff --check` 干净；
+closure matrix `status=ok`。
+
+---
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -1813,3 +1985,25 @@ sannai-community 仓库 README。）
   显式记录不做 2 项（monitor 对 `recall_facade` 的采集接线；`prefetch()` 三个旋钮合并为一次
   `resolve_knobs()` 以真正消除热路径重复读）。3077 passed + 1 failed →
   **3085 passed / 13 skipped / 0 failed**（净 +7），五项静态门全过。
+- `192e056..（BW，本节）`：接手 WIP checkpoint。**102 个 error 是一个根因**——
+  shell 测试从 `sys.modules` 弹掉 `plugins`/`plugins.memory` 却留下已导入的子模块，
+  于是 `from ... import` 成功而 `import ... as` 在 `getattr(plugins, "memory")` 上炸，
+  新增的 autouse conftest 恰好每条测试 setup 都跑这行，排在其后的测试全灭；
+  改为快照/还原**模块对象本身**（清名字会换掉类身份，把响亮失败变成静默错patch）。
+  GitHub CI 对该 commit 已是红的（run 30697011570），交接方 `gh` 未登录故未核验；
+  另修交接未提到的第 4 条本机失败（正斜杠字面量比 Windows 分隔符，同 BK）。
+  Owner 写入权威两份实现中**跑在生产上的是弱的那份**（不验 recorded-digest source /
+  不验 action 白名单 / 不验 token hash 长度 / 消费比对不含 `action_token_hash`），
+  统一抽到 `owner_write_authority.py`（只依赖 roots/store/JSONL，无 capability 单例）。
+  测试授权由全局 autouse 改为 21 个文件显式声明，Owner ingress/安全用例去掉授权后依然全绿。
+  `approve_external_evidence` 两处缺陷：`_review_actions` 无条件发放 +
+  `_digest_item` 白名单丢掉 `external_review_eligible`，导致**真 tainted 候选反而走普通分支**
+  （既有测试此前一直因无条件 token 而假通过）。`candidate_cluster` 移出
+  `LIVING_MEMORY_TARGET_TYPES` 判定为正确（集合只应含已写入的记录级目标，
+  `candidate` 从来不在其中），但 monitor 内嵌 fallback 拷贝未同步、已修并以 AST 比对钉死。
+  27 文件复审另得 5 项：backfill 脚本被新 fail-closed 契约打断（已补 envelope 参数）、
+  gate error_record 两种形状、`read_candidate_queue` 静默丢弃 schema 非法行（会被压缩永久抹掉）、
+  被拒授权无任何痕迹（补 audit）、gate 对 reject 候选也跑（改惰性）。
+  3010 passed + 1 failed + 102 errors → **3119 passed / 13 skipped / 0 failed / 0 errors**，
+  五项静态门 + closure matrix 全过。有意未做 2 项（blank-host smoke 不再覆盖永久写路径；
+  `_rebuild_gate_index_from_records` 每次 resolve 全账本重读的热路径成本）。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1780,7 +1780,32 @@ tainted 候选拿到的是 `approve_candidate`，而普通 approve 对 tainted �
 → 修复后 **3119 passed / 13 skipped / 0 failed / 0 errors**。
 五项静态门全过：import cycle 166 模块 / 0 环、write surface 153/153 unclassified 0、
 static hygiene、public checkout probe --strict exit 0、`git diff --check` 干净；
-closure matrix `status=ok`。
+closure matrix `status=ok`。GitHub CI 对最终提交全绿（full suite + 五门 + 空白门）。
+
+### clean clone + 全新 venv 门：查出两条既有环境缺口
+
+按交接要求做了 exact-commit clean clone + `pip install -e ".[dev]"` 全新 venv 全量，
+**首次跑出 15 failed**——两条都与本轮改动无关，是这道门本身该抓的东西：
+
+1. **`pyproject.toml` 的 dev 依赖在 Windows 上不完整（已修）**。
+   Windows 没有系统 tz 数据库，`zoneinfo.ZoneInfo("UTC")` 直接抛
+   `ZoneInfoNotFoundError`；`plugins/modules/context/digest_consolidation.py` 顶层
+   `from zoneinfo import ZoneInfo`，于是全新 venv 里 15 条测试中的 14 条挂掉
+   （digest_consolidation 10 条 + modules doctor 连带 3 条 + deep_reflection 1 条）。
+   本机之前一直绿是因为系统 Python 恰好装了 `tzdata 2025.3`，CI 绿是因为 Linux 有系统库——
+   **两个环境都在替这条缺失依赖兜底**，只有全新 venv 会暴露它。
+   已加 `tzdata; sys_platform == "win32"` 到 dev extras，实测 14 条全部转绿。
+   （未动运行时 `dependencies = []`：生产两台主机都是 Linux；但需记住
+   digest_consolidation 在 Windows 运行时同样会炸。）
+2. **`test_isolated_worker_executes_without_session_or_delivery_files` 在全新 venv 下必红（未修，登记）**。
+   该测试 `os.symlink(sys.executable, host/"venv"/"bin"/"python")`，
+   在 venv 里 `sys.executable` 是 `.venv/Scripts/python.exe`，符号链接到 venv 布局之外后
+   丢掉 `pyvenv.cfg` 上下文，子进程于是导不到 editable 装的 `plugins` → `returncode != 0`
+   → `ephemeral_worker_failed`。系统 Python 与 Linux CI 均无此问题。
+   文件不在本轮 diff 内，属既有跨环境假设缺口（与 BU.1「CI 空过、本机绿」、
+   BV 第 0 节「本机红、CI 绿」同族：**测试不验证自己的运行前提**）。
+
+修掉第 1 条后 clean-clone 全新 venv 的剩余失败为 **1 条**，即上述第 2 条。
 
 ---
 

--- a/plugins/memory/memory_os/crystallization_gate.py
+++ b/plugins/memory/memory_os/crystallization_gate.py
@@ -34,8 +34,11 @@ def _gate_error_result(code: str, *, component: str) -> dict[str, Any]:
         "error": code,
         "error_code": code,
         "error_count": 1,
+        # Same record shape as the per-candidate errors below.  These two used to
+        # disagree ("code" here, "error_code" there) inside one return field, so
+        # any consumer that read error_code would have found None on this path.
         "error_records": [
-            {"code": code, "candidate_id": "", "component": component}
+            {"candidate_id": "", "error_code": code, "component": component}
         ],
         "candidate_count": 0,
         "flagged_count": 0,
@@ -147,6 +150,7 @@ def run_crystallization_gate(
                     {
                         "candidate_id": cid,
                         "error_code": "edge_index_unavailable",
+                        "component": "crystallization_gate",
                     }
                 )
                 flagged.append(
@@ -189,6 +193,7 @@ def run_crystallization_gate(
                     error_records.append({
                         "candidate_id": cid,
                         "error_code": "edge_query_failed",
+                        "component": "crystallization_gate",
                     })
                     flagged.append({
                         "candidate_id": cid,
@@ -212,6 +217,7 @@ def run_crystallization_gate(
         error_records.append({
             "candidate_id": "",
             "error_code": "fts_query_failed",
+            "component": "crystallization_gate",
         })
         already_flagged = {
             str(item.get("candidate_id") or "") for item in flagged

--- a/plugins/memory/memory_os/crystallized.py
+++ b/plugins/memory/memory_os/crystallized.py
@@ -1184,6 +1184,28 @@ def read_candidate_queue(
     if error_records is not None:
         error_records.extend(io_result.error_records[-5:])
     candidates: list[CrystallizedCandidate] = []
+
+    def _reject(row: dict[str, Any], error_code: str) -> None:
+        """Record a schema-invalid row instead of dropping it silently.
+
+        These rows have to be visible for the same reason malformed JSON does:
+        the aggregation lane skips queue compaction whenever the reader reports
+        errors, and compaction is an all-or-nothing rewrite.  A row that parses
+        as JSON but is not a usable candidate would otherwise be dropped here
+        and then permanently erased by the next compaction, with nothing
+        anywhere saying so.
+        """
+        if error_records is None:
+            return
+        error_records.append({
+            "component": "crystallized_candidate_queue",
+            "operation": "read_candidate_queue",
+            "error_code": error_code,
+            "severity": "warning",
+            "recoverable": True,
+            "candidate_id": str(row.get("candidate_id") or "")[:120],
+        })
+
     for raw in io_result.records:
         candidate_id = raw.get("candidate_id")
         kind = raw.get("kind")
@@ -1192,14 +1214,18 @@ def read_candidate_queue(
         tags = raw.get("tags") or []
         provenance = raw.get("provenance")
         if not all(isinstance(value, str) and value.strip() for value in (candidate_id, kind, body)):
+            _reject(raw, "candidate_required_field_invalid")
             continue
         if not isinstance(source_event_ids, list) or not isinstance(tags, list):
+            _reject(raw, "candidate_list_field_invalid")
             continue
         if provenance is not None and not isinstance(provenance, dict):
+            _reject(raw, "candidate_provenance_invalid")
             continue
         try:
             rejection_count = int(raw.get("rejection_count", 0))
         except (TypeError, ValueError):
+            _reject(raw, "candidate_rejection_count_invalid")
             continue
         candidates.append(
             CrystallizedCandidate(

--- a/plugins/memory/memory_os/crystallized.py
+++ b/plugins/memory/memory_os/crystallized.py
@@ -16,6 +16,7 @@ from .approval import ApprovalDecision, ApprovalPurpose
 from .audit import append_audit
 from .jsonl_io import append_jsonl_locked, append_jsonl_lines_locked, locked_jsonl_file, _append_line_under_lock
 from .ids import new_crystallized_id
+from .owner_write_authority import validate_consumed_owner_write_context
 from .schema import CRYSTALLIZED_SCHEMA_VERSION
 from .store import MemoryOSStore, _format_frontmatter
 from .review_content_safety import permanent_promotion_forbidden_reason_codes
@@ -43,145 +44,6 @@ class CrystallizedApprovalError(ValueError):
 _PERMANENT_PROMOTION_WRITE_CAPABILITY = object()
 _RESOLVER_PROVISIONAL_WRITE_CAPABILITY = object()
 _PROBE_PROVISIONAL_WRITE_CAPABILITY = object()
-
-
-def _read_jsonl_dict_records(path: Path) -> list[dict[str, Any]]:
-    if not path.exists():
-        return []
-    records: list[dict[str, Any]] = []
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return []
-    for line in lines:
-        if not line.strip():
-            continue
-        try:
-            value = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(value, dict):
-            records.append(value)
-    return records
-
-
-def _validate_consumed_owner_write_context(
-    store: MemoryOSStore,
-    owner_action_context: dict[str, Any] | None,
-    *,
-    candidate: CrystallizedCandidate,
-    decision: ApprovalDecision,
-) -> bool:
-    """Revalidate a consumed Owner action without importing owner_actions.
-
-    Keeping this verification on canonical ledgers avoids a crystallized ↔
-    owner_actions import cycle and, more importantly, avoids trusting a Python
-    object as permanent-write authority.
-    """
-
-    if not isinstance(owner_action_context, dict):
-        return False
-    context = owner_action_context.get("owner_write_context")
-    if not isinstance(context, dict):
-        return False
-    required = {
-        "digest_id",
-        "reply_ingress_id",
-        "owner_id",
-        "channel",
-        "action_type",
-        "target_type",
-        "target_id",
-    }
-    if any(not context.get(key) for key in required):
-        return False
-    if decision.reviewer != str(context.get("owner_id") or ""):
-        return False
-
-    action_type = str(context.get("action_type") or "")
-    target_type = str(context.get("target_type") or "")
-    target_id = str(context.get("target_id") or "")
-    if action_type in {"approve_candidate", "approve_external_evidence"}:
-        if target_type != "candidate" or target_id != candidate.candidate_id:
-            return False
-    elif action_type == "approve_candidate_cluster":
-        action_context = owner_action_context.get("action_context")
-        if not isinstance(action_context, dict):
-            return False
-        scope = action_context.get("candidate_cluster_scope")
-        if not isinstance(scope, dict):
-            return False
-        if f"{scope.get('cluster_id', '')}:{scope.get('scope_hash', '')}" != target_id:
-            return False
-        members = scope.get("member_candidate_ids")
-        if not isinstance(members, list) or candidate.candidate_id not in {str(value) for value in members}:
-            return False
-    else:
-        return False
-
-    token_binding = owner_action_context.get("token_binding")
-    if not isinstance(token_binding, dict):
-        return False
-    digest_id = str(context.get("digest_id") or "")
-    owner_id = str(context.get("owner_id") or "")
-    channel = str(context.get("channel") or "")
-    token_hash = str(token_binding.get("action_token_hash") or "")
-    review_item_id = str(token_binding.get("review_item_id") or "")
-    digest_path = store.roots.memory_os_root / "system" / "owner_review_rendered_digests.jsonl"
-    digest_record = next(
-        (
-            record
-            for record in reversed(_read_jsonl_dict_records(digest_path))
-            if str(record.get("digest_id") or "") == digest_id
-            and str(record.get("owner_id") or "") == owner_id
-            and str(record.get("channel") or "") == channel
-        ),
-        None,
-    )
-    if digest_record is None:
-        return False
-    rendered = digest_record.get("rendered_digest")
-    if not isinstance(rendered, dict):
-        return False
-    sections = rendered.get("sections")
-    if not isinstance(sections, dict):
-        return False
-    token_match = False
-    for section_items in sections.values():
-        if not isinstance(section_items, list):
-            continue
-        for item in section_items:
-            if not isinstance(item, dict) or str(item.get("review_item_id") or "") != review_item_id:
-                continue
-            actions = item.get("action_tokens")
-            targets = item.get("action_targets")
-            if not isinstance(actions, dict) or not isinstance(targets, dict):
-                continue
-            token = str(actions.get(action_type) or "")
-            target = targets.get(action_type)
-            if not token or not isinstance(target, dict):
-                continue
-            token_match = (
-                hashlib.sha256(token.encode("utf-8")).hexdigest() == token_hash
-                and str(target.get("target_type") or "") == target_type
-                and str(target.get("target_id") or "") == target_id
-            )
-            if token_match:
-                break
-        if token_match:
-            break
-    if not token_match:
-        return False
-
-    consumption_path = store.roots.memory_os_root / "system" / "owner_action_context_consumptions.jsonl"
-    return any(
-        str(record.get("status") or "") == "consumed"
-        and str(record.get("context_id") or "") == str(owner_action_context.get("owner_write_context_id") or "")
-        and all(str(record.get(key) or "") == str(context.get(key) or "") for key in (
-            "digest_id", "owner_id", "channel", "action_type", "target_type", "target_id"
-        ))
-        for record in _read_jsonl_dict_records(consumption_path)
-    )
 
 
 def _canonical_transition_locked(method):
@@ -296,11 +158,11 @@ class CrystallizedMemoryService:
             # Owner-action ingress must first bind and consume one recorded
             # digest action context; the validator re-checks that durable
             # context against this exact candidate and decision.
-            if not _validate_consumed_owner_write_context(
+            if not validate_consumed_owner_write_context(
                 self.store,
                 owner_action_context,
-                candidate=candidate,
-                decision=decision,
+                candidate_id=candidate.candidate_id,
+                reviewer=decision.reviewer,
             ):
                 raise CrystallizedApprovalError("invalid or unconsumed owner action context")
         created_at = _timestamp(now)

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -36,6 +36,13 @@ from .memory_sources import (
     read_memory_source_feedback_records,
     read_memory_source_records,
 )
+from .owner_write_authority import (
+    OWNER_CANONICAL_WRITE_ACTION_TYPES,
+    owner_action_context_consumptions_path,
+    owner_review_rendered_digests_path,
+    safe_channel as _safe_channel,
+    verify_owner_write_binding as _verified_owner_write_binding,
+)
 from .read_model_paths import owner_actions_path as _owner_actions_path
 from .roots import MemoryOSRoots
 from .jsonl_io import (
@@ -211,10 +218,6 @@ ACTION_TYPES = {
     *PERMANENT_PROMOTION_ACTION_TYPES,
 }
 
-OWNER_CANONICAL_WRITE_ACTION_TYPES = frozenset(
-    {"approve_candidate", "approve_candidate_cluster", "approve_external_evidence"}
-)
-
 # V2-0 registry: scope the permanent-promotion delivery contract narrowly so
 # unrelated owner-review systems never contribute to its hard-zero invariants.
 LIVING_MEMORY_TARGET_TYPES = frozenset(
@@ -290,14 +293,6 @@ def right_brain_expression_outcomes_path(roots: MemoryOSRoots) -> Path:
 
 def owner_review_deliveries_path(roots: MemoryOSRoots) -> Path:
     return roots.memory_os_root / "system" / "owner_review_deliveries.jsonl"
-
-
-def owner_review_rendered_digests_path(roots: MemoryOSRoots) -> Path:
-    return roots.memory_os_root / "system" / "owner_review_rendered_digests.jsonl"
-
-
-def owner_action_context_consumptions_path(roots: MemoryOSRoots) -> Path:
-    return roots.memory_os_root / "system" / "owner_action_context_consumptions.jsonl"
 
 
 def owner_review_cron_helper_path(roots: MemoryOSRoots) -> Path:
@@ -2908,83 +2903,6 @@ def _assemble_living_memory_delivery_items(
     }
 
 
-def _verified_owner_write_binding(
-    store: MemoryOSStore,
-    record: dict[str, Any],
-) -> tuple[dict[str, Any], str]:
-    context = record.get("owner_write_context") if isinstance(record.get("owner_write_context"), dict) else {}
-    token_binding = record.get("token_binding") if isinstance(record.get("token_binding"), dict) else {}
-    action_type = str(record.get("action_type") or "")
-    target_type = str(record.get("target_type") or "")
-    target_id = str(record.get("target_id") or "")
-    owner_id = str(record.get("owner_id") or "")
-    channel = _safe_channel(str(record.get("channel") or ""))
-    digest_id = str(context.get("digest_id") or "")
-    reply_ingress_id = str(context.get("reply_ingress_id") or "")
-    token_hash = str(token_binding.get("action_token_hash") or "")
-    source = str(context.get("source") or "")
-    if action_type not in OWNER_CANONICAL_WRITE_ACTION_TYPES:
-        return {}, "owner_write_action_not_authorized"
-    if source not in {"recorded_digest", "latest_recorded_digest", "latest_owner_home_digest"}:
-        return {}, "owner_write_recorded_digest_required"
-    if not digest_id or not reply_ingress_id or len(token_hash) != 64:
-        return {}, "owner_write_context_incomplete"
-    if any(
-        str(context.get(key) or "") != expected
-        for key, expected in (
-            ("owner_id", owner_id),
-            ("channel", channel),
-            ("action_type", action_type),
-            ("target_type", target_type),
-            ("target_id", target_id),
-        )
-    ):
-        return {}, "owner_write_context_mismatch"
-    digest_record = _find_rendered_digest_record(
-        store.roots,
-        digest_id=digest_id,
-        owner_id=owner_id,
-        channel=channel,
-    )
-    if not digest_record:
-        return {}, "owner_write_recorded_digest_not_found"
-    rendered = _rendered_digest_from_record(digest_record)
-    matched: dict[str, Any] | None = None
-    for token, token_match in _rendered_action_token_map(rendered).items():
-        if hashlib.sha256(token.encode("utf-8")).hexdigest() != token_hash:
-            continue
-        matched = token_match
-        break
-    if not matched:
-        return {}, "owner_write_token_not_in_recorded_digest"
-    if any(
-        str(matched.get(key) or "") != expected
-        for key, expected in (
-            ("action_type", action_type),
-            ("target_type", target_type),
-            ("target_id", target_id),
-        )
-    ):
-        return {}, "owner_write_token_target_mismatch"
-    item = matched.get("item") if isinstance(matched.get("item"), dict) else {}
-    expected_review_item_id = str(item.get("review_item_id") or f"{target_type}:{target_id}")
-    if str(token_binding.get("review_item_id") or "") != expected_review_item_id:
-        return {}, "owner_write_review_item_mismatch"
-    return {
-        "schema_version": "memory-os.owner_write_context_consumption.v0",
-        "context_id": reply_ingress_id,
-        "digest_id": digest_id,
-        "reply_sha256": str(context.get("reply_sha256") or ""),
-        "action_token_hash": token_hash,
-        "review_item_id": expected_review_item_id,
-        "action_type": action_type,
-        "target_type": target_type,
-        "target_id": target_id,
-        "owner_id": owner_id,
-        "channel": channel,
-    }, ""
-
-
 def _consume_owner_write_context(store: MemoryOSStore, record: dict[str, Any]) -> dict[str, Any]:
     consumption, error = _verified_owner_write_binding(store, record)
     if error:
@@ -3002,63 +2920,6 @@ def _consume_owner_write_context(store: MemoryOSStore, record: dict[str, Any]) -
             json.dumps(consumption, ensure_ascii=False, sort_keys=True) + "\n",
         )
     return dict(consumption)
-
-
-def _validate_consumed_owner_write_context(
-    store: MemoryOSStore,
-    owner_action_context: dict[str, Any] | None,
-    *,
-    candidate: CrystallizedCandidate,
-    decision: ApprovalDecision,
-) -> bool:
-    if not isinstance(owner_action_context, dict):
-        return False
-    consumption, error = _verified_owner_write_binding(store, owner_action_context)
-    if error:
-        return False
-    if decision.reviewer != str(consumption.get("owner_id") or ""):
-        return False
-    action_type = str(consumption.get("action_type") or "")
-    target_type = str(consumption.get("target_type") or "")
-    target_id = str(consumption.get("target_id") or "")
-    if action_type in {"approve_candidate", "approve_external_evidence"}:
-        if target_type != "candidate" or target_id != candidate.candidate_id:
-            return False
-    elif action_type == "approve_candidate_cluster":
-        action_context = (
-            owner_action_context.get("action_context")
-            if isinstance(owner_action_context.get("action_context"), dict)
-            else {}
-        )
-        scope = (
-            action_context.get("candidate_cluster_scope")
-            if isinstance(action_context.get("candidate_cluster_scope"), dict)
-            else {}
-        )
-        scoped_target_id = f"{str(scope.get('cluster_id') or '')}:{str(scope.get('scope_hash') or '')}"
-        if scoped_target_id != target_id:
-            return False
-        if candidate.candidate_id not in {str(value) for value in scope.get("member_candidate_ids") or []}:
-            return False
-    else:
-        return False
-    context_id = str(consumption.get("context_id") or "")
-    for existing in reversed(_read_jsonl(owner_action_context_consumptions_path(store.roots))):
-        if str(existing.get("context_id") or "") != context_id:
-            continue
-        return all(
-            str(existing.get(key) or "") == str(consumption.get(key) or "")
-            for key in (
-                "digest_id",
-                "action_token_hash",
-                "action_type",
-                "target_type",
-                "target_id",
-                "owner_id",
-                "channel",
-            )
-        ) and str(existing.get("status") or "") == "consumed"
-    return False
 
 
 def apply_owner_action(
@@ -5599,6 +5460,11 @@ def _digest_item(item: dict[str, Any]) -> dict[str, Any]:
         "requires_maturation": bool(item.get("requires_maturation")),
         "expression_preview": _bounded_text(str(item.get("expression_preview") or ""), 360),
         "expression_preview_suppressed": bool(item.get("expression_preview_suppressed")),
+        # Carried through the bounded copy because _render_review_item() decides
+        # from it whether a candidate is offered approve_external_evidence or
+        # approve_candidate.  Dropping it here silently downgraded every tainted
+        # candidate to the ordinary-candidate branch on this render path.
+        "external_review_eligible": bool(item.get("external_review_eligible")),
         "payload_ref": _bounded_text(str(item.get("payload_ref") or ""), 220),
         "session_mirror_approval": _bounded_session_mirror_approval(
             item.get("session_mirror_approval") if isinstance(item.get("session_mirror_approval"), dict) else {}
@@ -6019,9 +5885,16 @@ def _review_actions(target_type: str, target_id: str) -> list[dict[str, str]]:
     if not target_id:
         return []
     if target_type == "candidate":
+        # No approve_external_evidence here.  This branch only renders ordinary
+        # candidates: a candidate whose provenance is actually tainted is caught
+        # earlier in _render_review_item() by the external_review_eligible test
+        # and offered approve_external_evidence instead of approve_candidate.
+        # Offering it to every candidate put a permanently invalid action in the
+        # Owner's digest — production validation still fails it closed, but a
+        # governance surface that lists actions the Owner cannot take teaches the
+        # Owner to ignore it.
         return [
             _review_action("approve", "approve_candidate", target_type, target_id),
-            _review_action("approve", "approve_external_evidence", target_type, target_id),
             _review_action("reject", "reject_candidate", target_type, target_id),
         ]
     if target_type == "candidate_cluster":
@@ -7070,26 +6943,6 @@ def _digest_mode(value: str | None) -> str:
 def _digest_id() -> str:
     created_at = datetime.now(timezone.utc)
     return f"odig_{created_at.strftime('%Y%m%dT%H%M%S%fZ')}_{uuid4().hex[:8]}"
-
-
-def _safe_channel(value: str) -> str:
-    channel = str(value or "").strip().lower().replace("-", "_")
-    allowed = {
-        "telegram",
-        "cli",
-        "web",
-        "slack",
-        "whatsapp",
-        "wecom",
-        "wechat",
-        "weixin",
-        "matrix",
-        "discord",
-        "signal",
-        "origin",
-        "unknown",
-    }
-    return channel if channel in allowed else "unknown"
 
 
 def _safe_target_ref(value: str) -> str:

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -3023,6 +3023,24 @@ def apply_owner_action(
         if action_type in OWNER_CANONICAL_WRITE_ACTION_TYPES:
             context_result = _consume_owner_write_context(store, record)
             if context_result.get("status") != "consumed":
+                # persist_error=False below keeps an unauthorized caller from
+                # appending to the owner-action ledger at all.  That is the
+                # right call, but it would otherwise leave a rejected
+                # canonical-write attempt with no durable trace anywhere, so
+                # record the rejection on the audit channel instead — bounded
+                # fields only, never the offered token.
+                append_audit(
+                    store.roots.audit_path,
+                    action="owner_canonical_write_authorization_rejected",
+                    status="error",
+                    target=f"{target_type}:{target_id}",
+                    details={
+                        "action_type": action_type,
+                        "owner_id": owner_id,
+                        "channel": _safe_channel(channel),
+                        "code": str(context_result.get("code") or "owner_write_authorization_required"),
+                    },
+                )
                 return _action_error(
                     store,
                     action_type,

--- a/plugins/memory/memory_os/owner_write_authority.py
+++ b/plugins/memory/memory_os/owner_write_authority.py
@@ -1,0 +1,316 @@
+"""Single source of authority for Owner-approved permanent canonical writes.
+
+This module is deliberately low-level.  It depends only on ``roots``/``store``
+path helpers and JSONL primitives, and it must never import ``owner_actions``
+or ``crystallized`` — both of those import *it*.
+
+It exists because the same verification used to be written twice.  ``owner_actions``
+carried the strict copy and ``crystallized`` carried a hand-rolled one added to
+break an import cycle; the two drifted, and the weaker of the pair was the one
+actually guarding production writes.  The ``crystallized`` copy never checked
+that the action context came from a recorded digest (``source``), never checked
+the action type against the canonical-write allowlist, never checked the token
+hash was a full SHA-256, and matched the consumption ledger without comparing
+``action_token_hash``.  Duplicating a security boundary is how a boundary
+quietly becomes optional, so there is one implementation here and no other.
+
+Authority is proved against canonical ledgers on disk.  There is intentionally
+no importable capability object for permanent writes: holding a Python value
+must never stand in for an Owner decision recorded in a delivered digest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .roots import MemoryOSRoots
+from .store import MemoryOSStore
+
+
+# The only action types that may authorize a permanent canonical write.
+OWNER_CANONICAL_WRITE_ACTION_TYPES = frozenset(
+    {"approve_candidate", "approve_candidate_cluster", "approve_external_evidence"}
+)
+
+# An Owner action context is only trusted when it was bound to a digest that was
+# actually rendered and recorded.  Surface-derived bindings are recomputed from
+# current live state and prove nothing about delivery, so they are not listed.
+RECORDED_DIGEST_CONTEXT_SOURCES = frozenset(
+    {"recorded_digest", "latest_recorded_digest", "latest_owner_home_digest"}
+)
+
+OWNER_WRITE_CONTEXT_CONSUMPTION_SCHEMA_VERSION = "memory-os.owner_write_context_consumption.v0"
+
+_SAFE_CHANNELS = frozenset(
+    {
+        "telegram",
+        "cli",
+        "web",
+        "slack",
+        "whatsapp",
+        "wecom",
+        "wechat",
+        "weixin",
+        "matrix",
+        "discord",
+        "signal",
+        "origin",
+        "unknown",
+    }
+)
+
+
+def safe_channel(value: str) -> str:
+    channel = str(value or "").strip().lower().replace("-", "_")
+    return channel if channel in _SAFE_CHANNELS else "unknown"
+
+
+def owner_review_rendered_digests_path(roots: MemoryOSRoots) -> Path:
+    return roots.memory_os_root / "system" / "owner_review_rendered_digests.jsonl"
+
+
+def owner_action_context_consumptions_path(roots: MemoryOSRoots) -> Path:
+    return roots.memory_os_root / "system" / "owner_action_context_consumptions.jsonl"
+
+
+def read_jsonl_dict_records(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            records.append(value)
+    return records
+
+
+def find_rendered_digest_record(
+    roots: MemoryOSRoots,
+    *,
+    digest_id: str,
+    owner_id: str,
+    channel: str,
+) -> dict[str, Any] | None:
+    for record in reversed(read_jsonl_dict_records(owner_review_rendered_digests_path(roots))):
+        if str(record.get("digest_id") or "") != digest_id:
+            continue
+        if owner_id and str(record.get("owner_id") or "") != owner_id:
+            continue
+        if channel and str(record.get("channel") or "") != safe_channel(channel):
+            continue
+        return record
+    return None
+
+
+def _canonical_write_target(action_type: str, item: dict[str, Any]) -> tuple[str, str]:
+    """Resolve the target a rendered action token points at.
+
+    Mirrors the generic digest target resolution for the canonical-write action
+    types: an explicit ``action_targets`` entry wins, otherwise the item's own
+    target fields stand in.  The expression-feedback special case in the generic
+    resolver is intentionally absent — those action types can never reach here.
+    """
+
+    action_targets = item.get("action_targets") if isinstance(item.get("action_targets"), dict) else {}
+    target = action_targets.get(action_type) if isinstance(action_targets.get(action_type), dict) else {}
+    if target:
+        return str(target.get("target_type") or ""), str(target.get("target_id") or "")
+    return str(item.get("target_type") or ""), str(item.get("target_id") or "")
+
+
+def _match_recorded_action_token(
+    rendered: dict[str, Any],
+    *,
+    token_hash: str,
+) -> dict[str, Any] | None:
+    """Find the rendered item whose action token hashes to *token_hash*.
+
+    Tokens are matched by hash rather than by value so the caller never has to
+    carry the raw token, and lower-cased before hashing to match how the reply
+    ingress derives the binding.
+    """
+
+    sections = rendered.get("sections") if isinstance(rendered.get("sections"), dict) else {}
+    for items in sections.values():
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            tokens = item.get("action_tokens") if isinstance(item.get("action_tokens"), dict) else {}
+            for action_type, token in tokens.items():
+                clean = str(token or "").lower()
+                if not clean:
+                    continue
+                if hashlib.sha256(clean.encode("utf-8")).hexdigest() != token_hash:
+                    continue
+                target_type, target_id = _canonical_write_target(str(action_type), item)
+                return {
+                    "item": item,
+                    "action_type": str(action_type),
+                    "target_type": target_type,
+                    "target_id": target_id,
+                }
+    return None
+
+
+def verify_owner_write_binding(
+    store: MemoryOSStore,
+    record: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Verify an Owner action record may authorize a permanent canonical write.
+
+    Returns ``(consumption, "")`` when the record is bound to a recorded digest
+    action token for exactly this owner, channel, action type and target, or
+    ``({}, error_code)`` otherwise.  Every failure path returns an error code —
+    there is no path that returns an empty error with an unverified record.
+    """
+
+    context = record.get("owner_write_context") if isinstance(record.get("owner_write_context"), dict) else {}
+    token_binding = record.get("token_binding") if isinstance(record.get("token_binding"), dict) else {}
+    action_type = str(record.get("action_type") or "")
+    target_type = str(record.get("target_type") or "")
+    target_id = str(record.get("target_id") or "")
+    owner_id = str(record.get("owner_id") or "")
+    channel = safe_channel(str(record.get("channel") or ""))
+    digest_id = str(context.get("digest_id") or "")
+    reply_ingress_id = str(context.get("reply_ingress_id") or "")
+    token_hash = str(token_binding.get("action_token_hash") or "")
+    source = str(context.get("source") or "")
+    if action_type not in OWNER_CANONICAL_WRITE_ACTION_TYPES:
+        return {}, "owner_write_action_not_authorized"
+    if source not in RECORDED_DIGEST_CONTEXT_SOURCES:
+        return {}, "owner_write_recorded_digest_required"
+    if not digest_id or not reply_ingress_id or len(token_hash) != 64:
+        return {}, "owner_write_context_incomplete"
+    if any(
+        str(context.get(key) or "") != expected
+        for key, expected in (
+            ("owner_id", owner_id),
+            ("channel", channel),
+            ("action_type", action_type),
+            ("target_type", target_type),
+            ("target_id", target_id),
+        )
+    ):
+        return {}, "owner_write_context_mismatch"
+    digest_record = find_rendered_digest_record(
+        store.roots,
+        digest_id=digest_id,
+        owner_id=owner_id,
+        channel=channel,
+    )
+    if not digest_record:
+        return {}, "owner_write_recorded_digest_not_found"
+    rendered = digest_record.get("rendered_digest") if isinstance(digest_record.get("rendered_digest"), dict) else {}
+    matched = _match_recorded_action_token(rendered, token_hash=token_hash)
+    if not matched:
+        return {}, "owner_write_token_not_in_recorded_digest"
+    if any(
+        str(matched.get(key) or "") != expected
+        for key, expected in (
+            ("action_type", action_type),
+            ("target_type", target_type),
+            ("target_id", target_id),
+        )
+    ):
+        return {}, "owner_write_token_target_mismatch"
+    item = matched.get("item") if isinstance(matched.get("item"), dict) else {}
+    expected_review_item_id = str(item.get("review_item_id") or f"{target_type}:{target_id}")
+    if str(token_binding.get("review_item_id") or "") != expected_review_item_id:
+        return {}, "owner_write_review_item_mismatch"
+    return {
+        "schema_version": OWNER_WRITE_CONTEXT_CONSUMPTION_SCHEMA_VERSION,
+        "context_id": reply_ingress_id,
+        "digest_id": digest_id,
+        "reply_sha256": str(context.get("reply_sha256") or ""),
+        "action_token_hash": token_hash,
+        "review_item_id": expected_review_item_id,
+        "action_type": action_type,
+        "target_type": target_type,
+        "target_id": target_id,
+        "owner_id": owner_id,
+        "channel": channel,
+    }, ""
+
+
+def validate_consumed_owner_write_context(
+    store: MemoryOSStore,
+    owner_action_context: dict[str, Any] | None,
+    *,
+    candidate_id: str,
+    reviewer: str,
+) -> bool:
+    """Re-verify a consumed Owner action against one specific candidate.
+
+    Takes ``candidate_id``/``reviewer`` as plain strings rather than the
+    candidate and decision objects so this module stays free of any import of
+    ``crystallized``.  Re-running the full binding check here (rather than
+    trusting that ingress already ran it) is deliberate: the write path must be
+    able to prove authority on its own, from the ledgers, at the moment it
+    writes.
+    """
+
+    if not isinstance(owner_action_context, dict):
+        return False
+    consumption, error = verify_owner_write_binding(store, owner_action_context)
+    if error:
+        return False
+    if str(reviewer or "") != str(consumption.get("owner_id") or ""):
+        return False
+    action_type = str(consumption.get("action_type") or "")
+    target_type = str(consumption.get("target_type") or "")
+    target_id = str(consumption.get("target_id") or "")
+    if action_type in {"approve_candidate", "approve_external_evidence"}:
+        if target_type != "candidate" or target_id != str(candidate_id):
+            return False
+    elif action_type == "approve_candidate_cluster":
+        action_context = (
+            owner_action_context.get("action_context")
+            if isinstance(owner_action_context.get("action_context"), dict)
+            else {}
+        )
+        scope = (
+            action_context.get("candidate_cluster_scope")
+            if isinstance(action_context.get("candidate_cluster_scope"), dict)
+            else {}
+        )
+        scoped_target_id = f"{str(scope.get('cluster_id') or '')}:{str(scope.get('scope_hash') or '')}"
+        if scoped_target_id != target_id:
+            return False
+        members = scope.get("member_candidate_ids")
+        if not isinstance(members, list):
+            return False
+        if str(candidate_id) not in {str(value) for value in members}:
+            return False
+    else:
+        return False
+    context_id = str(consumption.get("context_id") or "")
+    for existing in reversed(read_jsonl_dict_records(owner_action_context_consumptions_path(store.roots))):
+        if str(existing.get("context_id") or "") != context_id:
+            continue
+        return str(existing.get("status") or "") == "consumed" and all(
+            str(existing.get(key) or "") == str(consumption.get(key) or "")
+            for key in (
+                "digest_id",
+                "action_token_hash",
+                "action_type",
+                "target_type",
+                "target_id",
+                "owner_id",
+                "channel",
+            )
+        )
+    return False

--- a/plugins/modules/governance/candidate_aggregation.py
+++ b/plugins/modules/governance/candidate_aggregation.py
@@ -708,7 +708,12 @@ def _cluster_and_promote(
                 provisional_promotion=provisional_promotion,
                 cascade_policy=cascade_policy,
             )
-            gate_result = _resolver_candidate_gate_result(store, member)
+            # Gate only the verdicts that could actually write.  It opens two
+            # sqlite connections and runs an FTS query per call, and its result
+            # is read only on the approve path.
+            gate_result = (
+                _resolver_candidate_gate_result(store, member) if verdict.get("approve") else {}
+            )
             if verdict.get("approve") and _resolver_candidate_gate_allows(
                 gate_result, member.candidate_id,
             ):
@@ -862,7 +867,9 @@ def _cluster_and_promote(
                 provisional_promotion=provisional_promotion,
                 cascade_policy=cascade_policy,
             )
-            gate_result = _resolver_candidate_gate_result(store, c)
+            gate_result = (
+                _resolver_candidate_gate_result(store, c) if verdict.get("approve") else {}
+            )
             if verdict.get("approve") and _resolver_candidate_gate_allows(
                 gate_result, c.candidate_id,
             ):
@@ -994,7 +1001,9 @@ def _cluster_and_promote(
             provisional_promotion=provisional_promotion,
             cascade_policy=cascade_policy,
         )
-        gate_result = _resolver_candidate_gate_result(store, c)
+        gate_result = (
+            _resolver_candidate_gate_result(store, c) if verdict.get("approve") else {}
+        )
         if verdict.get("approve") and _resolver_candidate_gate_allows(
             gate_result, c.candidate_id,
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ dev = [
   "pytest>=8",
   "PyYAML>=6",
   "numpy>=1.24",
+  # Windows ships no system tz database, so zoneinfo.ZoneInfo("UTC") raises
+  # ZoneInfoNotFoundError there.  digest_consolidation.py imports ZoneInfo, so a
+  # fresh `pip install -e ".[dev]"` venv on Windows fails 15 tests without this.
+  # Linux/macOS use the OS database and ignore it.
+  'tzdata; sys_platform == "win32"',
 ]
 llm = [
   "openai>=1.0",

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -1198,8 +1198,14 @@ def summarize_living_memory_promotion(
     try:
         from plugins.memory.memory_os.owner_actions import LIVING_MEMORY_TARGET_TYPES
     except Exception:
+        # Must stay identical to owner_actions.LIVING_MEMORY_TARGET_TYPES.  This
+        # fallback only fires where the provider is not importable (clean host,
+        # remote probe), so a stale copy here does not fail loudly — it silently
+        # classifies the same item differently depending on the host, which is
+        # worse.  test_monitor_living_memory_fallback_matches_owner_actions pins
+        # the two together.
         LIVING_MEMORY_TARGET_TYPES = frozenset({
-            "candidate_cluster", "crystallized_record",
+            "crystallized_record",
             "provisional_crystallized_record", "permanent_memory_promotion",
         })
     promo = "permanent_memory_promotion"

--- a/scripts/memory_os_candidate_backfill_409.py
+++ b/scripts/memory_os_candidate_backfill_409.py
@@ -107,6 +107,11 @@ def main(argv: list[str] | None = None) -> int:
         "--hermes-home", default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"),
     )
     parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE") or "default")
+    parser.add_argument(
+        "--execution-gate-envelope-id",
+        default=os.environ.get("MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID", ""),
+        help="ExecutionGate envelope this backfill runs under (required with --apply)",
+    )
     args = parser.parse_args(argv)
 
     if args.apply and not args.confirm_backfill:
@@ -185,6 +190,18 @@ def main(argv: list[str] | None = None) -> int:
 
     # ── Apply ────────────────────────────────────────────────────────
     if args.apply:
+        # append_candidate_triage() is fail-closed on an empty envelope id, so
+        # check it here rather than letting the first write raise PermissionError
+        # after the summary has already been printed.
+        envelope_id = str(args.execution_gate_envelope_id or "").strip()
+        if not envelope_id:
+            print(
+                "ERROR: --apply requires --execution-gate-envelope-id "
+                "(or MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID); candidate triage is a "
+                "governed write and no longer accepts an operator backfill without one.",
+                file=sys.stderr,
+            )
+            return 2
         written = 0
 
         # Tag fleeting
@@ -196,6 +213,7 @@ def main(argv: list[str] | None = None) -> int:
                 target_state="fleeting",
                 reason="backfill: no decision content (chat/acknowledgment only)",
                 now=now,
+                execution_gate_envelope_id=envelope_id,
             )
             written += 1
 
@@ -215,6 +233,7 @@ def main(argv: list[str] | None = None) -> int:
                     reason=reason,
                     cluster_key=key,
                     now=now,
+                    execution_gate_envelope_id=envelope_id,
                 )
                 written += 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,28 @@
 """Shared test isolation helpers.
 
-The canonical-write adapter below is deliberately restricted to *direct calls
-from test modules*.  It never adds authority to a production caller such as
-``owner_actions.py`` or ``candidate_aggregation.py``; those paths must pass the
-real authorization object themselves.  This preserves historical fixture setup
-without allowing a global pytest patch to hide a missing production boundary.
+**Canonical-write authority is not granted automatically.**  A test that writes
+permanent crystallized memory has to say so, by requesting
+``crystallized_test_write_authority`` or declaring it at module level::
+
+    pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
+This used to be an autouse fixture applied to the entire suite.  That is the
+shape of the problem it was meant to solve: a blanket grant means a new test can
+drive a production caller that has *lost* its Owner binding and still go green,
+because the fixture quietly supplied the authority the caller failed to prove.
+Making the grant explicit turns "this test writes canonical memory" into
+something a reviewer can see in the diff, and makes the default fail-closed —
+an undeclared permanent write now raises ``CrystallizedApprovalError``.
+
+The grant is also narrow in a second way: it only applies to calls made
+*directly from a test module*.  Production callers such as ``owner_actions.py``
+and ``candidate_aggregation.py`` still have to pass real authority, so Owner
+ingress, security, and caller tests continue to exercise the real recorded
+digest path.  A test-only fixture must never be able to satisfy a boundary that
+production has to satisfy for itself.
+
+Individual tests can opt back out of a module-level grant with
+``@pytest.mark.require_explicit_crystallized_capability``.
 """
 
 from pathlib import Path
@@ -16,8 +34,10 @@ import pytest
 _TESTS_ROOT = Path(__file__).resolve().parent
 
 
-@pytest.fixture(autouse=True)
-def authorize_direct_crystallized_test_writes(request, monkeypatch):
+@pytest.fixture
+def crystallized_test_write_authority(request, monkeypatch):
+    """Authorize canonical writes issued directly by a test module."""
+
     if request.node.get_closest_marker("require_explicit_crystallized_capability"):
         return
 
@@ -28,13 +48,13 @@ def authorize_direct_crystallized_test_writes(request, monkeypatch):
     import plugins.memory.memory_os.crystallized as crystallized_module
 
     original_write = CrystallizedMemoryService.write_approved_record
-    original_validate_context = crystallized_module._validate_consumed_owner_write_context
+    original_validate_context = crystallized_module.validate_consumed_owner_write_context
     test_context = {"schema_version": "memory-os.test-owner-write-context.v0"}
 
-    def validate_context(store, context, *, candidate, decision):
+    def validate_context(store, context, *, candidate_id, reviewer):
         if context is test_context:
             return True
-        return original_validate_context(store, context, candidate=candidate, decision=decision)
+        return original_validate_context(store, context, candidate_id=candidate_id, reviewer=reviewer)
 
     def authorized_write(self, candidate, decision, *, capability=None, owner_action_context=None, **kwargs):
         caller = inspect.currentframe().f_back
@@ -54,7 +74,7 @@ def authorize_direct_crystallized_test_writes(request, monkeypatch):
             **kwargs,
         )
 
-    monkeypatch.setattr(crystallized_module, "_validate_consumed_owner_write_context", validate_context)
+    monkeypatch.setattr(crystallized_module, "validate_consumed_owner_write_context", validate_context)
     monkeypatch.setattr(CrystallizedMemoryService, "write_approved_record", authorized_write)
 
 

--- a/tests/plugins/memory/test_candidate_aggregation_logic.py
+++ b/tests/plugins/memory/test_candidate_aggregation_logic.py
@@ -33,6 +33,8 @@ from plugins.modules.governance.candidate_aggregation import (
     _MIN_SUBSTANTIVE_CHARS,
 )
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 _VALID_ENVELOPE_ID = "xgate_test_candidate_aggregation_envelope"
 
 

--- a/tests/plugins/memory/test_crystallized_expiry_cliff.py
+++ b/tests/plugins/memory/test_crystallized_expiry_cliff.py
@@ -283,6 +283,8 @@ def test_thundering_herd_top_n(tmp_path):
 
 from plugins.modules.governance.candidate_aggregation import _match_existing_provisional
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def test_bump_recurrence_on_match(tmp_path):
     """D.6: durable 撞已有 provisional → bump recurrence+1 + expires_at 续期，不新建."""

--- a/tests/plugins/memory/test_memory_os_candidate_clusters.py
+++ b/tests/plugins/memory/test_memory_os_candidate_clusters.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 
+from plugins.memory.memory_os.audit import read_audit_entries
 from plugins.memory.memory_os.cli import memory_os_command, register_cli
 from plugins.memory.memory_os.crystallized import CrystallizedCandidate, append_candidate_queue
 from plugins.memory.memory_os.candidate_clusters import (
@@ -191,6 +192,20 @@ def test_direct_candidate_cluster_apply_without_recorded_owner_token_fails_close
     assert result["code"] == "owner_write_recorded_digest_required"
     assert list(store.roots.crystallized_root.glob("*.md")) == []
     assert read_owner_action_records(store.roots) == []
+
+    # Keeping the owner-action ledger empty is deliberate — an unauthorized
+    # caller must not be able to append to it.  But a rejected permanent-write
+    # attempt still has to leave evidence somewhere, or forged-token probing is
+    # invisible; the audit channel carries it.
+    rejections = [
+        entry
+        for entry in read_audit_entries(store.roots.audit_path)
+        if entry.get("action") == "owner_canonical_write_authorization_rejected"
+    ]
+    assert len(rejections) == 1, rejections
+    assert rejections[0]["status"] == "error"
+    assert rejections[0]["details"]["owner_id"] == "attacker-process"
+    assert rejections[0]["details"]["code"] == "owner_write_recorded_digest_required"
 
 
 def test_candidate_cluster_action_scope_change_fails_closed_without_canonical_write(tmp_path):

--- a/tests/plugins/memory/test_memory_os_clearance_cycle.py
+++ b/tests/plugins/memory/test_memory_os_clearance_cycle.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 class FakeRoots:
     def __init__(self, tmp_path: Path) -> None:

--- a/tests/plugins/memory/test_memory_os_clearance_receipts.py
+++ b/tests/plugins/memory/test_memory_os_clearance_receipts.py
@@ -29,6 +29,8 @@ from plugins.memory.memory_os.clearance_receipts import (
     write_clearance_receipt,
 )
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 class FakeRoots:
     def __init__(self, tmp_path: Path) -> None:

--- a/tests/plugins/memory/test_memory_os_cli_modules.py
+++ b/tests/plugins/memory/test_memory_os_cli_modules.py
@@ -22,6 +22,10 @@ from plugins.memory.memory_os.__main__ import main as memory_os_module_main
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.store import MemoryOSStore
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def test_modules_status_reports_commandized_and_uncommandized_modules(tmp_path, monkeypatch, capsys):
     _init_store(tmp_path)

--- a/tests/plugins/memory/test_memory_os_crystallized.py
+++ b/tests/plugins/memory/test_memory_os_crystallized.py
@@ -241,6 +241,17 @@ def test_candidate_queue_skips_malformed_and_invalid_rows(tmp_path):
         "jsonl_malformed_line",
         "jsonl_non_object_line",
     }
+    # A row that parses as JSON but is not a usable candidate must be reported
+    # too, not dropped in silence.  The aggregation lane skips its all-or-nothing
+    # queue compaction whenever the reader reports errors, so an unreported drop
+    # here becomes a permanent deletion at the next compaction.
+    schema_rejects = [
+        record for record in errors
+        if record["error_code"] == "candidate_required_field_invalid"
+    ]
+    assert len(schema_rejects) == 1, errors
+    assert schema_rejects[0]["candidate_id"] == "missing-body"
+    assert schema_rejects[0]["component"] == "crystallized_candidate_queue"
 
 
 def test_approved_record_frontmatter_contains_approval_metadata_and_source_events(tmp_path):

--- a/tests/plugins/memory/test_memory_os_crystallized.py
+++ b/tests/plugins/memory/test_memory_os_crystallized.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import importlib.util
 import threading
 
 import pytest
@@ -25,6 +26,8 @@ from plugins.memory.memory_os.fixtures import build_event
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.schema import CRYSTALLIZED_SCHEMA_VERSION, EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
 
 
 def _service(tmp_path):
@@ -118,6 +121,31 @@ def test_caller_minted_resolver_provisional_requires_automation_capability(tmp_p
     assert list(service.store.roots.crystallized_root.glob("*.md")) == []
 
 
+def test_canonical_write_authority_fixture_is_opt_in_rather_than_autouse():
+    """The suite-wide grant must stay something a test has to ask for.
+
+    While ``crystallized_test_write_authority`` was autouse, every test in the
+    repository silently held permanent-write authority, so a production caller
+    that stopped proving its Owner binding still went green.  The two tests above
+    only demonstrate fail-closed behaviour because the default is *no* grant;
+    if this fixture were ever made autouse again they would start passing for
+    the wrong reason, and nothing else would notice.
+    """
+    conftest_path = Path(__file__).resolve().parents[2] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("_suite_conftest_probe", conftest_path)
+    suite_conftest = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(suite_conftest)
+
+    fixture = suite_conftest.crystallized_test_write_authority
+    # pytest >= 8.4 exposes the marker as ``_fixture_function_marker``; older
+    # releases attach ``_pytestfixturefunction`` to the function itself.
+    marker = getattr(fixture, "_fixture_function_marker", None) or getattr(
+        fixture, "_pytestfixturefunction", None
+    )
+    assert marker is not None, "could not locate the fixture marker on this pytest version"
+    assert marker.autouse is False
+
+
 def test_write_capability_imports_are_restricted_to_governed_production_callers():
     repo_root = Path(__file__).resolve().parents[3]
     expected = {
@@ -133,7 +161,7 @@ def test_write_capability_imports_are_restricted_to_governed_production_callers(
     }
     for capability, allowed in expected.items():
         found = {
-            str(path.relative_to(repo_root))
+            path.relative_to(repo_root).as_posix()
             for base in (repo_root / "plugins", repo_root / "scripts")
             for path in base.rglob("*.py")
             if capability in path.read_text(encoding="utf-8", errors="ignore")

--- a/tests/plugins/memory/test_memory_os_e2e.py
+++ b/tests/plugins/memory/test_memory_os_e2e.py
@@ -15,6 +15,8 @@ from plugins.memory.memory_os.inner_drive import InnerDriveEngine
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.store import MemoryOSStore
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 class FakeHindsightClient:
     def __init__(self):

--- a/tests/plugins/memory/test_memory_os_external_evidence_immunity.py
+++ b/tests/plugins/memory/test_memory_os_external_evidence_immunity.py
@@ -19,6 +19,8 @@ from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.modules.governance.candidate_aggregation import _cluster_and_promote
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 _VALID_ENVELOPE_ID = "xgate_test_external_evidence_immunity"
 
 

--- a/tests/plugins/memory/test_memory_os_external_evidence_owner_action.py
+++ b/tests/plugins/memory/test_memory_os_external_evidence_owner_action.py
@@ -116,7 +116,98 @@ def _approve_external_via_recorded_digest(
     return dict(parsed["owner_action_result"])
 
 
+def _rendered_candidate_action_types(
+    store: MemoryOSStore,
+    candidate_id: str,
+    *,
+    owner_id: str = "test-owner",
+) -> set[str]:
+    """Return the exact set of action types the Owner digest offers a candidate."""
+    channel = "telegram"
+    save_config(
+        {
+            "owner_review": {
+                "enabled": True,
+                "actions_enabled": True,
+                "recurring_delivery_enabled": True,
+                "recurring_delivery_mode": "hermes_cron",
+                "recurring_delivery_channel": channel,
+                "recurring_delivery_target_class": "owner_home",
+            }
+        },
+        store.roots.hermes_home,
+    )
+    rendered = render_owner_review_digest(
+        store,
+        owner_id=owner_id,
+        channel=channel,
+        max_action_required=20,
+        max_review_suggested=20,
+        max_fyi=20,
+        record_active=True,
+    )
+    item = next(
+        item
+        for items in rendered["sections"].values()
+        for item in items
+        if item.get("target_type") == "candidate" and item.get("target_id") == candidate_id
+    )
+    tokens = item.get("action_tokens") if isinstance(item.get("action_tokens"), dict) else {}
+    return set(tokens)
+
+
 # ── Tests ────────────────────────────────────────────────────────────────
+
+
+class TestExternalEvidenceActionIsOfferedOnlyWhereItIsValid:
+    """The digest must not offer an action the Owner is not allowed to take.
+
+    ``_review_actions()`` used to hand ``approve_external_evidence`` to *every*
+    candidate.  Production validation still rejected it for untainted candidates
+    (see ``test_approve_external_evidence_untainted_candidate_rejected``), so
+    this was never an authority bypass — but it put a permanently invalid action
+    in front of the Owner on every ordinary candidate, which trains the Owner to
+    ignore the surface that governance depends on them reading.
+
+    Both assertions are exact-set rather than ``in``/``not in``, so the inverse
+    regression — a tainted candidate silently losing its external action — fails
+    here too.
+    """
+
+    def test_ordinary_candidate_is_not_offered_external_evidence_approval(self, tmp_path):
+        store = _store(tmp_path)
+        append_candidate_queue(
+            store,
+            CrystallizedCandidate(
+                candidate_id="cand-ordinary-001",
+                kind="moment",
+                body="An ordinary candidate with no external provenance.",
+                source_event_ids=["evt-ordinary-001"],
+                sensitivity="private",
+                tags=["test"],
+                bridge_state="owner_eligible",
+                created_at=datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+
+        assert _rendered_candidate_action_types(store, "cand-ordinary-001") == {
+            "approve_candidate",
+            "reject_candidate",
+        }
+
+    def test_tainted_candidate_is_offered_external_evidence_instead_of_plain_approve(self, tmp_path):
+        store = _store(tmp_path)
+        _create_tainted_candidate(
+            store,
+            candidate_id="cand-tainted-001",
+            content="Externally sourced claim needing evidence review.",
+            external_ref="ext://provider/doc-1",
+        )
+
+        assert _rendered_candidate_action_types(store, "cand-tainted-001") == {
+            "approve_external_evidence",
+            "reject_candidate",
+        }
 
 
 class TestApproveExternalEvidenceOwnerAction:

--- a/tests/plugins/memory/test_memory_os_fact_judge.py
+++ b/tests/plugins/memory/test_memory_os_fact_judge.py
@@ -11,6 +11,10 @@ from plugins.memory.memory_os.crystallized import CrystallizedCandidate
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.store import MemoryOSStore
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -25,6 +25,10 @@ from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.schema import EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -1053,6 +1053,49 @@ def _seed_contradicts_edge(
     )
 
 
+def test_gate_error_records_use_one_shape_on_every_path(tmp_path):
+    """Every error record the gate emits must be readable the same way.
+
+    The early-return path built ``{"code": ...}`` while the per-candidate paths
+    built ``{"error_code": ...}``, both under the same ``error_records`` key.
+    Nothing crashed because the only consumer reads ``status``, but the next
+    consumer to iterate the records would have found ``error_code`` missing on
+    exactly the paths that matter — the failures.
+    """
+    from plugins.memory.memory_os.crystallization_gate import run_crystallization_gate
+
+    # Path 1: the index cannot be opened at all.
+    unopenable = run_crystallization_gate(str(tmp_path / "no_such_dir" / "index.db"))
+
+    # Path 2: candidates resolve, but no edge index is available to clear them.
+    store, index = _store(tmp_path)
+    _seed_canonical_crystallized(store, [
+        {"id": "cry_shape_a", "kind": "preference",
+         "created_at": "2026-06-01T10:00:00Z",
+         "source_event_ids": ["evt_a"], "tags": [],
+         "body": "The deployment strategy favors gradual rollout over canary."},
+    ])
+    index.rebuild_from_store(store)
+    no_edge_index = run_crystallization_gate(
+        str(index.roots.index_path),
+        candidates=[{
+            "candidate_id": "cand_shape_test",
+            "kind": "preference",
+            "body": "The deployment strategy favors gradual rollout over canary.",
+            "tags_json": "[]",
+        }],
+    )
+
+    assert unopenable["status"] == "error"
+    assert no_edge_index["status"] == "error"
+    for result in (unopenable, no_edge_index):
+        assert result["error_records"], result
+        for record in result["error_records"]:
+            assert set(record) == {"candidate_id", "error_code", "component"}, record
+            assert record["error_code"], record
+            assert record["component"], record
+
+
 def test_t2_2_1_gate_flags_contradicting_candidate(tmp_path):
     """T2.2.1: Gate flags a candidate whose body matches a crystallized
     record that has a contradicts edge."""
@@ -1219,7 +1262,7 @@ def test_t2_2_5_gate_returns_structured_error_when_index_cannot_open(tmp_path):
     assert result["error_code"] == "cannot_open_index"
     assert result["error_count"] == 1
     assert result["error_records"] == [
-        {"code": "cannot_open_index", "candidate_id": "", "component": "sqlite"}
+        {"candidate_id": "", "error_code": "cannot_open_index", "component": "sqlite"}
     ]
 
 
@@ -1234,7 +1277,7 @@ def test_t2_2_5_gate_returns_structured_error_when_candidates_cannot_be_read(tmp
     assert result["error_code"] == "cannot_read_candidates"
     assert result["error_count"] == 1
     assert result["error_records"] == [
-        {"code": "cannot_read_candidates", "candidate_id": "", "component": "sqlite"}
+        {"candidate_id": "", "error_code": "cannot_read_candidates", "component": "sqlite"}
     ]
 
 

--- a/tests/plugins/memory/test_memory_os_hindsight_adapter.py
+++ b/tests/plugins/memory/test_memory_os_hindsight_adapter.py
@@ -20,6 +20,8 @@ from plugins.memory.memory_os.adapters.hindsight import (
     HindsightExportRefused,
 )
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 class FakeHindsightClient:
     def __init__(self, *, fail=False):

--- a/tests/plugins/memory/test_memory_os_living_memory_delivery.py
+++ b/tests/plugins/memory/test_memory_os_living_memory_delivery.py
@@ -7,6 +7,10 @@ from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.store import MemoryOSStore
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def _store(tmp_path: object) -> MemoryOSStore:
     roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")

--- a/tests/plugins/memory/test_memory_os_owner_actions.py
+++ b/tests/plugins/memory/test_memory_os_owner_actions.py
@@ -67,6 +67,8 @@ from plugins.memory.memory_os.substrates.ledger import SubstrateOperationLedger
 from plugins.memory.memory_os.substrates.projection import ProjectionLedger, derive_projection_coherence
 from plugins.modules.governance.proposal_queue import ProposalQueueModule
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def _store(tmp_path, *, profile: str = "main") -> MemoryOSStore:
     roots = MemoryOSRoots.from_hermes_home(tmp_path, profile=profile)

--- a/tests/plugins/memory/test_memory_os_permanent_promotion.py
+++ b/tests/plugins/memory/test_memory_os_permanent_promotion.py
@@ -5,6 +5,8 @@ import re
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def test_proposal_id_and_content_hash_are_stable_for_same_input():
     from plugins.memory.memory_os.permanent_promotion import content_hash, make_proposal_id

--- a/tests/plugins/memory/test_memory_os_permanent_promotion_digest.py
+++ b/tests/plugins/memory/test_memory_os_permanent_promotion_digest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def test_real_production_migration_fixture_is_desensitised_and_non_mutating():
     import json

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -14,6 +14,10 @@ from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, WORKING_SCHEMA_VERSION, EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def _store(tmp_path):
     roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")

--- a/tests/plugins/memory/test_memory_os_vector_retrieval.py
+++ b/tests/plugins/memory/test_memory_os_vector_retrieval.py
@@ -5,6 +5,8 @@ import numpy as np
 import pytest
 from pathlib import Path
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 # ── Mock embedder for tests (no model download needed) ──────────────
 class MockEmbedder:

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -17,6 +17,39 @@ from scripts.memory_os_3_200_monitor import (
 )
 
 
+def test_monitor_living_memory_fallback_matches_owner_actions():
+    """The monitor's embedded fallback set must not drift from the real one.
+
+    ``summarize_living_memory_promotion`` imports ``LIVING_MEMORY_TARGET_TYPES``
+    and falls back to a literal copy when the provider is not importable — which
+    is the normal case on a clean host or through the remote probe.  A stale copy
+    therefore never raises; it just makes the same item count as living memory on
+    one host and not on another.  ``candidate_cluster`` was removed from the real
+    set and left behind here, which is exactly that failure.
+    """
+    import ast
+
+    from plugins.memory.memory_os.owner_actions import LIVING_MEMORY_TARGET_TYPES
+
+    source = Path(monitor.__file__).read_text(encoding="utf-8")
+    literals = [
+        frozenset(ast.literal_eval(node.value.args[0]))
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "LIVING_MEMORY_TARGET_TYPES"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and getattr(node.value.func, "id", "") == "frozenset"
+        and node.value.args
+    ]
+
+    assert literals, "monitor no longer carries a LIVING_MEMORY_TARGET_TYPES fallback literal"
+    for literal in literals:
+        assert literal == LIVING_MEMORY_TARGET_TYPES
+
+
 def test_monitor_script_help_bootstraps_repo_import_path():
     script = Path(__file__).resolve().parents[2] / "scripts" / "memory_os_3_200_monitor.py"
 

--- a/tests/scripts/test_memory_os_index_sync.py
+++ b/tests/scripts/test_memory_os_index_sync.py
@@ -24,6 +24,8 @@ from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.schema import EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def _load_sync_module():
     """Load memory_os_index_sync.py via importlib (same pattern as other script tests)."""

--- a/tests/scripts/test_verify_crystallized_lines_fix.py
+++ b/tests/scripts/test_verify_crystallized_lines_fix.py
@@ -29,6 +29,10 @@ from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.ids import new_crystallized_id, new_event_id
 from datetime import datetime, timezone
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def _ts():
     return datetime.now(timezone.utc).isoformat()

--- a/tests/system_modularization/test_memory_os_agent_os_shell.py
+++ b/tests/system_modularization/test_memory_os_agent_os_shell.py
@@ -1298,5 +1298,3 @@ def test_shell_session_hooks_skip_without_hermes_home(monkeypatch, tmp_path):
 def _audit_entries(hermes_home: Path) -> list[dict[str, Any]]:
     audit_path = hermes_home / "memory-os" / "audit" / "write_audit.jsonl"
     return read_audit_entries(audit_path)
-
-

--- a/tests/system_modularization/test_memory_os_agent_os_shell.py
+++ b/tests/system_modularization/test_memory_os_agent_os_shell.py
@@ -12,9 +12,47 @@ import pytest
 
 from plugins.memory.memory_os.audit import read_audit_entries
 
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SHELL_DIR = REPO_ROOT / "plugins" / "memory-os-agent-os"
+
+_PRESERVED_MODULE_PREFIXES = ("plugins", "memory_os")
+
+
+def _is_preserved_module(name: str) -> bool:
+    return any(name == prefix or name.startswith(f"{prefix}.") for prefix in _PRESERVED_MODULE_PREFIXES)
+
+
+@pytest.fixture(autouse=True)
+def restore_memory_os_import_state():
+    """Restore ``sys.modules``/``sys.path`` after every test in this file.
+
+    Several tests below import a *fake* provider tree out of ``tmp_path``, and to
+    do that they have to displace the real ``plugins`` packages.  Removing only
+    the parent packages is not the same as "not imported" — it leaves their
+    already-imported children behind, which is a hole rather than a clean slate:
+    ``import plugins.memory.memory_os.crystallized as x`` then re-imports a bare
+    ``plugins`` and dies on ``getattr(plugins, "memory")``, taking down every
+    later test in the session.
+
+    Restoring the original module *objects* (rather than clearing the names) is
+    the load-bearing part.  A purge would hand later tests a second, distinct
+    copy of classes that other test modules already bound at collection time, so
+    ``monkeypatch.setattr`` on a class would patch an object under no one's test.
+    That failure is silent; this one at least was loud.
+    """
+    saved_modules = {name: module for name, module in sys.modules.items() if _is_preserved_module(name)}
+    saved_path = list(sys.path)
+    try:
+        yield
+    finally:
+        for name in [name for name in sys.modules if _is_preserved_module(name)]:
+            if name not in saved_modules:
+                del sys.modules[name]
+        sys.modules.update(saved_modules)
+        sys.path[:] = saved_path
 
 
 class FakePluginContext:
@@ -1141,7 +1179,6 @@ def test_shell_runtime_path_adds_flat_provider_parent(monkeypatch, tmp_path):
 
 
 def test_shell_runtime_path_infers_hermes_home_from_installed_plugin_without_env(monkeypatch, tmp_path):
-    original_sys_path = list(sys.path)
     hermes_home = tmp_path / "home"
     installed_shell = hermes_home / "plugins" / "memory-os-agent-os"
     installed_shell.mkdir(parents=True)
@@ -1153,19 +1190,14 @@ def test_shell_runtime_path_infers_hermes_home_from_installed_plugin_without_env
     flat_provider.mkdir(parents=True)
     monkeypatch.delenv("HERMES_HOME", raising=False)
 
-    try:
-        module = load_shell_module_from(shell_init)
-        module._ensure_memory_os_runtime_path()
+    module = load_shell_module_from(shell_init)
+    module._ensure_memory_os_runtime_path()
 
-        assert str(runtime_root) in sys.path
-        assert str(hermes_home / "plugins") in sys.path
-    finally:
-        sys.path[:] = original_sys_path
-        _clear_imported_memory_os_modules()
+    assert str(runtime_root) in sys.path
+    assert str(hermes_home / "plugins") in sys.path
 
 
 def test_shell_alias_imports_provider_from_inferred_runtime_without_env(monkeypatch, tmp_path, capsys):
-    original_sys_path = list(sys.path)
     hermes_home = tmp_path / "home"
     installed_shell = hermes_home / "plugins" / "memory-os-agent-os"
     installed_shell.mkdir(parents=True)
@@ -1195,16 +1227,29 @@ def test_shell_alias_imports_provider_from_inferred_runtime_without_env(monkeypa
     ]:
         sys.modules.pop(name, None)
 
-    try:
-        module = load_shell_module_from(shell_init, name="memory_os_agent_os_shell_installed_runtime")
+    module = load_shell_module_from(shell_init, name="memory_os_agent_os_shell_installed_runtime")
 
-        result = module._memory_os_agent_os_exit_code(argparse.Namespace(agent_os_command="status"))
+    result = module._memory_os_agent_os_exit_code(argparse.Namespace(agent_os_command="status"))
 
-        assert result == 0
-        assert json.loads(capsys.readouterr().out) == {"delegated": "status", "status": "ok"}
-    finally:
-        sys.path[:] = original_sys_path
-        _clear_imported_memory_os_modules()
+    assert result == 0
+    assert json.loads(capsys.readouterr().out) == {"delegated": "status", "status": "ok"}
+
+
+def test_installed_runtime_import_leaves_no_hole_in_the_real_plugins_package():
+    """Counterfactual guard for ``restore_memory_os_import_state``.
+
+    Runs immediately after the two tests that displace the real ``plugins``
+    packages with a fake ``tmp_path`` tree.  Without the restoring fixture the
+    session is left holding ``plugins.memory.memory_os.crystallized`` while
+    ``plugins.memory`` is gone, and this import raises
+    ``ImportError: cannot import name 'memory' from 'plugins'`` — the failure
+    that took out every test sorting after this file.
+    """
+    import plugins.memory.memory_os.crystallized as crystallized_module
+
+    assert Path(sys.modules["plugins"].__file__).resolve() == REPO_ROOT / "plugins" / "__init__.py"
+    assert sys.modules["plugins.memory.memory_os.crystallized"] is crystallized_module
+    assert Path(crystallized_module.__file__).resolve().is_relative_to(REPO_ROOT)
 
 
 def test_shell_session_start_hook_writes_bounded_audit_marker(monkeypatch, tmp_path):
@@ -1255,13 +1300,3 @@ def _audit_entries(hermes_home: Path) -> list[dict[str, Any]]:
     return read_audit_entries(audit_path)
 
 
-def _clear_imported_memory_os_modules() -> None:
-    for name in [
-        "plugins",
-        "plugins.memory",
-        "plugins.memory.memory_os",
-        "plugins.memory.memory_os.cli",
-        "memory_os",
-        "memory_os.cli",
-    ]:
-        sys.modules.pop(name, None)

--- a/tests/system_modularization/test_provisional_sweep_module.py
+++ b/tests/system_modularization/test_provisional_sweep_module.py
@@ -4,6 +4,10 @@ import json
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
 
 def _setup_store_with_provisional_records(tmp_path, *, count=5, expires_days=7):
     """Create a store with provisional crystallized records for sweep testing."""


### PR DESCRIPTION
Continues from the WIP checkpoint `192e056`, which is currently **red on main** — CI run [30697011570](https://github.com/btnalit/Hermes-Memory-OS/actions/runs/30697011570) reports `3011 passed, 13 skipped, 102 errors`.

## P0 — the 102 errors were one root cause, not 102 defects

`tests/system_modularization/test_memory_os_agent_os_shell.py` popped `plugins`, `plugins.memory` and `plugins.memory.memory_os` from `sys.modules` while leaving their already-imported children behind. That is a hole, not a clean slate:

- `from plugins.memory.memory_os.crystallized import X` still succeeds (the leaf is cached)
- `import plugins.memory.memory_os.crystallized as x` fails — that bytecode re-imports a bare `plugins` and then does `getattr(plugins, "memory")`, and the `sys.modules['plugins.memory']` fallback was popped too

The new `tests/conftest.py` ran exactly those two lines at **every test setup**, so every test sorting after that file errored. Reproduced identically in three environments (GitHub Actions, the handoff's Linux isolated run, Windows local).

Fixed with an autouse fixture that snapshots and restores the module **objects**. A full purge was rejected deliberately: other test modules bind classes at collection time, so re-importing hands them a second copy and `monkeypatch.setattr(cls, ...)` patches an object no test is using — turning a loud failure into a silent one.

Also fixes a fourth local failure the handoff did not report: a forward-slash literal compared against native Windows separators.

## P1 — one owner-write validator instead of two

`owner_actions` and `crystallized` each carried `_validate_consumed_owner_write_context`. The `owner_actions` copy was **dead code**; the `crystallized` copy was the one guarding production, and it was the weaker of the pair — it never checked the context came from a recorded digest, never checked the action type against the canonical-write allowlist, never checked the token hash length, and matched the consumption ledger without comparing `action_token_hash`.

Both replaced by `plugins/memory/memory_os/owner_write_authority.py`, which depends only on roots/store/JSONL primitives and exposes no importable permanent-write capability.

## P1 — test write authority is now opt-in

The autouse grant handed permanent-write authority to every test in the repository, so a production caller that stopped proving its Owner binding could still go green. Now a named fixture declared by the 21 files that need it. Notably the Owner ingress and security files stayed green **without** it, confirming they exercise the real recorded-digest path.

## P1 — `approve_external_evidence` offered only where valid

Two stacked defects: `_review_actions()` handed the token to every candidate unconditionally, and `_digest_item()` rebuilt items from a key allowlist that dropped `external_review_eligible` — so on that render path genuinely tainted candidates fell through to the ordinary branch. The pre-existing test only passed **because** of the unconditional token. Covered now by exact action-token-set assertions in both directions.

## P1 — `candidate_cluster` classification

Removing it from `LIVING_MEMORY_TARGET_TYPES` is correct: the set now holds only already-written record-level targets, and a cluster is a proposal to write, exactly like `candidate`, which was never a member. But the monitor's embedded fallback copy still listed it — and that fallback only fires where the provider is not importable, so it never errors, it just classifies the same item differently per host. Fixed and pinned by test.

## 27-file review — five further findings

1. `scripts/memory_os_candidate_backfill_409.py --apply` was broken by this commit's fail-closed triage contract and never updated
2. `crystallization_gate` emitted two error_record shapes under one key
3. `read_candidate_queue()` dropped schema-invalid rows silently — then compaction erased them permanently
4. rejected canonical-write authorization left no durable trace (now audited; ledger stays untouched by design)
5. the crystallization gate ran for every candidate including rejected ones

## Verification

- Full suite **3119 passed / 13 skipped / 0 failed / 0 errors** (was 3010 passed / 1 failed / 102 errors)
- import cycle 166 modules / 0 cycles; write surface 153/153 unclassified 0; static hygiene; public checkout probe `--strict` exit 0; `git diff --check` clean; closure matrix `status=ok`
- Checklist section BW added per CLAUDE.md

Draft: clean-clone + fresh-venv verification still running. Not deployed; no production data touched.
