### PR TITLE
docs: adoption closure plan for the un-wired helper backlog

### DIFF
--- a/docs/resolver/hermes-memory-os-optimization-roadmap.md
+++ b/docs/resolver/hermes-memory-os-optimization-roadmap.md
@@ -252,6 +252,8 @@ designed
 
 ### P2 — helper-only adoption debt
 
+> **闭环方案见 [`hermes-memory-os-adoption-closure-plan.md`](hermes-memory-os-adoption-closure-plan.md)（2026-08-03）**：该文档把本清单按"接线之后会发生什么"重新分类——6 项合并即终结、4 项建议删除、只有 3 项会进入观察窗口，并为每项指定了具名调用点、退出条件、反事实测试与回滚方式。另更正本节两处：`timeutil` 的实际调用点是 **77 处 / 46 文件**（本节记的 10 处是模块数），且 `parse_utc` 与裸 `fromisoformat` 实测**不等价**，迁移不得按机械重构推进。
+
 10. 以下能力仍不得标为 wired/live（2026-07-29 依据 `004a16b` 逐一以 import/caller 证据核实，
     除注明外全部仅被自身测试引用）：
    - `timeutil` 的剩余 ad-hoc parser 迁移——生产/脚本代码仍有 10 处独立时间解析实现：


### PR DESCRIPTION
Documentation only.

Answers the question directly: **is every module's closure stuck on observation?** Measured answer — no. R1 is genuinely observation-gated and self-closing. R3/R4, R5.1–5.3 and R6 are blocked on nobody having wired the helpers.

Evidence: 9 modules, ~1722 LOC, all with tests, **zero production importers**. Observation ends by itself; adoption does not — it has no date and no owner.

## The classification

Organised by *what happens after wiring*, not by roadmap section:

| Class | Meaning | Count | Terminal on merge? |
|---|---|---|---|
| 1 | internal migration, no owner-visible change | 2 | ✅ |
| 2 | tooling/CI, zero runtime risk | 4 | ✅ |
| 3 | changes owner-visible behavior → shadow → canary | 3 | ❌ becomes an observation item |
| 4 | delete rather than wire | 4 | ✅ |

**6 terminal on merge, 4 terminal by deletion, only 3 enter observation** — and those 3 all touch recall output, where observation is correct discipline rather than a stall. Stated up front deliberately: if the plan read "wire 13 things" and 3 then entered 30-day windows, the same frustration would recur in a month.

Each item names a concrete caller site (`file:symbol`), exit condition, counterfactual test and rollback. An item without a named caller site is not planned yet — that vagueness is how the backlog formed.

## Two roadmap corrections, both measured

- **`timeutil` is not a mechanical refactor.** Real scope is **77 call sites across 46 files** (the roadmap's "10" was a module count), and `parse_utc` is **not equivalent** to a bare `fromisoformat`: naive timestamps return `None` instead of a naive datetime, and invalid input returns `None` instead of raising. A blind swap would silently drop records wherever naive stamps are accepted. The plan requires a differential test **per call site**.
- **`natural_evidence` and `lifecycle` join the delete list.** Production already runs `execution_gate.resolve_trigger_class()` instead of the former; a wired `plugins/system/lifecycle.py` already exists alongside the unreferenced `memory_os` one. That duplicate module name also produced a false-positive importer count in my first pass, which grep re-verification corrected.

## The structural fix

Makes **deletion the default and wiring the thing requiring justification**. R6 already says "优先删除平行 helper"; the backlog accumulated because wiring was implicitly the default. Inverting it is the one line that prevents a repeat.

Three decisions are left explicitly to the Owner (Class 4 delete/keep; where `restraint`'s cross-session denial state lives; whether to open the Class 3 shadows now).