### PR TITLE
feat(memory-os): Owner reject/defer on session_mirror + cron lane disable audit

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -1960,6 +1960,92 @@ static hygiene / public checkout probe（strict），`git diff --check` 干净�
 
 ---
 
+## BY — session_mirror reject/defer + cron lane 停用审计（2026-08-02）
+
+收网评审后 owner 指定开发待办第 4、5 两项（第 6 项 `oa_` 密钥化明确不做）。
+
+### 待办 4 — owner 无法拒绝 session_mirror 导入审批
+
+owner 只有 approve 一个选项，「别再问了」无法表达。owner 决策：**reject + defer 都做**。
+
+两者语义不同，实现路径也不同：
+
+- **reject = 这个会话别导入**。照现有 `closed` 机制按 target 关闭即可——但**只做这一步是错的**。
+  `SessionMirror.scan()` 的选择是纯队头（`platform_filtered[:limit]`，无任何排除状态），
+  于是被拒绝的会话每次 scan 仍在队头、`return []` 短路，**后面所有会话被永久饿死**，
+  而且 lane 一旦毕业，真正被导入的还是这个被拒绝的会话。所以排除必须由
+  `session_mirror.py` 自己认账：新增 `_owner_rejected_fingerprints()`，从 owner action 账本
+  读回 `reject_session_mirror_apply` 的 fingerprint 并过滤 `new_sessions`，
+  新增 `skipped_by_owner_rejection_count` 保持可见（不静默跳过）。
+  **刻意不写进 SessionMirror state**：`_rebuild_state()` 从事件重建，存那里的拒绝会在下一次
+  state 修复时无声消失、被拒会话复活。账本是 append-only 且从不由事件重建。
+  读取路径复用既有的 `read_jsonl(owner_actions_path(...))`（session_mirror 早已这么读，
+  不 import owner_actions 模块，无环）。
+- **defer = 整条 lane 安静一阵**。**不能**用关闭 target 表达——`target_id` 由队头会话 fingerprint
+  派生，换一个会话就是新 target，owner 立刻又被问。改为 lane 级判定
+  `_session_mirror_lane_deferred()`，照搬 `defer_candidate_cluster` 的既有契约
+  （`deferred_until`、默认 7 天、过期自动重开）。
+
+顺链改到的地方：action 类型集合、`TERMINAL_ACTIONS_BY_TARGET_TYPE`、
+`_closed_targets` 的 defer 过期判定抽成 `DEFER_ACTION_TYPES`（漏登记 = 永久关闭而非暂停）、
+idempotency 的过期 defer 重发、action_type→target_type 映射、
+`_owner_action_type_from_reply`、`_reply_verb_matches_action_type`、`_review_actions`、
+校验与 effect handler、owner 可见文案两处（例句原本只显示 approve 一条、后果说明只讲批准）。
+
+`_session_mirror_apply_review_items` 的 `lane_deferred` **故意设为必填关键字参数**（Section W
+第 4 条）：它有两个调用方（digest 组装、aging report），给默认值就会漏掉一个、让被 owner
+静音的项在另一个面继续出现。实测这个决定当场生效——改完两个调用方都以 TypeError 报错而非静默跳过。
+
+安全边界复核：三处 apply 路径（`cli.py:2084`、`session_mirror.py:115/1004`）都硬比对
+`approve_session_mirror_apply`，因此 reject/defer 记录**结构上不可能**授权一次导入；
+两个新类型也未加入 `DIGEST_OPTIONAL_SURFACE_ACTION_TYPES`，仍需 recorded digest 绑定。
+
+### 待办 5 — cron lane 停用没有审计痕迹
+
+生产实况：`memory-os-expression-feedback-request`（active-closure 8 个 job 之一）在 Hermes job
+层 `enabled=false`，而 `cron_lane_disabled.json` **根本不存在**——停用绕开了文档化的 per-lane
+机制，主机上没有任何地方记录原因。owner 决策：**保持停用，但补正式审计记录**。
+
+- `cron_lane_disabled.json` 升 v1：新增 `{"lanes": {key: {reason, actor, disabled_at}}}` 形状，
+  两种旧形状（裸 list、`disabled_lane_keys` 包装）继续解析并回落为空审计字段。
+  新增 `read_lane_disable_records()` / `build_lane_disable_state()`；
+  `read_disabled_lane_keys()` 改为它的派生。**"损坏文件不停用任何 lane"这一失败方向保持不变**。
+- `memory_os_cron_group_runner.py` 里的**第二份拷贝**同步（Section W 第 5 条）。
+  反事实实测：不同步的话，一旦 owner 记了原因、keys 挪到 `lanes` 下，旧解析器就读不到，
+  **审计动作本身会把停用的 lane 重新跑起来**。
+- monitor：`helper_completion_disabled_records` 带出 source/reason/actor/disabled_at；
+  新增「停用但无原因」独立信号 `helper_completion_disabled_undocumented_count` 与 WARN 码
+  `execution_gate_memory_os_cron_helper_completion_disabled_without_audit_record`。
+  状态可能是对的，但「对且无解释」在下次复审时与漂移不可区分。
+
+### 顺手关闭待办 1（比原记录严重）
+
+按 Section W 第 5 条扫同类模式时查实：**未注册的 WARN 码在 clean-host 会被判
+`clean_host_warn_unclassified`，那是 FAIL 不是 WARN**。原记录以为要不要注册取决于
+`deploy_memory_os.py` 是否接入 cron onboarding，实际无关——任何 clean host 上只要有 lane
+被停用/stale/尚未跑过，monitor 就会因为这个红。五个码全部注册，
+一律 `warn_if_production`：**只修 clean-host，绝不把现有生产 WARN 升级成 FAIL**
+（生产当前正在 WARN 的 `..._disabled` 与 `..._boundary_unobserved` 行为不变）。
+
+### 反事实覆盖
+
+7 项全部 revert→FAIL→restore→PASS 实测通过：scan 排除过滤、`DEFER_ACTION_TYPES` 过期重开、
+lane defer 静音、group runner v1 形状、monitor 未登记停用追踪、clean-host WARN 注册、
+reply verb 映射。
+
+### 测试与门
+
+3130 → **3148 passed / 13 skipped / 0 failed**（+18）。
+import cycle / write surface（unclassified 0）/ public checkout probe --strict / `git diff --check`
+全过。`static_hygiene` 的 `compileall` 子项在本 worktree 内 FAIL，经定位为 **Windows MAX_PATH
+环境伪影**：该检查把源码绝对路径镜像到临时 `pycache_prefix` 下，worktree 路径较长导致
+目标 261 字符、超 260 上限一个字符；换短 prefix 后 `compileall` exit 0，全部文件正常编译，
+非代码缺陷（主检出与 Linux CI 不受影响）。
+
+仅 `local_pass`：本节记录时尚未部署 3.200。
+
+---
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -1969,17 +2055,16 @@ BJ 待办的"9 项 Windows 本地 pre-existing 测试失败诊断"已由 BK 完�
 已修复；2/9（pytest_policy skip-count）诊断为本机环境伪影，非项目代码缺陷，不修复。
 
 当前遗留：
-1. 四个 helper-completion 兄弟 WARN 码的 clean-host 分类表注册（视 `deploy_memory_os.py` 是否
-   接入 cron onboarding 决定是否需要，BJ 记录）。
+1. ~~四个 helper-completion 兄弟 WARN 码的 clean-host 分类表注册~~ —— **BY 已关闭**，且实测
+   比原记录更严重：未注册的 WARN 码在 clean-host 会落 `clean_host_warn_unclassified` 即 **FAIL**，
+   与 `deploy_memory_os.py` 是否接入 cron onboarding 无关。五个码（含 BY 新增的
+   `..._disabled_without_audit_record`）全部按 `warn_if_production` 注册，生产行为不变。
 2. `install_memory_os_plugin.py` 五处 `str(path.relative_to(...))` 与本次修复的
    `plan_deployment()` 同一模式，当前无触发路径，暂不改动（BK 记录）。
 3. `shell_alias_no_env()` 的 22 条 CLI 探针命令并行执行（`ThreadPoolExecutor`）对同一
    `HERMES_HOME` 文件/SQLite 状态的一般性并发风险——无实测复现、无并发单测覆盖，记录为已知
    残留风险（BM 记录，`review_reply` 使用假 token 探针本身已确认安全）。
-4. **owner 无法拒绝 session_mirror 导入审批**：`session_mirror_apply` 只暴露 approve，
-   `TERMINAL_ACTIONS_BY_TARGET_TYPE` 也只认 approve，且 target_id 随首个 pending 会话
-   fingerprint 变化。owner 目前没有「别再问了」的表达方式。补 reject/defer 需新 owner
-   action 类型 + 终态注册 + handler + 回滚契约，属治理面扩张，待 owner 决策（BX 记录）。
+4. ~~owner 无法拒绝 session_mirror 导入审批~~ —— **BY 已关闭**（owner 决策：reject + defer 都做）。
 
 （原 4、5 两项——BP 记录的 Track A 模块/脚本落差与 `unread_partner_replies` 语义缺口——已随
 BQ 的 community 模块整体迁出本仓库，不再是本仓库待办；债务记录随代码一并迁至
@@ -2209,3 +2294,22 @@ sannai-community 仓库 README。）
   3119 → **3130 passed / 13 skipped / 0 failed**，四道静态门全过。
   仅 `local_pass`：未跑 3.200 live monitor、未部署。
   留 1 项待 owner 决策：session_mirror 审批目前无 reject/defer（待办第 4 项）。
+- `54296ea..（BY，本节）`：收网评审后按 owner 指定开发待办第 4、5 两项（第 6 项 `oa_` 密钥化
+  明确不做）。**第 4 项最重的一点不是加两个 action 类型，而是查实 reject 若只关闭 target 会
+  饿死整条队列**——`SessionMirror.scan()` 选择是纯队头且无排除状态，被拒会话每次仍在队头、
+  短路返回，后面所有会话永不出现，lane 毕业后真正导入的还是它；排除因此下沉到
+  `session_mirror.py` 自己的 `_owner_rejected_fingerprints()`，且**刻意读 owner action 账本
+  而非写进 state**（`_rebuild_state()` 从事件重建，存 state 的拒绝会在修复时无声消失）。
+  defer 则不能按 target 关闭（`target_id` 随队头 fingerprint 变，换个会话又问一遍），
+  改为 lane 级判定并照搬 `defer_candidate_cluster` 的 `deferred_until`/7 天/过期重开契约；
+  `_closed_targets` 的过期判定抽成 `DEFER_ACTION_TYPES`（漏登记 = 永久关闭而非暂停）。
+  `lane_deferred` 设为必填关键字参数，当场把两个调用方炸成 TypeError 而非静默漏改。
+  第 5 项 `cron_lane_disabled.json` 升 v1 带 reason/actor/disabled_at，两种旧形状继续解析，
+  「损坏文件不停用任何 lane」的失败方向不变，**group runner 的第二份拷贝同步**
+  （否则记录原因这个动作本身会把停用的 lane 重新跑起来），monitor 新增「停用但无原因」
+  独立 WARN 码。顺手关闭待办 1 并更正其严重性：**未注册 WARN 码在 clean-host 是 FAIL
+  不是 WARN**，与 deploy 是否接入 onboarding 无关；五个码一律按 `warn_if_production` 注册，
+  不把现有生产 WARN 升级成 FAIL。7 项反事实全部 revert→FAIL→restore→PASS 实测。
+  3130 → **3148 passed / 13 skipped / 0 failed**（+18），四道静态门全过；
+  `static_hygiene` 的 compileall 在本 worktree 内 FAIL 已定位为 Windows MAX_PATH 伪影
+  （镜像路径 261 字符超 260 一个字符，换短 prefix 后 exit 0），非代码缺陷。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -2065,10 +2065,27 @@ owner 每天 09:00 收到的仍是 BX 之前的渲染（口径撒谎、翻页跳
   与仓库 `54296ea` 逐字节一致；`pending_session_preview` 命中 4（BX 到位）、
   `owner_write_authority.py` 存在（BW 到位）；manifest `deployed_head=54296ea`；
   fresh-process import 指向 runtime 树。
-- Full Monitor（live）：**98 PASS / 7 WARN / 1 FAIL**，唯一 FAIL 仍是
-  `v2_exposure_schema_era_unhealthy`，与本次部署无关（数据成熟度驱动，
+- Full Monitor（live，**从 BY worktree 的 monitor 脚本发起**，非主机上已部署的
+  `54296ea` 版；差别是前者多一条 BY 新增的 WARN 码）：**98 PASS / 7 WARN / 1 FAIL**，
+  唯一 FAIL 仍是 `v2_exposure_schema_era_unhealthy`，与本次部署无关（数据成熟度驱动，
   实测正在推进：rollup lag 74.4h→26.5h、schema-era 分类率 0.6506→0.7018、
   observation_days 19.7/30、conservation failures 0）。
+
+  与 08-02 部署前快照（99 PASS / 4 WARN / 1 FAIL）逐条对齐后，三条新增 WARN 全部有解释、
+  **无一是本次部署引入的回归**：
+
+  1. `..._disabled_without_audit_record` —— BY 自己新增的码，且它**在真实生产数据上一次命中**
+     就是 item 5 要抓的那个状态（`memory-os-expression-feedback-request` 在 Hermes job 层
+     停用、无任何原因记录）。属预期。
+  2. `full_monitor_runtime_over_target` —— 本次从 Windows 经 SSH 发起，非主机 cron 路径，
+     墙钟本就更长；路线图 §5-5 已登记的既有 WARN。
+  3. `low_clue_llm_judge_unavailable` —— **PASS→WARN 的那一条**（`low_clue_llm_judge_available`
+     在 08-02 是 PASS，PASS 计数 99→98 由它贡献）。经 owner 确认：**OpenAI 额度耗尽**，
+     非功能故障。判断器配置完好（`enabled=true`、`mode=bounded_vote`，实测解析到
+     `gpt-5.6-luna`/`openai-codex`），只是调用发不出去 → `status="skipped"`，
+     而 monitor 的判定是「status 不在 {error, skipped} 才算 available」，于是把
+     "额度不足导致未调用" 与 "判断器不可用" 合并成同一个 WARN。
+     **登记为 monitor 语义弱点**（外部额度/主动跳过/真故障三者不可区分），非本次部署缺陷。
 
 **部署过程中发现一个仓库缺陷（未修，登记）**：`deploy_memory_os.py` 的 `--timeout` 默认 60s，
 而它自己的第一道 compat 门 `memory_os_upgrade_compat_check.py` 在 3.200 上实测需 **63s**，
@@ -2097,6 +2114,24 @@ BJ 待办的"9 项 Windows 本地 pre-existing 测试失败诊断"已由 BK 完�
    `HERMES_HOME` 文件/SQLite 状态的一般性并发风险——无实测复现、无并发单测覆盖，记录为已知
    残留风险（BM 记录，`review_reply` 使用假 token 探针本身已确认安全）。
 4. ~~owner 无法拒绝 session_mirror 导入审批~~ —— **BY 已关闭**（owner 决策：reject + defer 都做）。
+5. **待 BY 合并并部署后，在 3.200 补写 `expression_feedback_request` 的停用审计记录**
+   （item 5 的数据侧，机制侧已在 BY 完成）。**现在不能写**：主机上运行的 group runner
+   仍是 `54296ea`，它只认裸 list 与 `disabled_lane_keys` 两种旧形状，此刻写 v1 的 `lanes`
+   形状会被读成"没有任何 lane 被停用"。BY 部署后再写，内容为：
+
+   ```json
+   {"schema_version": "memory-os.cron_lane_disabled.v1",
+    "lanes": {"expression_feedback_request": {
+      "reason": "<owner 填：与右脑表达 lane 一同退休>",
+      "actor": "owner",
+      "disabled_at": "<写入时 UTC>"}}}
+   ```
+
+   写完后 monitor 的 `..._disabled_without_audit_record` 应从 1 归 0，
+   `..._disabled` 仍保留（lane 确实是停用的，只是从此有据可查）。
+   注意该 lane 当前是在 Hermes **job** 层停用的；补记录不改变运行状态。
+6. `deploy_memory_os.py --timeout` 默认 60s < 自身 compat 门实测 63s（BY.1 记录），
+   默认参数下 preflight 必失败且错误码误导，未修。
 
 （原 4、5 两项——BP 记录的 Track A 模块/脚本落差与 `unread_partner_replies` 语义缺口——已随
 BQ 的 community 模块整体迁出本仓库，不再是本仓库待办；债务记录随代码一并迁至

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -2042,7 +2042,39 @@ import cycle / write surface（unclassified 0）/ public checkout probe --strict
 目标 261 字符、超 260 上限一个字符；换短 prefix 后 `compileall` exit 0，全部文件正常编译，
 非代码缺陷（主检出与 Linux CI 不受影响）。
 
-仅 `local_pass`：本节记录时尚未部署 3.200。
+BY 自身仅 `local_pass`（在 PR #10，未合并故未部署）。但本轮顺带关闭了收网评审查出的
+**发布→部署缺口**，见下。
+
+### BY.1 — 3.200 补上 BW(#8) + BX(#9) 部署（2026-08-03）
+
+收网评审查实：生产 `deployed_head=5bf0022`，**BW 与 BX 合并后从未部署**，
+owner 每天 09:00 收到的仍是 BX 之前的渲染（口径撒谎、翻页跳项、`smfp_…`）；
+且 manifest 声明的 `active_runtime_path=/opt/Hermes-Memory-OS` 停在 `192e056`——
+即 BW 接手前那个 CI 红的 WIP commit，谁从该路径部署就会推上已知坏树。
+
+已处理：
+
+- `/opt/Hermes-Memory-OS` 由 `192e056` fast-forward 到 `54296ea`（工作树干净，纯 ff）。
+- 备份 `/root/.hermes/backups/memory-os-pre-bw-bx-20260803T042836Z`（21M，
+  含 plugins / runtime / scripts 三棵已部署代码树与旧 manifest）。
+- `deploy_memory_os.py --mode production-safe --profile upgrade` 走完
+  plan → preflight → dry-run → apply：`fail=[]`，
+  pass 含 apply_applied / postcheck_pass / deployment_manifest_write_pass /
+  cron_adapter_probe_pass / boundary_runtime_probe_pass。**未加 `--allow-restart`，Gateway 未重启。**
+- 部署后核验：live runtime `owner_actions.py` sha 前 16 位 `e43ed37c369748ba`，
+  与仓库 `54296ea` 逐字节一致；`pending_session_preview` 命中 4（BX 到位）、
+  `owner_write_authority.py` 存在（BW 到位）；manifest `deployed_head=54296ea`；
+  fresh-process import 指向 runtime 树。
+- Full Monitor（live）：**98 PASS / 7 WARN / 1 FAIL**，唯一 FAIL 仍是
+  `v2_exposure_schema_era_unhealthy`，与本次部署无关（数据成熟度驱动，
+  实测正在推进：rollup lag 74.4h→26.5h、schema-era 分类率 0.6506→0.7018、
+  observation_days 19.7/30、conservation failures 0）。
+
+**部署过程中发现一个仓库缺陷（未修，登记）**：`deploy_memory_os.py` 的 `--timeout` 默认 60s，
+而它自己的第一道 compat 门 `memory_os_upgrade_compat_check.py` 在 3.200 上实测需 **63s**，
+于是默认参数下 `--phase preflight` 必然失败，且错误码是 **`compat_json_invalid`**——
+把"超时被截断"报成"JSON 非法"，指向完全错误的方向。本次以 `--timeout 300` 绕过。
+修法应是默认值调高 + 超时与 JSON 解析失败分别报码。
 
 ---
 
@@ -2313,3 +2345,12 @@ sannai-community 仓库 README。）
   3130 → **3148 passed / 13 skipped / 0 failed**（+18），四道静态门全过；
   `static_hygiene` 的 compileall 在本 worktree 内 FAIL 已定位为 Windows MAX_PATH 伪影
   （镜像路径 261 字符超 260 一个字符，换短 prefix 后 exit 0），非代码缺陷。
+- `（BY.1，本节）`：3.200 补上 BW(#8)+BX(#9) 部署——收网评审查实生产 `deployed_head=5bf0022`、
+  两个已合并周期从未部署，owner 每日议程一直是坏渲染；且 manifest 声明的
+  `active_runtime_path=/opt` 停在 CI 红的 `192e056`。`/opt` ff 到 `54296ea`、备份后
+  `deploy_memory_os.py` production-safe 走完 apply（`fail=[]`、未重启 Gateway），
+  部署后 owner_actions sha 与 `54296ea` 逐字节一致、manifest 已绑定；
+  Full Monitor **98 PASS / 7 WARN / 1 FAIL**，唯一 FAIL 仍是与本次无关的
+  `v2_exposure_schema_era_unhealthy`（且实测在推进：lag 74.4h→26.5h）。
+  新登记一个仓库缺陷：`deploy_memory_os.py --timeout` 默认 60s < 自身 compat 门实测 63s，
+  默认参数下 preflight 必失败，且错误码 `compat_json_invalid` 把超时误报成 JSON 非法。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -2093,6 +2093,33 @@ owner 每天 09:00 收到的仍是 BX 之前的渲染（口径撒谎、翻页跳
 把"超时被截断"报成"JSON 非法"，指向完全错误的方向。本次以 `--timeout 300` 绕过。
 修法应是默认值调高 + 超时与 JSON 解析失败分别报码。
 
+### BY.2 — 修 BY.1 登记的 deployer 超时缺陷（2026-08-03）
+
+两个独立缺陷，一个体感一个误导：
+
+1. **默认预算低于自身第一道门的实测成本。** `--timeout` 默认 60s，而
+   `memory_os_upgrade_compat_check.py` 在 3.200 实测 **63s**，于是**默认参数下
+   `--phase preflight` 必然失败**。低配主机更慢（2.88 约 3.6GiB RAM 且吃 swap）。
+   抽出 `DEFAULT_COMMAND_TIMEOUT_SECONDS = 300` 并用于函数签名、`_run_command`、
+   argparse 三处。这是**上限不是等待**——提前结束的命令不受影响。
+2. **「没给出答案」被报成「答案格式不对」。** `_classification_failures()` 只判
+   `json` 是不是 dict，于是超时（exit 124）、崩溃、真·JSON 非法三种情况全部落
+   `compat_json_invalid`，把运维指向完全错误的方向。改为分三档：
+   `compat_timed_out`（带 `hint` 明说要调 `--timeout`）、`compat_command_failed`（带 exit_code）、
+   `compat_json_invalid`（仅当命令成功但输出不可解析）。`124` 抽成 `_TIMEOUT_EXIT_CODE`。
+
+**按 Section W 第 5 条全项目扫同类模式，查出这不是孤例**——`_classify_llm_judge_probe`、
+`_classify_cron_adapter_probe`、`_classify_boundary_runtime_probe` 三个探针分类器
+**完全相同的缺陷**（只判 payload 形状、不看 exit_code），超时同样被报成 `..._json_invalid`。
+抽 `_probe_transport_fault()` 三处统一修。另三处
+（`_classify_install`、`_run_memory_projection_refresh`、`_classify_deployment_manifest`）
+本来就先判 exit_code，**已正确，未动**。
+
+向后兼容：`exit_code` 缺省取 0（＝无传输故障证据），既有不带 exit_code 的调用与测试行为不变；
+探针输出正常但内容不合格时，原有 `..._json_invalid` 判定原样保留。
+
+反事实：4 项 revert→FAIL→restore→PASS（超时/JSON 分档、默认值下限、崩溃码、探针同族修复）。
+
 ---
 
 ## 待办
@@ -2130,8 +2157,7 @@ BJ 待办的"9 项 Windows 本地 pre-existing 测试失败诊断"已由 BK 完�
    写完后 monitor 的 `..._disabled_without_audit_record` 应从 1 归 0，
    `..._disabled` 仍保留（lane 确实是停用的，只是从此有据可查）。
    注意该 lane 当前是在 Hermes **job** 层停用的；补记录不改变运行状态。
-6. `deploy_memory_os.py --timeout` 默认 60s < 自身 compat 门实测 63s（BY.1 记录），
-   默认参数下 preflight 必失败且错误码误导，未修。
+6. ~~`deploy_memory_os.py --timeout` 默认 60s < 自身 compat 门实测 63s~~ —— **BY.2 已修**。
 
 （原 4、5 两项——BP 记录的 Track A 模块/脚本落差与 `unread_partner_replies` 语义缺口——已随
 BQ 的 community 模块整体迁出本仓库，不再是本仓库待办；债务记录随代码一并迁至
@@ -2389,3 +2415,12 @@ sannai-community 仓库 README。）
   `v2_exposure_schema_era_unhealthy`（且实测在推进：lag 74.4h→26.5h）。
   新登记一个仓库缺陷：`deploy_memory_os.py --timeout` 默认 60s < 自身 compat 门实测 63s，
   默认参数下 preflight 必失败，且错误码 `compat_json_invalid` 把超时误报成 JSON 非法。
+- `（BY.2，本节）`：修 BY.1 登记的 deployer 超时缺陷。两件事：`--timeout` 默认 60s 抽成
+  `DEFAULT_COMMAND_TIMEOUT_SECONDS = 300`（自身 compat 门在 3.200 实测 63s，默认参数下
+  preflight 必失败；低配主机更慢，且这是上限不是等待）；`_classification_failures()` 把
+  超时/崩溃/真·JSON 非法三种情况分成 `compat_timed_out`（带调 `--timeout` 的 hint）、
+  `compat_command_failed`、`compat_json_invalid`，不再把"没给出答案"报成"答案格式不对"。
+  **按 Section W 第 5 条扫出这不是孤例**——三个探针分类器（llm_judge / cron_adapter /
+  boundary_runtime）完全相同的缺陷，抽 `_probe_transport_fault()` 一并修；另三处本就先判
+  exit_code，已正确未动。`exit_code` 缺省取 0 保证既有调用行为不变。
+  4 项反事实 revert→FAIL→restore→PASS。3148 → **3159 passed / 13 skipped / 0 failed**（+11）。

--- a/plugins/memory/memory_os/cron_registry.py
+++ b/plugins/memory/memory_os/cron_registry.py
@@ -729,23 +729,75 @@ def lane_disable_state_path(hermes_home: Path | str) -> Path:
     return Path(hermes_home) / "memory-os" / "system" / "cron_lane_disabled.json"
 
 
-def read_disabled_lane_keys(hermes_home: Path | str) -> frozenset[str]:
-    """Lane keys the owner has disabled. Unreadable/malformed state disables
-    nothing -- a corrupt file must never silently stop governed lanes."""
+LANE_DISABLE_STATE_SCHEMA_VERSION = "memory-os.cron_lane_disabled.v1"
+LANE_DISABLE_AUDIT_FIELDS = ("reason", "actor", "disabled_at")
+
+
+def read_lane_disable_records(hermes_home: Path | str) -> dict[str, dict[str, str]]:
+    """Disabled lane keys mapped to whatever audit detail the owner recorded.
+
+    Three on-disk shapes are accepted, oldest first::
+
+        ["lane_key", ...]                                   # pre-audit bare list
+        {"disabled_lane_keys": ["lane_key", ...]}           # pre-audit wrapper
+        {"lanes": {"lane_key": {"reason": ..., "actor": ..., "disabled_at": ...}}}
+
+    The first two carry no reason at all, so their records come back with empty
+    audit fields; that is what lets the monitor separate "the owner disabled
+    this lane, and here is why" from an undocumented stop.  A corrupt or
+    unreadable file disables nothing -- that failure direction keeps governed
+    lanes running rather than silently starving them.
+    """
     path = lane_disable_state_path(hermes_home)
     if not path.exists():
-        return frozenset()
+        return {}
     try:
         loaded = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return frozenset()
+        return {}
+    entries: Any
     if isinstance(loaded, dict):
+        lanes = loaded.get("lanes")
+        if isinstance(lanes, dict):
+            records: dict[str, dict[str, str]] = {}
+            for key, value in lanes.items():
+                lane_key = str(key)
+                if not lane_key:
+                    continue
+                detail = value if isinstance(value, dict) else {}
+                records[lane_key] = {
+                    field: str(detail.get(field) or "") for field in LANE_DISABLE_AUDIT_FIELDS
+                }
+            return records
         entries = loaded.get("disabled_lane_keys")
     else:
         entries = loaded
     if not isinstance(entries, list):
-        return frozenset()
-    return frozenset(str(entry) for entry in entries if str(entry))
+        return {}
+    return {
+        str(entry): {field: "" for field in LANE_DISABLE_AUDIT_FIELDS}
+        for entry in entries
+        if str(entry)
+    }
+
+
+def build_lane_disable_state(records: dict[str, dict[str, str]]) -> dict[str, Any]:
+    """The v1 document shape, so an operator writing this file by hand produces
+    something the runtime and the monitor both already parse."""
+    return {
+        "schema_version": LANE_DISABLE_STATE_SCHEMA_VERSION,
+        "lanes": {
+            str(key): {field: str((detail or {}).get(field) or "") for field in LANE_DISABLE_AUDIT_FIELDS}
+            for key, detail in records.items()
+            if str(key)
+        },
+    }
+
+
+def read_disabled_lane_keys(hermes_home: Path | str) -> frozenset[str]:
+    """Lane keys the owner has disabled. Unreadable/malformed state disables
+    nothing -- a corrupt file must never silently stop governed lanes."""
+    return frozenset(read_lane_disable_records(hermes_home))
 
 
 def groups_for_specs(specs: tuple[MemoryOSCronSpec, ...]) -> tuple[MemoryOSCronGroupSpec, ...]:

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -206,6 +206,8 @@ ACTION_TYPES = {
     "apply_proposal",
     "allow_speak_once",
     "approve_session_mirror_apply",
+    "reject_session_mirror_apply",
+    "defer_session_mirror_apply",
     *HINDSIGHT_CURATION_ACTION_TYPES,
     *EXPRESSION_FEEDBACK_ACTION_TYPES,
     "approve_edge",
@@ -235,7 +237,11 @@ TERMINAL_ACTIONS_BY_TARGET_TYPE = {
     "proposal": {"approve_proposal", "reject_proposal", "apply_proposal"},
     "memory_source": {"mark_feedback"},
     "speak": {"allow_speak_once"},
-    "session_mirror_apply": {"approve_session_mirror_apply"},
+    "session_mirror_apply": {
+        "approve_session_mirror_apply",
+        "reject_session_mirror_apply",
+        "defer_session_mirror_apply",
+    },
     "hindsight_curation": HINDSIGHT_CURATION_ACTION_TYPES,
     "expression": EXPRESSION_FEEDBACK_ACTION_TYPES,
     "provisional_crystallized_record": {
@@ -245,6 +251,12 @@ TERMINAL_ACTIONS_BY_TARGET_TYPE = {
     "edge": {"approve_edge", "reject_edge"},
     "permanent_memory_promotion": PERMANENT_PROMOTION_ACTION_TYPES,
 }
+
+# Terminal actions that close a target only until `deferred_until` passes.
+# `_closed_targets` must re-open the target once a defer expires, so every
+# defer action type has to be listed here -- a missing entry closes the target
+# permanently and silently retires the review item.
+DEFER_ACTION_TYPES = frozenset({"defer_candidate_cluster", "defer_session_mirror_apply"})
 
 
 def owner_actions_path(roots: MemoryOSRoots) -> Path:
@@ -1680,12 +1692,19 @@ def owner_review_delivery_status_report(store: MemoryOSStore) -> dict[str, Any]:
 
 
 def owner_review_aging_report(store: MemoryOSStore) -> dict[str, Any]:
-    closed = _closed_targets(read_owner_action_records(store.roots))
+    owner_action_records = read_owner_action_records(store.roots)
+    closed = _closed_targets(owner_action_records)
     items = _candidate_cluster_review_items(store, closed)
     items.extend(_candidate_review_items(store, closed))
     items.extend(_proposal_review_items(store, closed))
     items.extend(_proposal_apply_review_items(store, closed))
-    items.extend(_session_mirror_apply_review_items(store, closed))
+    items.extend(
+        _session_mirror_apply_review_items(
+            store,
+            closed,
+            lane_deferred=_session_mirror_lane_deferred(owner_action_records),
+        )
+    )
     items.extend(_speak_review_items(store, closed))
     items.extend(_left_brain_advisor_review_items(store, closed))
     items.extend(_provisional_crystallized_review_items(store, closed))
@@ -2762,7 +2781,8 @@ def owner_review_queue_report(
     limit: int = 20,
     permanent_promotion_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    closed = _closed_targets(read_owner_action_records(store.roots))
+    owner_action_records = read_owner_action_records(store.roots)
+    closed = _closed_targets(owner_action_records)
     items: list[dict[str, Any]] = []
     cluster_items = _candidate_cluster_review_items(store, closed)
     collapsed_candidate_ids = {
@@ -2778,7 +2798,13 @@ def owner_review_queue_report(
     )
     items.extend(_proposal_review_items(store, closed))
     items.extend(_proposal_apply_review_items(store, closed))
-    items.extend(_session_mirror_apply_review_items(store, closed))
+    items.extend(
+        _session_mirror_apply_review_items(
+            store,
+            closed,
+            lane_deferred=_session_mirror_lane_deferred(owner_action_records),
+        )
+    )
     items.extend(_speak_review_items(store, closed))
     items.extend(_left_brain_advisor_review_items(store, closed))
     items.extend(_provisional_crystallized_review_items(store, closed))
@@ -3014,7 +3040,7 @@ def apply_owner_action(
         action_type=idempotency_action_type,
     )
     existing = _find_idempotent_action(store.roots, idempotency_key)
-    if existing and action_type == "defer_candidate_cluster" and not _defer_action_is_active(existing):
+    if existing and action_type in DEFER_ACTION_TYPES and not _defer_action_is_active(existing):
         existing = None
     if existing:
         duplicate = _duplicate_record(existing, idempotency_key, action_type, target_type, target_id, owner_id, channel)
@@ -3056,7 +3082,7 @@ def apply_owner_action(
         note=note,
         rating=rating,
     )
-    if action_type == "defer_candidate_cluster":
+    if action_type in DEFER_ACTION_TYPES:
         record["deferred_until"] = _normalized_defer_until(deferred_until)
     _attach_owner_reply_context(record, reply_context or {})
     if original_target_id != target_id:
@@ -3830,6 +3856,33 @@ def _apply_state_transition(store: MemoryOSStore, record: dict[str, Any], *, not
             "actual_identity_write": False,
             "actual_unapproved_crystallized_approval": False,
         }
+    if action_type in {"reject_session_mirror_apply", "defer_session_mirror_apply"}:
+        context = record.pop("action_context", {})
+        approval = (
+            context.get("session_mirror_approval")
+            if isinstance(context.get("session_mirror_approval"), dict)
+            else {}
+        )
+        fingerprint = str(approval.get("selected_pending_session_fingerprint") or "")
+        if action_type == "reject_session_mirror_apply":
+            # SessionMirror.scan() reads this fingerprint back out of the owner
+            # action ledger to drop the session from its candidate list. Losing
+            # it here would leave the rejection cosmetic: the session stays at
+            # the head of the queue and is re-offered on the next digest.
+            record["owner_effect"]["owner_rejected_session_mirror_apply"] = True
+        else:
+            record["owner_effect"]["owner_deferred_session_mirror_apply"] = True
+        return {
+            "approval_scope": "session_mirror_production_bounded_apply",
+            "stable_scope_id": str(approval.get("stable_scope_id") or ""),
+            "digest_item_id": str(approval.get("digest_item_id") or ""),
+            "selected_pending_session_fingerprint": fingerprint,
+            "boundary_contract_version": str(approval.get("boundary_contract_version") or ""),
+            "actual_send": False,
+            "actual_execute": False,
+            "actual_identity_write": False,
+            "actual_unapproved_crystallized_approval": False,
+        }
     if action_type in HINDSIGHT_CURATION_ACTION_TYPES:
         decision = _append_hindsight_curation_decision(store, record, note=note)
         record["owner_effect"]["owner_recorded_hindsight_curation_decision"] = True
@@ -4021,7 +4074,11 @@ def _validate_action_target(
             return "speak_payload_transcript_marker"
     if action_type in EXPRESSION_FEEDBACK_ACTION_TYPES and target_type != "expression":
         return "invalid_expression_target"
-    if action_type == "approve_session_mirror_apply":
+    if action_type in {
+        "approve_session_mirror_apply",
+        "reject_session_mirror_apply",
+        "defer_session_mirror_apply",
+    }:
         if target_type != "session_mirror_apply":
             return "invalid_session_mirror_apply_target"
         if not target_id.startswith("production_bounded:"):
@@ -4878,7 +4935,42 @@ def _proposal_apply_review_items(store: MemoryOSStore, closed: set[str]) -> list
     return items
 
 
-def _session_mirror_apply_review_items(store: MemoryOSStore, closed: set[str]) -> list[dict[str, Any]]:
+def _session_mirror_lane_deferred(
+    actions: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """True while an Owner defer on the SessionMirror lane is still in force.
+
+    The review item's ``target_id`` is derived from the pending session's
+    fingerprint, so it changes as soon as a different session reaches the head
+    of the queue. A per-target close therefore cannot express "stop asking me
+    about this lane" -- the next session simply produces a new target. Defer is
+    evaluated lane-wide instead, and expires on its own like every other defer.
+    """
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        if str(action.get("action_type") or "") != "defer_session_mirror_apply":
+            continue
+        if action.get("result") not in {"applied", "duplicate_ignored"}:
+            continue
+        if _defer_action_is_active(action, now=now):
+            return True
+    return False
+
+
+def _session_mirror_apply_review_items(
+    store: MemoryOSStore,
+    closed: set[str],
+    *,
+    lane_deferred: bool,
+) -> list[dict[str, Any]]:
+    # `lane_deferred` is deliberately required: this function has two callers
+    # (digest assembly and the aging report) and a default would let one of them
+    # keep surfacing an item the Owner has silenced.
+    if lane_deferred:
+        return []
     from .session_mirror import (
         SESSION_MIRROR_BOUNDARY_CONTRACT_VERSION,
         SessionMirror,
@@ -5821,7 +5913,10 @@ def _review_suggested_action(actions: list[dict[str, str]], target_type: str) ->
     if target_type == "speak" and examples:
         return f"{examples[0]}；如果内容不合适，让 Hermes 记录具体表达反馈"
     if target_type == "session_mirror_apply" and examples:
-        return examples[0]
+        # All three are honoured now. Showing only examples[0] would leave the
+        # Owner believing approve is still the single available answer, which is
+        # the complaint that produced reject/defer in the first place.
+        return " or ".join(examples[:3])
     if target_type == "hindsight_curation" and examples:
         return " or ".join(examples[:3])
     if target_type == "candidate_cleanup":
@@ -5961,6 +6056,8 @@ def _review_consequence(target_type: str) -> str:
         return (
             "批准会授权一个 bounded SessionMirror 生产导入 scope 并允许一次真实 smoke；"
             "不写长期记忆、不发送消息、不执行工具、不改 identity/route/score。"
+            "拒绝只把这个会话永久排除在导入之外，队列里后面的会话照常提问；"
+            "延后会让整条 lane 安静到指定时间（默认 7 天）后自动重新提问。"
         )
     if target_type == "left_brain_advisor_finding":
         return "仅进入 owner digest 可见面；不会创建审批 token、不会 apply、不会改策略或长期记忆。"
@@ -6029,7 +6126,15 @@ def _review_actions(target_type: str, target_id: str) -> list[dict[str, str]]:
         )
         return actions
     if target_type == "session_mirror_apply":
-        return [_review_action("approve", "approve_session_mirror_apply", target_type, target_id)]
+        # approve imports this one session; reject permanently excludes it from
+        # the lane; defer silences the whole lane until `deferred_until`. Without
+        # the latter two the Owner's only options were to approve or to be asked
+        # again on the next digest.
+        return [
+            _review_action("approve", "approve_session_mirror_apply", target_type, target_id),
+            _review_action("reject", "reject_session_mirror_apply", target_type, target_id),
+            _review_action("defer", "defer_session_mirror_apply", target_type, target_id),
+        ]
     if target_type == "hindsight_curation":
         return [
             _review_action("approve", "retain_hindsight_curation", target_type, target_id),
@@ -6907,6 +7012,10 @@ def _owner_action_type_from_reply(verb: str, item: dict[str, Any]) -> str:
         return "allow_speak_once"
     if verb == "approve" and target_type == "session_mirror_apply":
         return "approve_session_mirror_apply"
+    if verb == "reject" and target_type == "session_mirror_apply":
+        return "reject_session_mirror_apply"
+    if verb == "defer" and target_type == "session_mirror_apply":
+        return "defer_session_mirror_apply"
     if verb == "approve" and target_type == "hindsight_curation":
         return "retain_hindsight_curation"
     if verb == "reject" and target_type == "hindsight_curation":
@@ -6936,9 +7045,9 @@ def _reply_verb_matches_action_type(verb: str, action_type: str) -> bool:
             "approve_edge",
         }
     if verb == "reject":
-        return action_type in {"reject_candidate", "reject_candidate_cluster", "reject_proposal", "reject_hindsight_curation", "reject_provisional_crystallized_record", "reject_provisional_knob_override", "reject_edge"}
+        return action_type in {"reject_candidate", "reject_candidate_cluster", "reject_proposal", "reject_hindsight_curation", "reject_provisional_crystallized_record", "reject_provisional_knob_override", "reject_edge", "reject_session_mirror_apply"}
     if verb == "defer":
-        return action_type == "defer_candidate_cluster"
+        return action_type in DEFER_ACTION_TYPES
     if verb == "feedback":
         return action_type == "mark_feedback" or action_type in EXPRESSION_FEEDBACK_ACTION_TYPES
     if verb == "allow":
@@ -8873,7 +8982,7 @@ def _closed_targets(
         action_type = str(action.get("action_type", ""))
         if action_type not in TERMINAL_ACTIONS_BY_TARGET_TYPE.get(target_type, set()):
             continue
-        if action_type == "defer_candidate_cluster" and not _defer_action_is_active(action, now=now):
+        if action_type in DEFER_ACTION_TYPES and not _defer_action_is_active(action, now=now):
             continue
         closed.add(f"{target_type}:{action.get('target_id', '')}")
     return closed
@@ -8953,7 +9062,11 @@ def _normalize_target(action_type: str, target: str) -> tuple[str, str]:
         return "memory_source", value
     if action_type == "allow_speak_once":
         return "speak", value
-    if action_type == "approve_session_mirror_apply":
+    if action_type in {
+        "approve_session_mirror_apply",
+        "reject_session_mirror_apply",
+        "defer_session_mirror_apply",
+    }:
         return "session_mirror_apply", value
     if action_type in HINDSIGHT_CURATION_ACTION_TYPES:
         return "hindsight_curation", value

--- a/plugins/memory/memory_os/session_mirror.py
+++ b/plugins/memory/memory_os/session_mirror.py
@@ -54,6 +54,7 @@ def _bounded_auto_apply_dry_run(report: dict[str, Any]) -> dict[str, Any]:
         "selected_session_count": int(report.get("selected_session_count") or 0),
         "skipped_by_platform_count": int(report.get("skipped_by_platform_count") or 0),
         "skipped_by_limit_count": int(report.get("skipped_by_limit_count") or 0),
+        "skipped_by_owner_rejection_count": int(report.get("skipped_by_owner_rejection_count") or 0),
         "selected_session_fingerprints": [
             str(item)
             for item in (report.get("selected_session_fingerprints") if isinstance(report.get("selected_session_fingerprints"), list) else [])
@@ -365,6 +366,29 @@ class SessionMirror:
             "findings": findings,
         }
 
+    def _owner_rejected_fingerprints(self) -> frozenset[str]:
+        """Pending-session fingerprints the Owner rejected from a digest reply.
+
+        Read from the owner action ledger, not from SessionMirror state:
+        ``_rebuild_state()`` reconstructs state from Memory-OS events, so a
+        rejection recorded there would silently vanish on the next state repair
+        and the rejected session would be re-offered and eventually imported.
+        The ledger is append-only and is never rebuilt from events.
+        """
+        rejected: set[str] = set()
+        for record in read_jsonl(owner_actions_path(self.store.roots)):
+            if not isinstance(record, dict):
+                continue
+            if str(record.get("action_type") or "") != "reject_session_mirror_apply":
+                continue
+            if str(record.get("result") or "") not in {"applied", "duplicate_ignored"}:
+                continue
+            result_ref = record.get("result_ref") if isinstance(record.get("result_ref"), dict) else {}
+            fingerprint = str(result_ref.get("selected_pending_session_fingerprint") or "")
+            if fingerprint:
+                rejected.add(fingerprint)
+        return frozenset(rejected)
+
     def scan(
         self,
         *,
@@ -379,11 +403,23 @@ class SessionMirror:
         error_summary = _error_summary_from_findings(findings)
         sessions = self._discover_sessions()
         covered = self._provider_captured_session_ids()
-        new_sessions = [
+        pending_sessions = [
             session
             for session in sessions
             if session["session_id"] not in covered and session["dedup_key"] not in state["seen_sessions"]
         ]
+        # An Owner rejection is honoured here rather than only on the digest
+        # surface. Selection is otherwise pure head-of-queue (`[:limit]` below),
+        # so a rejected session would be re-offered on every scan, permanently
+        # starving every session behind it, and would still be the one this lane
+        # imported once the lane graduated.
+        rejected_fingerprints = self._owner_rejected_fingerprints()
+        new_sessions = [
+            session
+            for session in pending_sessions
+            if str(session.get("fingerprint") or "") not in rejected_fingerprints
+        ]
+        skipped_by_owner_rejection_count = len(pending_sessions) - len(new_sessions)
         platforms = _normalize_platform_allowlist(platform_allowlist)
         platform_filtered = [
             session for session in new_sessions if not platforms or str(session.get("platform") or "").lower() in platforms
@@ -429,6 +465,7 @@ class SessionMirror:
                     "selected_session_count": len(selected_sessions),
                     "skipped_by_platform_count": skipped_by_platform_count,
                     "skipped_by_limit_count": skipped_by_limit_count,
+                    "skipped_by_owner_rejection_count": skipped_by_owner_rejection_count,
                     "new_event_count": 0,
                     "dry_run": False,
                     "apply_bounded": True,
@@ -482,6 +519,7 @@ class SessionMirror:
                 selected_session_count=len(selected_sessions),
                 skipped_by_platform_count=skipped_by_platform_count,
                 skipped_by_limit_count=skipped_by_limit_count,
+                skipped_by_owner_rejection_count=skipped_by_owner_rejection_count,
                 platform_allowlist=platforms,
                 max_sessions=limit,
                 selected_sessions=selected_safe_sessions,
@@ -502,6 +540,7 @@ class SessionMirror:
             "selected_session_count": len(selected_sessions),
             "skipped_by_platform_count": skipped_by_platform_count,
             "skipped_by_limit_count": skipped_by_limit_count,
+            "skipped_by_owner_rejection_count": skipped_by_owner_rejection_count,
             "new_event_count": len(selected_sessions),
             "dry_run": dry_run,
             "apply_bounded": not dry_run or bool(limit or platforms),
@@ -691,6 +730,7 @@ class SessionMirror:
         selected_session_count: int,
         skipped_by_platform_count: int,
         skipped_by_limit_count: int,
+        skipped_by_owner_rejection_count: int,
         platform_allowlist: list[str],
         max_sessions: int,
         selected_sessions: list[dict[str, Any]],
@@ -715,6 +755,7 @@ class SessionMirror:
             "selected_session_count": selected_session_count,
             "skipped_by_platform_count": skipped_by_platform_count,
             "skipped_by_limit_count": skipped_by_limit_count,
+            "skipped_by_owner_rejection_count": skipped_by_owner_rejection_count,
             "written_event_ids": written_event_ids,
             "written_event_ids_count": len(written_event_ids),
             "selected_sessions": selected_sessions,

--- a/scripts/deploy_memory_os.py
+++ b/scripts/deploy_memory_os.py
@@ -28,6 +28,13 @@ from scripts.memory_os_host_profile import resolve_host_runtime_profile
 Runner = Callable[..., dict[str, Any]]
 FAST_PROBE_RECOMMENDED_TIMEOUT_SECONDS = 120
 FULL_MONITOR_MIN_CALLER_TIMEOUT_SECONDS = 300
+_TIMEOUT_EXIT_CODE = 124
+# Per-command budget. The old 60s default was below what this tool's own first
+# gate needs: memory_os_upgrade_compat_check.py measures ~63s on 3.200, so
+# `--phase preflight` failed on default arguments alone, and low-spec hosts
+# (2.88 runs ~3.6GiB RAM under swap pressure) are slower still. This is a
+# ceiling, not a wait -- commands that finish early are unaffected.
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 300
 
 
 def deploy_memory_os(
@@ -41,7 +48,7 @@ def deploy_memory_os(
     phase: str,
     profile: str,
     host: str = "",
-    timeout: int = 60,
+    timeout: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
     allow_restart: bool = False,
     restart_command: str = "",
     python_bin: str | None = None,
@@ -369,7 +376,7 @@ def _run_json(
     return redacted
 
 
-def _run_command(argv: list[str], *, host: str | None = None, timeout: int = 60) -> dict[str, Any]:
+def _run_command(argv: list[str], *, host: str | None = None, timeout: int = DEFAULT_COMMAND_TIMEOUT_SECONDS) -> dict[str, Any]:
     del host
     # _build_commands() prefixes some argv lists with ["env", "KEY=VALUE", ...]
     # so HERMES_HOME is scoped per-command even when several commands run in
@@ -393,7 +400,7 @@ def _run_command(argv: list[str], *, host: str | None = None, timeout: int = 60)
         stdout = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode("utf-8", "replace")
         stderr = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode("utf-8", "replace")
         return {
-            "exit_code": 124,
+            "exit_code": _TIMEOUT_EXIT_CODE,
             "stdout": stdout,
             "stderr": stderr + f"\ncommand timed out after {timeout}s",
         }
@@ -547,7 +554,38 @@ def _run_llm_judge_probe(
     return _classify_llm_judge_probe(result)
 
 
+def _probe_transport_fault(result: dict[str, Any], *, prefix: str) -> dict[str, Any] | None:
+    """A probe that never answered is not a probe that answered badly.
+
+    Same defect class as the compat gate above: keying only on "is the payload
+    the right shape" turns a timeout or a crash into a `..._json_invalid`
+    verdict, which names the wrong cause. Returns a bounded fault report for a
+    transport failure, or None when the command completed and its output should
+    be judged on its own terms.
+    """
+    exit_code = int(result.get("exit_code", 0) or 0)
+    if exit_code == _TIMEOUT_EXIT_CODE:
+        return {
+            "status": "warn",
+            "reason": f"{prefix}_timed_out",
+            "exit_code": exit_code,
+            "hint": "raise --timeout; probes are slower on low-spec hosts",
+            "probe": result,
+        }
+    if exit_code != 0 and not isinstance(result.get("json"), dict):
+        return {
+            "status": "warn",
+            "reason": f"{prefix}_command_failed",
+            "exit_code": exit_code,
+            "probe": result,
+        }
+    return None
+
+
 def _classify_llm_judge_probe(result: dict[str, Any]) -> dict[str, Any]:
+    fault = _probe_transport_fault(result, prefix="llm_judge_probe")
+    if fault is not None:
+        return fault
     data = result.get("json")
     if not isinstance(data, dict) or data.get("schema_version") != "memory-os.low_clue_recall.v0":
         return {"status": "warn", "reason": "llm_judge_probe_json_invalid", "probe": result}
@@ -585,6 +623,9 @@ def _run_cron_adapter_probe(
 
 
 def _classify_cron_adapter_probe(result: dict[str, Any]) -> dict[str, Any]:
+    fault = _probe_transport_fault(result, prefix="cron_adapter_probe")
+    if fault is not None:
+        return fault
     data = result.get("json")
     if not isinstance(data, dict) or data.get("schema_version") != "memory-os.hermes_cron_adapter_probe.v0":
         return {"status": "warn", "reason": "cron_adapter_probe_json_invalid", "probe": result}
@@ -622,6 +663,9 @@ def _run_boundary_runtime_probe(
 
 
 def _classify_boundary_runtime_probe(result: dict[str, Any]) -> dict[str, Any]:
+    fault = _probe_transport_fault(result, prefix="boundary_runtime_probe")
+    if fault is not None:
+        return fault
     data = result.get("json")
     if not isinstance(data, dict) or data.get("schema_version") != "memory-os.boundary_runtime_probe.v0":
         return {"status": "warn", "reason": "boundary_runtime_probe_json_invalid", "probe": result}
@@ -782,7 +826,30 @@ def _classify_deployment_manifest(result: dict[str, Any], *, action: str) -> dic
 
 
 def _classification_failures(result: dict[str, Any]) -> list[dict[str, Any]]:
+    # Distinguish "the gate ran and said no" from "the gate never produced an
+    # answer".  Collapsing them into compat_json_invalid sent operators looking
+    # for malformed JSON when the real cause was a timeout: the compat check
+    # needs ~63s on 3.200 and the default budget used to be 60s, so the very
+    # first phase failed on default arguments and blamed the wrong thing.
+    exit_code = int(result.get("exit_code", 0) or 0)
+    if exit_code == _TIMEOUT_EXIT_CODE:
+        return [
+            {
+                "code": "compat_timed_out",
+                "exit_code": exit_code,
+                "hint": "raise --timeout; the compatibility gate is slower on low-spec hosts",
+                "stderr_tail": str(result.get("stderr") or "")[-300:],
+            }
+        ]
     data = result.get("json")
+    if exit_code != 0 and not isinstance(data, dict):
+        return [
+            {
+                "code": "compat_command_failed",
+                "exit_code": exit_code,
+                "stderr_tail": str(result.get("stderr") or "")[-300:],
+            }
+        ]
     if not isinstance(data, dict):
         return [{"code": "compat_json_invalid"}]
     classification = data.get("classification") if isinstance(data.get("classification"), dict) else {}
@@ -1003,7 +1070,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--llm-judge-preset", choices=["active", "none", "report-only", "bounded-vote"], default="active")
     parser.add_argument("--phase", choices=["plan", "preflight", "dry-run", "apply", "postcheck"], default="plan")
     parser.add_argument("--profile", choices=["fresh", "upgrade"], default="upgrade")
-    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--timeout", type=int, default=DEFAULT_COMMAND_TIMEOUT_SECONDS)
     parser.add_argument(
         "--python-bin",
         default="",

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -326,6 +326,37 @@ CLEAN_HOST_WARN_CLASSIFICATIONS: dict[str, dict[str, str]] = {
         "reason": "clean-host can expose bounded component suppressed-error counters without proving runtime unhealthy",
         "production_behavior": "warn_if_production",
     },
+    # ExecutionGate cron helper-completion family. An unclassified WARN is a
+    # clean-host FAIL (`clean_host_warn_unclassified`), and none of these five
+    # were registered -- so any host where a lane was disabled, stale, or had
+    # not yet run turned the clean-host monitor red for a state that is normal
+    # there. `warn_if_production` is deliberate: it preserves today's
+    # production behaviour exactly rather than escalating live WARNs to FAIL.
+    "execution_gate_memory_os_cron_helper_completion_missing": {
+        "classification": "expected_clean_host",
+        "reason": "clean-host installs the lanes before any of them has run, so completion evidence is legitimately absent",
+        "production_behavior": "warn_if_production",
+    },
+    "execution_gate_memory_os_cron_helper_completion_stale": {
+        "classification": "expected_clean_host",
+        "reason": "clean-host has no natural cron cadence, so the newest completion record ages past its lane window",
+        "production_behavior": "warn_if_production",
+    },
+    "execution_gate_memory_os_cron_helper_completion_disabled": {
+        "classification": "expected_clean_host",
+        "reason": "a disabled lane is an owner/operator decision, not an install or runtime defect",
+        "production_behavior": "warn_if_production",
+    },
+    "execution_gate_memory_os_cron_helper_completion_disabled_without_audit_record": {
+        "classification": "expected_clean_host",
+        "reason": "clean-host disables jobs without writing the per-lane audit record; the gap is reported, not treated as a defect",
+        "production_behavior": "warn_if_production",
+    },
+    "execution_gate_memory_os_cron_helper_boundary_unobserved": {
+        "classification": "expected_clean_host",
+        "reason": "boundary evidence only exists once a lane has actually executed under its envelope",
+        "production_behavior": "warn_if_production",
+    },
     "doctor_warning_finding": {
         "classification": "expected_clean_host",
         "reason": "clean-host can surface non-blocking doctor warnings during bootstrap compatibility checks",
@@ -2380,6 +2411,22 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
                         "code": "execution_gate_memory_os_cron_helper_completion_disabled",
                         "count": helper_disabled,
                         "lanes": execution_gate_cron.get("helper_completion_disabled_lanes") or [],
+                        "records": execution_gate_cron.get("helper_completion_disabled_records") or {},
+                    }
+                )
+            helper_disabled_undocumented = int(
+                execution_gate_cron.get("helper_completion_disabled_undocumented_count") or 0
+            )
+            if helper_disabled_undocumented > 0:
+                # The lane is stopped and nothing on the host records why. The
+                # state may well be correct -- but "correct and unexplained" is
+                # indistinguishable from drift on the next review, so it is
+                # reported rather than folded into the plain disabled WARN.
+                warn.append(
+                    {
+                        "code": "execution_gate_memory_os_cron_helper_completion_disabled_without_audit_record",
+                        "count": helper_disabled_undocumented,
+                        "lanes": execution_gate_cron.get("helper_completion_disabled_undocumented_lanes") or [],
                     }
                 )
             if helper_stale > 0:
@@ -7513,11 +7560,18 @@ def _execution_gate_helper_completion_summary(specs_by_lane, jobs_by_name=None):
     # member of its group), so per-lane control is restored via this list --
     # see plugins/memory/memory_os/cron_registry.read_disabled_lane_keys.
     try:
-        from plugins.memory.memory_os.cron_registry import read_disabled_lane_keys
+        from plugins.memory.memory_os.cron_registry import read_lane_disable_records
 
-        disabled_lane_keys = read_disabled_lane_keys(_hermes_home)
+        lane_disable_records = read_lane_disable_records(_hermes_home)
     except Exception:
-        disabled_lane_keys = frozenset()
+        lane_disable_records = {}
+    disabled_lane_keys = frozenset(lane_disable_records)
+    # A lane can also be stopped by disabling its Hermes job directly, which
+    # bypasses the per-lane file and therefore records no reason anywhere.
+    # That is a different fact from a documented owner disable and is reported
+    # separately -- otherwise the WARN says a lane is off but nothing says why.
+    disabled_undocumented: list[str] = []
+    disabled_records: dict[str, dict[str, str]] = {}
     for lane in sorted(expected_lanes):
         spec = specs_by_lane.get(lane) if isinstance(specs_by_lane.get(lane), dict) else {}
         job_name = str(spec.get("name") or "")
@@ -7527,6 +7581,16 @@ def _execution_gate_helper_completion_summary(specs_by_lane, jobs_by_name=None):
         owner_disabled_lane = bool(lane_key) and lane_key in disabled_lane_keys
         if (isinstance(cron_job, dict) and cron_job.get("enabled") is False) or owner_disabled_lane:
             disabled.append(lane)
+            audit = lane_disable_records.get(lane_key) if owner_disabled_lane else {}
+            audit = audit if isinstance(audit, dict) else {}
+            disabled_records[lane] = {
+                "source": "lane_disable_file" if owner_disabled_lane else "hermes_job",
+                "reason": str(audit.get("reason") or ""),
+                "actor": str(audit.get("actor") or ""),
+                "disabled_at": str(audit.get("disabled_at") or ""),
+            }
+            if not disabled_records[lane]["reason"]:
+                disabled_undocumented.append(lane)
             if record:
                 # A disabled job isn't expected to produce FRESH evidence,
                 # but if a completion record already exists, any recorded
@@ -7594,6 +7658,9 @@ def _execution_gate_helper_completion_summary(specs_by_lane, jobs_by_name=None):
         "helper_completion_missing_lanes": missing,
         "helper_completion_reconciled_lanes": reconciled_via_cron_status,
         "helper_completion_disabled_lanes": disabled,
+        "helper_completion_disabled_records": disabled_records,
+        "helper_completion_disabled_undocumented_count": len(disabled_undocumented),
+        "helper_completion_disabled_undocumented_lanes": disabled_undocumented,
         "helper_completion_reconciliation_status": "degraded" if reconciled_via_cron_status else "not_used",
         "helper_completion_accounted_count": len(completed) + len(missing) + len(reconciled_via_cron_status) + len(disabled),
         "helper_completion_stale_lanes": stale,

--- a/scripts/memory_os_cron_group_runner.py
+++ b/scripts/memory_os_cron_group_runner.py
@@ -342,6 +342,14 @@ def _load_group_from_registry(group_key: str) -> tuple[dict[str, Any], list[dict
 
 
 def _read_disabled_lane_keys(hermes_home: Path) -> frozenset[str]:
+    """Mirror of ``cron_registry.read_lane_disable_records`` for the installed
+    layout, where the registry module may not be importable.
+
+    Three shapes are accepted: the pre-audit bare list, the pre-audit
+    ``disabled_lane_keys`` wrapper, and the v1 ``lanes`` map carrying
+    reason/actor/disabled_at.  The tick only needs the keys, but it must not
+    stop honouring a disable just because the owner recorded a reason for it.
+    """
     path = hermes_home / "memory-os" / "system" / "cron_lane_disabled.json"
     if not path.exists():
         return frozenset()
@@ -350,6 +358,8 @@ def _read_disabled_lane_keys(hermes_home: Path) -> frozenset[str]:
     except (OSError, json.JSONDecodeError):
         # A corrupt disable list must never silently stop governed lanes.
         return frozenset()
+    if isinstance(loaded, dict) and isinstance(loaded.get("lanes"), dict):
+        return frozenset(str(key) for key in loaded["lanes"] if str(key))
     entries = loaded.get("disabled_lane_keys") if isinstance(loaded, dict) else loaded
     if not isinstance(entries, list):
         return frozenset()

--- a/tests/plugins/memory/test_memory_os_cron_registry.py
+++ b/tests/plugins/memory/test_memory_os_cron_registry.py
@@ -1,12 +1,16 @@
 import json
 
 from plugins.memory.memory_os.cron_registry import (
+    LANE_DISABLE_STATE_SCHEMA_VERSION,
     LEGACY_PER_LANE_CRON_JOB_NAMES,
+    build_lane_disable_state,
     cron_registry_snapshot,
     groups_from_snapshot,
     memory_os_cron_groups,
     memory_os_cron_spec_by_key,
     memory_os_cron_specs,
+    read_disabled_lane_keys,
+    read_lane_disable_records,
     specs_from_snapshot,
     write_cron_registry_snapshot,
 )
@@ -289,3 +293,72 @@ def test_every_tick_fires_at_least_as_often_as_its_fastest_installed_lane():
             f"{group.name} fires every {tick_interval}min but its fastest "
             f"installed member needs every {fastest}min"
         )
+
+
+# ── per-lane disable: audit trail ─────────────────────────────────────
+
+
+def _write_disable_file(home, payload):
+    path = home / "memory-os" / "system" / "cron_lane_disabled.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) if not isinstance(payload, str) else payload, encoding="utf-8")
+    return path
+
+
+def test_lane_disable_reads_all_three_on_disk_shapes(tmp_path):
+    """Adding audit fields must not orphan hosts already carrying the older
+    shapes -- both pre-audit forms keep disabling their lanes, they simply
+    report no reason."""
+    bare = tmp_path / "bare"
+    _write_disable_file(bare, ["alpha"])
+    wrapper = tmp_path / "wrapper"
+    _write_disable_file(wrapper, {"disabled_lane_keys": ["alpha"]})
+    audited = tmp_path / "audited"
+    _write_disable_file(
+        audited,
+        {
+            "schema_version": LANE_DISABLE_STATE_SCHEMA_VERSION,
+            "lanes": {"alpha": {"reason": "retired", "actor": "owner", "disabled_at": "2026-08-02T00:00:00Z"}},
+        },
+    )
+
+    assert read_disabled_lane_keys(bare) == frozenset({"alpha"})
+    assert read_disabled_lane_keys(wrapper) == frozenset({"alpha"})
+    assert read_disabled_lane_keys(audited) == frozenset({"alpha"})
+
+    assert read_lane_disable_records(bare)["alpha"]["reason"] == ""
+    assert read_lane_disable_records(wrapper)["alpha"]["reason"] == ""
+    audited_record = read_lane_disable_records(audited)["alpha"]
+    assert audited_record["reason"] == "retired"
+    assert audited_record["actor"] == "owner"
+    assert audited_record["disabled_at"] == "2026-08-02T00:00:00Z"
+
+
+def test_corrupt_disable_file_disables_nothing(tmp_path):
+    """Load-bearing failure direction: a corrupt file must never silently stop
+    governed lanes."""
+    home = tmp_path / "home"
+    _write_disable_file(home, "{ not json at all")
+
+    assert read_disabled_lane_keys(home) == frozenset()
+    assert read_lane_disable_records(home) == {}
+
+
+def test_missing_disable_file_disables_nothing(tmp_path):
+    assert read_disabled_lane_keys(tmp_path / "absent") == frozenset()
+    assert read_lane_disable_records(tmp_path / "absent") == {}
+
+
+def test_build_lane_disable_state_round_trips(tmp_path):
+    """An operator writing this file by hand should produce exactly what the
+    runtime and monitor already parse."""
+    home = tmp_path / "home"
+    document = build_lane_disable_state(
+        {"expression_feedback_request": {"reason": "retired with右脑表达 lanes", "actor": "owner", "disabled_at": "2026-08-02T00:00:00Z"}}
+    )
+    _write_disable_file(home, document)
+
+    assert document["schema_version"] == LANE_DISABLE_STATE_SCHEMA_VERSION
+    records = read_lane_disable_records(home)
+    assert records["expression_feedback_request"]["reason"] == "retired with右脑表达 lanes"
+    assert read_disabled_lane_keys(home) == frozenset({"expression_feedback_request"})

--- a/tests/plugins/memory/test_memory_os_owner_digest_agenda.py
+++ b/tests/plugins/memory/test_memory_os_owner_digest_agenda.py
@@ -259,7 +259,9 @@ def _session_mirror_item(tmp_path, monkeypatch) -> dict[str, object]:
     from plugins.memory.memory_os import session_mirror as session_mirror_module
 
     monkeypatch.setattr(session_mirror_module, "SessionMirror", _FakeSessionMirror)
-    items = owner_actions_module._session_mirror_apply_review_items(_store(tmp_path), set())
+    items = owner_actions_module._session_mirror_apply_review_items(
+        _store(tmp_path), set(), lane_deferred=False
+    )
     assert len(items) == 1
     return items[0]
 
@@ -291,10 +293,123 @@ def test_session_preview_survives_the_bounded_digest_copy(tmp_path, monkeypatch)
 
 
 def test_session_mirror_item_offers_no_action_it_cannot_honour(tmp_path, monkeypatch):
-    """reject_session_mirror_apply does not exist; the digest must not imply it."""
+    """The digest must offer exactly the actions the processor will honour.
+
+    This previously pinned approve-only, because reject/defer did not exist and
+    the cron prompt kept teaching the model to invent `memory reject oa_...`.
+    Both now exist, so all three are offered -- but the invariant is unchanged:
+    every rendered token must be terminal for this target type.
+    """
     item = _session_mirror_item(tmp_path, monkeypatch)
     rendered = owner_actions_module._render_review_item(
         owner_actions_module._digest_item(item), section="action_required"
     )
 
-    assert set(rendered["action_tokens"]) == {"approve_session_mirror_apply"}
+    assert set(rendered["action_tokens"]) == {
+        "approve_session_mirror_apply",
+        "reject_session_mirror_apply",
+        "defer_session_mirror_apply",
+    }
+    assert (
+        set(rendered["action_tokens"])
+        <= owner_actions_module.TERMINAL_ACTIONS_BY_TARGET_TYPE["session_mirror_apply"]
+    )
+
+
+# ── Owner defer: lane-wide silence with an expiry ─────────────────────
+
+
+def _defer_action(deferred_until: str, *, result: str = "applied") -> dict[str, object]:
+    return {
+        "schema_version": "memory-os.owner_action.v0",
+        "owner_action_id": "oact_defer_session_mirror",
+        "action_type": "defer_session_mirror_apply",
+        "target_type": "session_mirror_apply",
+        "target_id": "production_bounded:whatever_was_at_the_head",
+        "owner_id": "owner",
+        "channel": "telegram",
+        "result": result,
+        "created_at": "2026-06-01T00:00:00Z",
+        "deferred_until": deferred_until,
+    }
+
+
+def test_active_lane_defer_silences_the_session_mirror_item(tmp_path, monkeypatch):
+    """"别再问了" cannot be expressed by closing a target: `target_id` is derived
+    from the pending session's fingerprint, so the next session produces a new
+    target and the Owner is asked again. Defer is evaluated lane-wide."""
+    from plugins.memory.memory_os import session_mirror as session_mirror_module
+
+    monkeypatch.setattr(session_mirror_module, "SessionMirror", _FakeSessionMirror)
+
+    assert owner_actions_module._session_mirror_lane_deferred([_defer_action("2099-01-01T00:00:00Z")]) is True
+    items = owner_actions_module._session_mirror_apply_review_items(
+        _store(tmp_path), set(), lane_deferred=True
+    )
+
+    assert items == []
+
+
+def test_expired_lane_defer_lets_the_session_mirror_item_return(tmp_path, monkeypatch):
+    """A defer is a pause, not a retirement -- it must expire on its own."""
+    from plugins.memory.memory_os import session_mirror as session_mirror_module
+
+    monkeypatch.setattr(session_mirror_module, "SessionMirror", _FakeSessionMirror)
+
+    assert owner_actions_module._session_mirror_lane_deferred([_defer_action("2020-01-01T00:00:00Z")]) is False
+    items = owner_actions_module._session_mirror_apply_review_items(
+        _store(tmp_path), set(), lane_deferred=False
+    )
+
+    assert len(items) == 1
+
+
+def test_unapplied_defer_does_not_silence_the_lane(tmp_path):
+    """A dry-run reply is not an Owner decision."""
+    assert (
+        owner_actions_module._session_mirror_lane_deferred(
+            [_defer_action("2099-01-01T00:00:00Z", result="dry_run")]
+        )
+        is False
+    )
+
+
+def test_expired_session_mirror_defer_reopens_the_target(tmp_path):
+    """`_closed_targets` skips defer action types whose `deferred_until` passed.
+
+    Counterfactual: with `defer_session_mirror_apply` missing from
+    DEFER_ACTION_TYPES the target closes permanently and the review item is
+    silently retired instead of paused.
+    """
+    active = owner_actions_module._closed_targets([_defer_action("2099-01-01T00:00:00Z")])
+    expired = owner_actions_module._closed_targets([_defer_action("2020-01-01T00:00:00Z")])
+
+    assert "session_mirror_apply:production_bounded:whatever_was_at_the_head" in active
+    assert expired == set()
+
+
+def test_session_mirror_reply_verbs_resolve_to_the_new_action_types():
+    """`memory reject oa_...` / `memory defer oa_...` must resolve for this target.
+
+    Before this existed the verbs resolved to "" and the Owner's reply was
+    refused -- which is why the cron prompt had to teach the model not to write
+    them.
+    """
+    item = {"target_type": "session_mirror_apply"}
+
+    assert owner_actions_module._owner_action_type_from_reply("approve", item) == "approve_session_mirror_apply"
+    assert owner_actions_module._owner_action_type_from_reply("reject", item) == "reject_session_mirror_apply"
+    assert owner_actions_module._owner_action_type_from_reply("defer", item) == "defer_session_mirror_apply"
+    assert owner_actions_module._reply_verb_matches_action_type("reject", "reject_session_mirror_apply") is True
+    assert owner_actions_module._reply_verb_matches_action_type("defer", "defer_session_mirror_apply") is True
+
+
+def test_session_mirror_reject_is_not_an_approval():
+    """OwnerGate: only approve may authorize the bounded import. The CLI apply
+    gate matches on `approve_session_mirror_apply`, so reject/defer must never
+    be accepted there."""
+    from plugins.memory.memory_os import owner_write_authority
+
+    assert "reject_session_mirror_apply" not in owner_write_authority.OWNER_CANONICAL_WRITE_ACTION_TYPES
+    assert "defer_session_mirror_apply" not in owner_write_authority.OWNER_CANONICAL_WRITE_ACTION_TYPES
+    assert owner_actions_module._reply_verb_matches_action_type("approve", "reject_session_mirror_apply") is False

--- a/tests/plugins/memory/test_memory_os_session_mirror.py
+++ b/tests/plugins/memory/test_memory_os_session_mirror.py
@@ -7,6 +7,7 @@ from plugins.memory.memory_os.cli import memory_os_command, register_cli
 from plugins.memory.memory_os.config import save_config
 from plugins.memory.memory_os.execution_gate import execution_gate_records_path, execution_gate_scope_hash
 from plugins.memory.memory_os.fixtures import build_event
+from plugins.memory.memory_os.read_model_paths import owner_actions_path
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.schema import EventEnvelope
 from plugins.memory.memory_os.runtime import MemoryOSRuntime
@@ -906,3 +907,119 @@ def test_unreadable_session_json_is_surfaced_not_silently_skipped(tmp_path):
         if finding["id"] in {"session_json_unreadable", "session_json_not_an_object"}
     }
     assert surfaced == {"session_json_unreadable", "session_json_not_an_object"}
+
+
+# ── Owner reject: scan-level exclusion ────────────────────────────────
+
+
+def _add_session(path, *, session_id, platform="telegram", marker="B"):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "insert into sessions(id, source, created_at, updated_at) values (?, ?, ?, ?)",
+            (session_id, platform, "2026-05-21T09:00:00+00:00", "2026-05-21T09:01:00+00:00"),
+        )
+        conn.executemany(
+            "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
+            [
+                (session_id, "user", "第二个会话的问题 " + marker * 120, "2026-05-21T09:00:01+00:00"),
+                (session_id, "assistant", "第二个会话的回答 " + marker * 120, "2026-05-21T09:00:02+00:00"),
+            ],
+        )
+
+
+def _reject_owner_action(store, fingerprint, *, result="applied"):
+    _append_owner_action(
+        owner_actions_path(store.roots),
+        {
+            "schema_version": "memory-os.owner_action.v0",
+            "owner_action_id": f"oact_reject_{fingerprint[:8]}",
+            "action_type": "reject_session_mirror_apply",
+            "target_type": "session_mirror_apply",
+            "target_id": f"production_bounded:{fingerprint}",
+            "owner_id": "owner",
+            "channel": "telegram",
+            "result": result,
+            "result_ref": {"selected_pending_session_fingerprint": fingerprint},
+            "owner_effect": {"owner_rejected_session_mirror_apply": True},
+        },
+    )
+
+
+def test_owner_rejected_session_stops_starving_the_sessions_behind_it(tmp_path):
+    """Counterfactual: selection is pure head-of-queue (`platform_filtered[:limit]`).
+
+    Without the scan-level rejection filter, the rejected session stays at the
+    head, is re-offered on every digest, and is still the session the lane would
+    import once graduated -- so every session behind it is starved forever.
+    """
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", session_id="session-a")
+    _add_session(tmp_path / "state.db", session_id="session-b")
+
+    first = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+    head = first["selected_session_fingerprints"][0]
+    assert first["skipped_by_owner_rejection_count"] == 0
+
+    _reject_owner_action(store, head)
+    after = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    assert after["skipped_by_owner_rejection_count"] == 1
+    assert len(after["selected_session_fingerprints"]) == 1
+    assert head not in after["selected_session_fingerprints"]
+
+
+def test_owner_rejection_survives_session_mirror_state_rebuild(tmp_path):
+    """The rejection is read from the append-only owner action ledger, never from
+    SessionMirror state: `_rebuild_state()` reconstructs state from Memory-OS
+    events, so a rejection stored there would silently vanish on the next repair
+    and the rejected session would be re-offered and eventually imported."""
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", session_id="session-a")
+    _add_session(tmp_path / "state.db", session_id="session-b")
+
+    head = SessionMirror(store).scan(dry_run=True, max_sessions=1)["selected_session_fingerprints"][0]
+    _reject_owner_action(store, head)
+
+    mirror = SessionMirror(store)
+    mirror.state_path.parent.mkdir(parents=True, exist_ok=True)
+    mirror.state_path.write_text("{ this is not json", encoding="utf-8")
+
+    rebuilt = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    assert rebuilt["state_rebuilt"] is True
+    assert rebuilt["skipped_by_owner_rejection_count"] == 1
+    assert head not in rebuilt["selected_session_fingerprints"]
+
+
+def test_unapplied_reject_record_does_not_exclude_the_session(tmp_path):
+    """A dry-run owner action is not a decision. Only applied/duplicate_ignored
+    rejections may remove a session from the candidate list."""
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", session_id="session-a")
+
+    head = SessionMirror(store).scan(dry_run=True, max_sessions=1)["selected_session_fingerprints"][0]
+    _reject_owner_action(store, head, result="dry_run")
+
+    after = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    assert after["skipped_by_owner_rejection_count"] == 0
+    assert after["selected_session_fingerprints"] == [head]
+
+
+def test_owner_rejected_session_is_never_imported_by_a_real_apply(tmp_path):
+    """The exclusion must hold on the write path, not only on the digest surface."""
+    store = _store(tmp_path)
+    _enable_test_host_apply(store)
+    _create_state_db(tmp_path / "state.db", session_id="session-a")
+    _add_session(tmp_path / "state.db", session_id="session-b")
+
+    head = SessionMirror(store).scan(dry_run=True, max_sessions=1)["selected_session_fingerprints"][0]
+    _reject_owner_action(store, head)
+
+    applied = SessionMirror(store).scan(
+        dry_run=False, max_sessions=1, apply_governance=_test_host_governance()
+    )
+
+    assert applied["skipped_by_owner_rejection_count"] == 1
+    assert head not in applied["selected_session_fingerprints"]
+    assert applied["new_event_count"] == 1

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -7175,3 +7175,90 @@ def test_monitor_error_observability_reports_component_coverage_gap():
     assert "memory_os.permanent_promotion" in coverage["unaggregated_components"]
     assert coverage["unaggregated_component_count"] == len(coverage["unaggregated_components"])
     assert coverage["unaggregated_component_count"] > 0
+
+
+def _disable_audit_summary(tmp_path, disable_payload, *, job_enabled=True):
+    namespace: dict[str, object] = {}
+    _exec_remote_probe_prefix(namespace)
+    system = tmp_path / "memory-os" / "system"
+    system.mkdir(parents=True, exist_ok=True)
+    if disable_payload is not None:
+        (system / "cron_lane_disabled.json").write_text(
+            json.dumps(disable_payload), encoding="utf-8"
+        )
+    namespace["_hermes_home"] = str(tmp_path)
+    specs_by_lane = {
+        "expression_feedback_request": {
+            "key": "expression_feedback_request",
+            "name": "memory-os-expression-feedback-request",
+            "lane_id": "expression_feedback_request",
+            "due_interval_minutes": 10080,
+        }
+    }
+    jobs_by_name = {
+        "memory-os-expression-feedback-request": {
+            "name": "memory-os-expression-feedback-request",
+            "enabled": job_enabled,
+            "schedule": "0 5 * * 0",
+        }
+    }
+    return namespace["_execution_gate_helper_completion_summary"](specs_by_lane, jobs_by_name)
+
+
+def test_documented_lane_disable_carries_its_reason_into_the_summary(tmp_path):
+    """A disabled lane with a recorded reason is explainable, not drift."""
+    summary = _disable_audit_summary(
+        tmp_path,
+        {
+            "schema_version": "memory-os.cron_lane_disabled.v1",
+            "lanes": {
+                "expression_feedback_request": {
+                    "reason": "retired with the right-brain expression lanes",
+                    "actor": "owner",
+                    "disabled_at": "2026-08-02T00:00:00Z",
+                }
+            },
+        },
+    )
+
+    assert summary["helper_completion_disabled_count"] == 1
+    record = summary["helper_completion_disabled_records"]["expression_feedback_request"]
+    assert record["source"] == "lane_disable_file"
+    assert record["reason"] == "retired with the right-brain expression lanes"
+    assert record["actor"] == "owner"
+    assert summary["helper_completion_disabled_undocumented_count"] == 0
+
+
+def test_hermes_job_level_disable_without_a_reason_is_reported_as_undocumented(tmp_path):
+    """This is the observed production state: the job is disabled in Hermes and
+    cron_lane_disabled.json does not exist, so nothing on the host records why.
+    The state may be correct, but unexplained is indistinguishable from drift.
+    """
+    summary = _disable_audit_summary(tmp_path, None, job_enabled=False)
+
+    assert summary["helper_completion_disabled_count"] == 1
+    record = summary["helper_completion_disabled_records"]["expression_feedback_request"]
+    assert record["source"] == "hermes_job"
+    assert record["reason"] == ""
+    assert summary["helper_completion_disabled_undocumented_count"] == 1
+    assert summary["helper_completion_disabled_undocumented_lanes"] == ["expression_feedback_request"]
+
+
+def test_execution_gate_helper_completion_warn_codes_are_clean_host_classified():
+    """Counterfactual: an unregistered WARN code makes the clean-host monitor
+    emit `clean_host_warn_unclassified`, which is a FAIL. None of this family
+    was registered, so any clean host with a disabled/stale/not-yet-run lane
+    went red for a state that is normal there.
+    """
+    table = monitor.CLEAN_HOST_WARN_CLASSIFICATIONS
+
+    for code in (
+        "execution_gate_memory_os_cron_helper_completion_missing",
+        "execution_gate_memory_os_cron_helper_completion_stale",
+        "execution_gate_memory_os_cron_helper_completion_disabled",
+        "execution_gate_memory_os_cron_helper_completion_disabled_without_audit_record",
+        "execution_gate_memory_os_cron_helper_boundary_unobserved",
+    ):
+        assert code in table, f"{code} would fail the clean-host monitor as unclassified"
+        # Registering must not escalate today's production WARNs into FAILs.
+        assert table[code]["production_behavior"] == "warn_if_production"

--- a/tests/scripts/test_memory_os_cron_group_runner.py
+++ b/tests/scripts/test_memory_os_cron_group_runner.py
@@ -393,3 +393,44 @@ def test_failed_member_still_records_attempt_so_it_retries_on_cadence(tmp_path, 
 
     assert soon["member_ran_count"] == 0
     assert soon["member_skipped_not_due_count"] == 1
+
+
+def test_v1_audited_disable_file_still_stops_the_lane(tmp_path, stub_helpers):
+    """Counterfactual: the runner's own copy of the parser only understood the
+    bare list and the `disabled_lane_keys` wrapper. Recording a *reason* moves
+    the keys under `lanes`, so an un-updated parser would find no keys and run
+    a lane the owner had disabled -- the audit trail silently re-enabling it.
+    """
+    runner = _load_group_runner()
+    home = tmp_path / "home"
+    stub_helpers("_stub_alpha.py")
+    stub_helpers("_stub_beta.py")
+    _write_snapshot(
+        home,
+        [
+            {"key": "alpha", "raw_script": "_stub_alpha.py"},
+            {"key": "beta", "raw_script": "_stub_beta.py"},
+        ],
+    )
+    disable_path = home / "memory-os" / "system" / "cron_lane_disabled.json"
+    disable_path.parent.mkdir(parents=True, exist_ok=True)
+    disable_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "memory-os.cron_lane_disabled.v1",
+                "lanes": {
+                    "beta": {
+                        "reason": "retired with the right-brain expression lanes",
+                        "actor": "owner",
+                        "disabled_at": "2026-08-02T00:00:00Z",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = runner.run_group("tick_test", hermes_home=home)
+
+    assert report["member_skipped_disabled_count"] == 1
+    assert {item["key"] for item in report["members"] if item["status"] == "ok"} == {"alpha"}

--- a/tests/scripts/test_memory_os_deploy.py
+++ b/tests/scripts/test_memory_os_deploy.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 
 from scripts.deploy_memory_os import (
+    DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    _classification_failures,
     _classify_boundary_runtime_probe,
     _classify_cron_adapter_probe,
     _classify_llm_judge_probe,
@@ -1409,3 +1411,114 @@ def test_postcheck_fails_and_renders_cognitive_loop_timer_failure(tmp_path):
     assert {"code": "postcheck_failed"} in classify_deploy_report(report)["fail"]
     assert "postcheck_fail_codes=cognitive_loop_timer_inactive" in rendered
     assert "postcheck_cognitive_loop_timer=inactive/disabled" in rendered
+
+
+# ── preflight: a gate that never answered is not a malformed answer ───
+
+
+def test_timed_out_compat_gate_is_not_reported_as_invalid_json():
+    """Counterfactual: `_classification_failures` keyed only on "is the parsed
+    payload a dict", so a timeout produced `compat_json_invalid` and sent the
+    operator hunting for malformed JSON. Observed on 3.200: the compat gate
+    needs ~63s, the default budget was 60s, so `--phase preflight` failed on
+    default arguments and blamed the wrong cause.
+    """
+    timed_out = {
+        "exit_code": 124,
+        "stdout": "",
+        "stderr": "\ncommand timed out after 60s",
+        "json": None,
+    }
+
+    fail = _classification_failures(timed_out)
+
+    assert [item["code"] for item in fail] == ["compat_timed_out"]
+    assert fail[0]["exit_code"] == 124
+    assert "--timeout" in fail[0]["hint"]
+
+
+def test_failed_compat_command_is_distinguished_from_bad_json():
+    """A crashed gate and a gate that emitted garbage are different faults."""
+    crashed = {"exit_code": 3, "stdout": "", "stderr": "Traceback ...", "json": None}
+
+    fail = _classification_failures(crashed)
+
+    assert [item["code"] for item in fail] == ["compat_command_failed"]
+    assert fail[0]["exit_code"] == 3
+
+
+def test_successful_command_with_unparseable_output_is_still_json_invalid():
+    """The original code stays reachable for the fault it actually names."""
+    garbage = {"exit_code": 0, "stdout": "not json", "stderr": "", "json": None}
+
+    assert [item["code"] for item in _classification_failures(garbage)] == ["compat_json_invalid"]
+
+
+def test_healthy_compat_payload_reports_its_own_failures_unchanged():
+    """Distinguishing transport faults must not swallow the gate's real verdict."""
+    result = {
+        "exit_code": 0,
+        "stdout": "{}",
+        "json": {"classification": {"fail": [{"code": "shell_doctor_command_failed"}]}},
+    }
+
+    assert [item["code"] for item in _classification_failures(result)] == ["shell_doctor_command_failed"]
+
+
+def test_default_command_timeout_exceeds_the_measured_compat_gate_cost():
+    """Regression guard for the actual production symptom.
+
+    The compat gate measured ~63s on 3.200 and low-spec hosts are slower, so a
+    default at or near 60s makes `--phase preflight` fail before it starts.
+    """
+    assert DEFAULT_COMMAND_TIMEOUT_SECONDS >= 240
+
+    report = deploy_memory_os(
+        repo_root=Path(__file__).resolve().parents[2],
+        hermes_home="/tmp/hermes-home",
+        mode="production-safe",
+        hindsight_mode="auto",
+        phase="plan",
+        profile="upgrade",
+    )
+    compat = report["commands"]["compat"]
+    assert int(compat[compat.index("--timeout") + 1]) >= 240
+
+
+@pytest.mark.parametrize(
+    "classifier, prefix",
+    [
+        (_classify_llm_judge_probe, "llm_judge_probe"),
+        (_classify_cron_adapter_probe, "cron_adapter_probe"),
+        (_classify_boundary_runtime_probe, "boundary_runtime_probe"),
+    ],
+)
+def test_timed_out_probes_are_not_reported_as_invalid_json(classifier, prefix):
+    """Section W rule 5: the compat gate's defect was not unique to it.
+
+    All three probe classifiers keyed only on payload shape, so a timeout was
+    reported as `..._json_invalid` -- pointing the operator at the probe's
+    output instead of at the budget that cut it off.
+    """
+    timed_out = {"exit_code": 124, "stdout": "", "stderr": "timed out", "json": None}
+
+    report = classifier(timed_out)
+
+    assert report["reason"] == f"{prefix}_timed_out"
+    assert report["exit_code"] == 124
+    assert "--timeout" in report["hint"]
+
+
+@pytest.mark.parametrize(
+    "classifier, prefix",
+    [
+        (_classify_llm_judge_probe, "llm_judge_probe"),
+        (_classify_cron_adapter_probe, "cron_adapter_probe"),
+        (_classify_boundary_runtime_probe, "boundary_runtime_probe"),
+    ],
+)
+def test_probe_classifiers_still_report_bad_output_as_json_invalid(classifier, prefix):
+    """A completed probe emitting garbage keeps its original, accurate verdict."""
+    garbage = {"exit_code": 0, "stdout": "not json", "json": None}
+
+    assert classifier(garbage)["reason"] == f"{prefix}_json_invalid"


### PR DESCRIPTION
Owner-designated items 4 and 5 from the closure review. Item 6 (`oa_` keying) deliberately not done.

## 待办 4 — session_mirror reject/defer

The Owner could only approve; "别再问了" was inexpressible. The two are different problems:

**reject** closes one session — but closing the target alone is a trap. `SessionMirror.scan()` selects the pure head of the queue (`platform_filtered[:limit]`) with no exclusion state, so a rejected session stays at the head, short-circuits the review item forever, and is still what the lane imports once graduated. **Every session behind it is starved.** The exclusion is therefore honoured inside `session_mirror.py`, read back from the append-only owner action ledger — deliberately *not* stored in SessionMirror state, because `_rebuild_state()` reconstructs from events and a rejection kept there would vanish on the next state repair.

**defer** cannot be expressed by closing a target at all: `target_id` derives from the head session's fingerprint, so the next session produces a new target and the Owner is asked again. Evaluated lane-wide instead, reusing the existing `defer_candidate_cluster` contract (`deferred_until`, 7-day default, expiry reopens).

`lane_deferred` is a **required** keyword arg — two callers, and a default would let one keep surfacing a silenced item. It caught both callers as a TypeError.

Fail-closed by construction: all three apply-path checks still match `approve_session_mirror_apply` exactly, so reject/defer records cannot authorize an import. Neither new type joins `DIGEST_OPTIONAL_SURFACE_ACTION_TYPES`.

## 待办 5 — cron lane disable audit

Production disabled `memory-os-expression-feedback-request` at the Hermes job level with no `cron_lane_disabled.json` at all — nothing on the host recorded why. Owner decision: keep it disabled, record it properly.

`cron_lane_disabled.json` gains a v1 shape with `reason`/`actor`/`disabled_at`; both older shapes still parse; a corrupt file still disables nothing. **The group runner's second copy of the parser is updated too** — otherwise recording a reason moves the keys under `lanes` and silently re-enables the lane. The monitor reports "disabled without an audit record" as its own signal.

## Also closes 待办 1 (and corrects its severity)

An unregistered WARN code is a clean-host **FAIL** (`clean_host_warn_unclassified`), not a WARN — and independent of whether `deploy_memory_os.py` wires cron onboarding, which is what the original note assumed. All five helper-completion codes registered as `warn_if_production`, so today's production WARNs are **not** escalated to FAIL.

## Verification

- 7 counterfactuals verified revert→FAIL→restore→PASS
- 3130 → **3148 passed / 13 skipped / 0 failed** (+18)
- import cycle / write surface (unclassified 0) / public checkout probe --strict / range `git diff --check`: pass
- `static_hygiene`'s compileall fails *inside this worktree only* — Windows MAX_PATH artifact (mirrored `pycache_prefix` path is 261 chars vs the 260 limit); with a short prefix compileall exits 0. Not a code defect; unaffected on main and on Linux CI.

`local_pass` only — not yet deployed to 3.200.

## Note on deploy sequencing

Production currently runs `5bf0022`; **BW (#8) and BX (#9) are merged but never deployed**, so the Owner's 09:00 agenda is still the pre-BX rendering. `/opt/Hermes-Memory-OS` on 3.200 (the manifest's `active_runtime_path`) sits at `192e056`, the CI-red WIP commit. Once this merges I'll sync `/opt` to main and deploy BW+BX+this together.