### PR TITLE
fix(timeutil): allow_naive must still return a UTC-aware datetime

### DIFF
--- a/docs/resolver/hermes-memory-os-adoption-closure-plan.md
+++ b/docs/resolver/hermes-memory-os-adoption-closure-plan.md
@@ -101,6 +101,39 @@ helper，而不是继续增加第三套语义」，而这批 helper 之所以累
   - **必须单独处理**：用户输入的时间参数（`cli.py:930/931` 的 `--since`/`--until`），
     用户合法地会输入无时区值，`parse_utc` 会返回 `None`。这些站点要么显式
     `allow_naive=True`，要么保留原实现，并在注释写明原因。
+
+> **批次 B 执行结果（2026-08-03）——范围比预想更小，但查出一个真 bug。**
+>
+> 差分测试（先测、后改）发现 `parse_utc` 与它要替换的内联实现有 **4 处分歧**，其中一处是崩溃级：
+>
+> | 输入 | 内联实现（生产在跑） | 修复前的 `parse_utc(allow_naive=True)` |
+> |---|---|---|
+> | `2026-08-03T04:05:06`（无时区） | tz-aware UTC | **naive** ← 与 aware 相减即 `TypeError` |
+> | `2026-08-03`（仅日期） | 午夜 UTC | `None` |
+> | `2026-08-03T04:05`（无秒） | 正常 | `None` |
+> | `2026-08-03 04:05:06`（空格分隔） | tz-aware | naive |
+>
+> **裁定**：`allow_naive=True` 返回 naive 是 `timeutil` 的**契约违反**——docstring 明写
+> 「a timezone-aware datetime in UTC」，且所有内联副本都强制转 UTC。已修复：无偏移且
+> `allow_naive=True` 时附加 `timezone.utc`。**正则的严格性保留不放宽**（拒绝仅日期/无秒
+> 是治理时间戳解析器应有的严格）。
+>
+> 既有测试 `test_naive_allowed` 原本断言 `tzinfo is None`——**它钉住的正是这个 bug**。
+> 这是第 8.0 条的活标本：一个从未被调用的 helper，它的测试只验证它自己的假设。已刻意更新。
+>
+> **⚠️ 常设隐患（独立于本次迁移，供后续会话）**：`parse_utc` 拒绝仅日期与无秒时间戳。
+> 任何目前接受这两种格式的调用点，一旦迁移过来就会**静默开始丢记录**。
+> 已用 `test_parse_utc_is_deliberately_stricter_than_fromisoformat` 钉死为契约。
+>
+> **实际迁移范围：31 处里只迁了 1 处。** 按裁定「逐站点追溯输入是否机器生成，追不到就踢出」：
+> - ✅ `execution_gate.py:_record_created_at` —— `created_at` 由本模块自己在 478/517 行
+>   以 `now.isoformat().replace("+00:00","Z")` 写入，**完整追溯到机器写入者**，已迁移。
+> - ❌ `v3_retention.py:_parse_datetime`（`item["expires_at"]`）、
+>   `task_state.py:_parse_timestamp`（`record["updated_at"|"created_at"]`）——
+>   本轮**追不到确定的写入者**，按裁定踢出本批。不是"不能迁"，是"没验证过就不迁"。
+> - 其余 28 处出于以下原因不在范围内：`try` 包住的不止解析、或接受用户输入、或会撞上严格性分歧。
+>   **「迁完 31 处」不是目标。**
+
 - **建议**：**先迁移"严格改进"子集**，按文件分批、每批独立 PR 带差分测试；
   用户输入类站点单独一批并逐个判断。不追求 77 处全清。
 

--- a/plugins/memory/memory_os/execution_gate.py
+++ b/plugins/memory/memory_os/execution_gate.py
@@ -18,6 +18,7 @@ from .jsonl_io import (
 )
 from .roots import MemoryOSRoots
 from .store import MemoryOSStore
+from .timeutil import parse_utc
 
 
 EXECUTION_GATE_SCHEMA_VERSION = "memory-os.execution_gate_envelope.v0"
@@ -688,16 +689,13 @@ def rotate_execution_gate_records(
 
 
 def _record_created_at(record: dict[str, Any]) -> datetime | None:
-    raw = str(record.get("created_at") or "").strip()
-    if not raw:
-        return None
-    try:
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    # `created_at` on these records is written by this module itself
+    # (`now.isoformat().replace("+00:00", "Z")`), so it is always a full
+    # machine-generated ISO timestamp -- which is what makes parse_utc a safe
+    # substitute here. parse_utc is deliberately stricter than fromisoformat
+    # (it rejects date-only and second-less values), so sites parsing
+    # user- or config-supplied timestamps must not be migrated the same way.
+    return parse_utc(str(record.get("created_at") or "").strip(), allow_naive=True)
 
 
 def _expiry_status(value: Any, *, now: datetime | None = None, require_present: bool = False) -> str:

--- a/plugins/memory/memory_os/timeutil.py
+++ b/plugins/memory/memory_os/timeutil.py
@@ -79,6 +79,14 @@ def parse_utc(value: str | None, *, allow_naive: bool = False) -> datetime | Non
             tz = timezone(offset)
         elif not allow_naive:
             return None
+        else:
+            # allow_naive means "accept input that carries no offset", not
+            # "return something unusable". Without this the function contradicts
+            # its own contract ("a timezone-aware datetime in UTC") and hands
+            # back a naive value, which raises TypeError the moment a caller
+            # subtracts it from an aware datetime. The inlined copies this
+            # helper is meant to replace have always coerced to UTC here.
+            tz = timezone.utc
     try:
         dt = datetime(year, month, day, hour, minute, second, microsecond, tzinfo=tz)
     except (ValueError, OverflowError):

--- a/tests/plugins/memory/test_memory_os_timeutil.py
+++ b/tests/plugins/memory/test_memory_os_timeutil.py
@@ -33,9 +33,17 @@ class TestParseUtc:
         assert parse_utc("2026-07-22T12:00:00") is None
 
     def test_naive_allowed(self):
+        # This previously asserted `dt.tzinfo is None`, pinning a defect: the
+        # function's docstring promises "a timezone-aware datetime in UTC", and
+        # every inlined copy it exists to replace coerces a naive value to UTC.
+        # Returning naive made the helper unusable -- subtracting it from an
+        # aware datetime raises TypeError. Nobody hit it because nothing in
+        # production ever called this module, so its own test simply encoded
+        # its own assumption. allow_naive means "accept input carrying no
+        # offset", not "hand back something that cannot be used".
         dt = parse_utc("2026-07-22T12:00:00", allow_naive=True)
         assert dt is not None
-        assert dt.tzinfo is None
+        assert dt.tzinfo == timezone.utc
 
     def test_empty_string(self):
         assert parse_utc("") is None
@@ -151,3 +159,62 @@ class TestAliases:
     def test_parse_dt(self):
         assert parse_dt("2026-07-22T12:00:00Z") is not None
         assert parse_dt("2026-07-22T12:00:00") is None  # naive rejected
+
+# ── allow_naive must still return a UTC-aware datetime ────────────────
+
+
+def _inlined_parse(value):
+    """The shape this helper exists to replace, copied verbatim from the
+    call sites that have been running it in production for months."""
+    try:
+        parsed = datetime.fromisoformat(str(value or "").replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def test_allow_naive_returns_utc_aware_not_naive():
+    """Counterfactual: without the fix this returns a NAIVE datetime, and the
+    first caller that subtracts it from an aware datetime raises
+    TypeError: can't subtract offset-naive and offset-aware datetimes.
+
+    The docstring promises "a timezone-aware datetime in UTC"; allow_naive
+    means "accept input carrying no offset", not "return something unusable".
+    """
+    parsed = parse_utc("2026-08-03T04:05:06", allow_naive=True)
+
+    assert parsed is not None
+    assert parsed.tzinfo == timezone.utc
+    # The arithmetic that would have blown up.
+    assert (datetime(2026, 8, 3, 5, 0, 0, tzinfo=timezone.utc) - parsed).total_seconds() > 0
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-08-03T04:05:06Z",
+        "2026-08-03T04:05:06+08:00",
+        "2026-08-03T04:05:06",
+        "2026-08-03T04:05:06.123456Z",
+        "2026-08-03 04:05:06",
+        "",
+    ],
+)
+def test_parse_utc_matches_the_inlined_implementation_it_replaces(value):
+    """Differential test: migrating a call site must not change its result."""
+    assert parse_utc(value, allow_naive=True) == _inlined_parse(value)
+
+
+@pytest.mark.parametrize("value", ["2026-08-03", "2026-08-03T04:05"])
+def test_parse_utc_is_deliberately_stricter_than_fromisoformat(value):
+    """Standing hazard, pinned on purpose.
+
+    parse_utc rejects date-only and second-less timestamps; the inlined
+    implementation accepts both. Any call site that currently accepts these
+    formats will SILENTLY START DROPPING RECORDS if migrated. This test exists
+    so that divergence is a documented contract rather than a surprise.
+    """
+    assert _inlined_parse(value) is not None
+    assert parse_utc(value, allow_naive=True) is None


### PR DESCRIPTION
Batch B of the adoption closure plan. **Differential testing before touching any call site** found a real defect, and shrank the migration from 31 sites to 1.

## The defect

`parse_utc` disagreed with the inlined implementations it exists to replace, on four inputs. One is crash-class:

| Input | Inlined impl (in production) | `parse_utc(allow_naive=True)` before |
|---|---|---|
| `2026-08-03T04:05:06` (no offset) | tz-aware UTC | **naive** ← `TypeError` on arithmetic |
| `2026-08-03` (date-only) | midnight UTC | `None` |
| `2026-08-03T04:05` (no seconds) | parses | `None` |
| `2026-08-03 04:05:06` (space sep) | tz-aware | naive |

The docstring promises *"a timezone-aware datetime in UTC"*, so the **helper** was wrong and the call sites — running this shape for months — were right. `allow_naive` now means "accept input carrying no offset", not "return something unusable".

**Regex strictness is deliberately NOT relaxed.** `parse_utc` still rejects date-only and second-less timestamps; that is now pinned by a test, because any site currently accepting those formats would **silently start dropping records** if migrated. Standing hazard for future batches, not a bug.

## The pre-existing test pinned the defect

`test_naive_allowed` asserted `tzinfo is None`. That is the plan's §8.0 in miniature: *a helper nobody ever called has no premise validated by anything except its own tests, which encode its own assumptions.* Updated deliberately, with the reasoning in the test.

## Migration scope: 1 of 31

Each candidate's input had to be **traced to a machine writer**, not assumed:

- ✅ `execution_gate._record_created_at` — `created_at` is written by this same module (lines 478/517, `now.isoformat().replace('+00:00','Z')`).
- ❌ `v3_retention._parse_datetime`, `task_state._parse_timestamp` — inputs could not be traced to a definite writer this round. Not *"cannot migrate"*; *"not verified, so not migrated"*.
- The other 28 are out of scope: the `try` wraps more than the parse, or they take user input, or they'd hit the strictness divergence. **"Migrate all 31" is not a goal.**

Only the `allow_naive=True` path changed semantics, and it had **zero production callers** before this migration — `continuity` and `restraint` both use the default.

## Verification

3035 → **3044 passed / 13 skipped / 0 failed**. Counterfactual verified revert→FAIL→restore→PASS. Import cycle pass, write surface unclassified 0, public checkout probe pass, whitespace clean.