### PR TITLE
Core switches must not ship dark: preset fix, upgrade auto-enable, outage detector

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -3503,6 +3503,79 @@ installer 1）。复审处置 fold 后受影响三文件定向重跑 260 passed�
 public checkout probe --strict exit 0、`git diff --check` 干净。
 证据级别：**仅 `local_pass`**，未部署、未推送。
 
+## CE — 核心开关守护：升级自动开、安装预设纠偏、断流探测器（2026-08-05）
+
+Owner 指令：安装/升级脚本要保证核心功能自动打开、核心定时任务配置注册齐全；
+外部对接可选项另说。审计后按三层收口（cron 注册链核查后判定已有兜底，见末段）。
+
+### CE.1 翻转来源实锤：`production-safe` 预设本身就写 `enabled: False`
+
+审计直接找到了 CD.E 断流的最可能翻转来源——不是"意外洗键"，而是**有意的
+预设**：`MEMORY_SOURCES_PRESETS["production-safe"]["enabled"] = False`，
+且有既有测试 `..._preset_is_explicitly_off` 把它钉死为设计。而
+test-host / operational 两个预设都是 True——**唯独"生产安全"预设让生产
+观测链全盲**。"safe" 的正确含义在 `mode=metadata_only`（永不含原文），
+不在关掉记录器。已翻转预设并反转该测试语义
+（`..._preset_enables_metadata_only`，docstring 记录 CE 裁定）。
+
+### CE.2 升级自动开 + 归一化洗键根除
+
+- `_ensure_config_defaults`（每次 install/upgrade 必经）新增**唯一一个**
+  自动纠偏：`memory_sources.enabled` False→True。刻意只此一个——带
+  shadow→apply 毕业管治的模式（context_router / recall_arbitration /
+  owner_review …）**报告不翻**（`core_mode_report`），自动翻会绕过毕业管治；
+  外部对接（hindsight / v3）不动。
+- **顺链抓到并修掉一个真回归途径**：该函数原走 `load_config→save_config`
+  往返，归一化会**剥离 schema 外的键**（其他安装步骤刚写入的 `preset`
+  标记被洗掉——新增测试当场以 KeyError 复现）。改为 `_read_json_config`
+  直读直写。这与 CD.E 的"配置重写翻开关"同族——**config 的 load→save
+  往返本身就是键清洗器**。全项目余 3 处 `save_config` 调用点
+  （cli.py:326 hindsight adoption、__init__.py:823、installer:1687）
+  登记为待逐个核查的观察项，不在本轮扩面。
+
+### CE.3 status 暴露记录器状态 + monitor 双检查
+
+- `build_status_report` 新增 `memory_sources_recording`
+  块（enabled/raw_enabled/mode）——开关状态首次有了可被 monitor 读到的面。
+- monitor 新增两个 WARN 码（均注册 clean-host 分类、
+  `production_behavior=fail_if_production`，沿 BD.1 机制生产升级 FAIL）：
+  - `memory_sources_recording_disabled`：生产上记录器被关即红
+    （CD.E 那四天的形状，今后活不过一次 monitor）；
+  - `memory_sources_disclosure_outage`：**断流签名**——stats 窗口
+    （24h）内零披露而同窗口内存在 provider 捕获的对话事件。事件时间戳
+    由 correlation probe 顺手带出（`latest_conversation_turn_ts`，
+    同 writer 统一 isoformat，分类端解析比较不做字符串比较——BF.3 教训），
+    旧快照无该块时按值守卫静默（不造零、不误报）。
+    "安静≠坏"的对偶有测试钉住：对话在窗口外、或披露正常时不告警。
+
+### cron 注册链核查结论（不改代码）
+
+- 快照重生成已由 install/onboarding 归口（CB 部署要求，CD.D 端到端证实）；
+- job 缺失/漂移已有兜底：per-lane helper-completion freshness（due 窗口内
+  必 WARN）、unregistered drift 分类、owner_review 专项 job missing 检查——
+  核心 group job 消失最迟一个 due 周期内可见；
+- onboarding 创建 job 保持 owner-gated（`--owner-approved` 经 ResolverGate），
+  deploy 不自动创建——这是边界不是缺口。
+
+### CE 反事实覆盖与测试
+
+新文件 `test_memory_os_core_switch_guard.py` 6 测 + 预设语义测试反转，
+revert 三源文件实测 5 红 1 绿（绿的一个是守卫型负向断言，天然非反事实）。
+`preset` 洗键回归由既有 `..._llm_judge_active_config` 测试以 KeyError
+复现、修后转绿。
+
+### CE 测试与门
+
+定向 281 passed（monitor/cli/runtime/install/guard 五文件）+ 四门全过
+（import cycle / write surface 156 不变 unclassified 0 / static hygiene /
+public checkout probe --strict）、`git diff --check` 干净。
+全量 **3158 passed / 13 skipped / 1 failed**——唯一失败为
+`test_execution_gate_runner_serializes_parallel_sidecar_updates`，
+已登记在案的并发环境 flake（与本批改动无调用关系），隔离重跑
+整文件 11 passed + 单测 passed，判定非回归。
+证据级别：`local_pass`；monitor 双检查的 `live_monitor_pass` 待下一次
+统一部署后取得。
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -4316,6 +4389,13 @@ PR #19 合并为 `53880cd` 后统一部署（含此前未部署的 BZ/CA/CB/CC/C
   长期唯一 FAIL 按纪元边界设计转 `healthy_no_sample` 且清算闸门保持冻结；
   attribution_schema 端到端验证如实登记为待 Gateway 重载。
   证据级别 `deploy_pass` + `live_monitor_pass`。纯文档记录。
+- `（CE，本节）`：核心开关守护三层收口——`production-safe` 预设翻转
+  （它是唯一让披露记录器全黑的预设，翻转来源实锤）、升级路径自动重开
+  `memory_sources.enabled`（毕业管治模式只报告不翻）、`_ensure_config_defaults`
+  改直读直写根除 load→save 归一化洗键（新测试以 KeyError 当场复现该回归）、
+  monitor 新增 `memory_sources_recording_disabled` + `memory_sources_disclosure_outage`
+  两红线（CD.E 那四天的形状今后活不过一次 monitor）。cron 注册链核查为已有
+  兜底，不改。6+1 反事实实测，四门全过。
 
 ### CD.E — 披露断流四天的根因、修复与归因链首次全绿（2026-08-05）
 

--- a/plugins/memory/memory_os/cli.py
+++ b/plugins/memory/memory_os/cli.py
@@ -78,6 +78,7 @@ from .memory_projection import (
     memory_projection_status,
 )
 from .memory_sources import (
+    memory_sources_enabled,
     memory_sources_feedback_history_report,
     memory_sources_feedback_last_report,
     memory_sources_history_report,
@@ -227,6 +228,15 @@ def build_status_report(store: MemoryOSStore) -> dict[str, Any]:
         "recent_event_summaries": recent_summaries,
         "hindsight_adapter_enabled": bool(config.get("hindsight_adapter_enabled")),
         "hindsight_substrate": hindsight_status_report(store),
+        # Whether the disclosure ledger is recording. This switch was flipped
+        # off by a July config rewrite and nothing surfaced it for four days
+        # (CE); the monitor's memory_sources_recording_disabled check reads
+        # this block, so the state finally has an alarmed reader.
+        "memory_sources_recording": {
+            "enabled": memory_sources_enabled(config.get("memory_sources")),
+            "raw_enabled": bool((config.get("memory_sources") or {}).get("enabled")),
+            "mode": str((config.get("memory_sources") or {}).get("mode") or ""),
+        },
         "low_clue_recall": {
             "enabled": bool((config.get("low_clue_recall") or {}).get("enabled"))
             if isinstance(config.get("low_clue_recall"), dict)

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -138,8 +138,14 @@ DEEP_REFLECTION_CONFIG_DEFAULTS: dict[str, object] = {
 
 
 MEMORY_SOURCES_PRESETS: dict[str, dict[str, object]] = {
+    # CE: production-safe now ENABLES the disclosure ledger. "Safe" lives in
+    # mode=metadata_only (no raw bodies ever), not in switching the recorder
+    # off: this was the only preset that shipped it dark, a production-safe
+    # install could silently flip a live host's recorder off, and the whole
+    # attribution/exposure observation chain starves without it (the four-day
+    # outage of CD.E). test-host/operational already enabled it.
     "production-safe": {
-        "enabled": False,
+        "enabled": True,
         "mode": "metadata_only",
         "retention_days": 30,
         "record_live_prefetch": True,
@@ -1866,29 +1872,72 @@ def _ensure_config_defaults(
     *,
     dry_run: bool = False,
 ) -> dict[str, object]:
-    """Apply safe defaults to existing config.json without overwriting user values."""
-    # Lazy-import to avoid circular import during install before plugin is copied
-    from plugins.memory.memory_os.config import load_config, save_config
+    """Apply safe defaults to existing config.json without overwriting user values.
 
+    Reads and writes the raw JSON directly, NEVER through
+    load_config/save_config: that round-trip normalizes the whole file and
+    strips keys outside the schema (e.g. the ``preset`` markers other
+    installer steps just wrote) -- the same key-laundering mechanism that let
+    a config rewrite silently flip production switches (CD.E).
+    """
     config_path = hermes_home / "memory-os" / "config.json"
     if not config_path.exists():
         return {"status": "no_config", "reason": "config.json not found"}
-    cfg = load_config(hermes_home)
+    cfg = _read_json_config(config_path)
     changed: list[str] = []
 
     if cfg.get("prefetch_char_budget", 0) < 5500:
         cfg["prefetch_char_budget"] = 5500
         changed.append("prefetch_char_budget: 2200 → 5500")
 
+    # CE: core observability must not ship dark on an upgraded host. The
+    # disclosure ledger (memory_sources, metadata_only -- no raw bodies) is
+    # the input of the whole attribution/exposure observation chain; a July
+    # config rewrite left it off and production ran a silent four-day
+    # disclosure outage. This is deliberately the ONLY switch auto-enabled
+    # here: modes with a shadow->apply graduation contract (context_router,
+    # recall_arbitration, owner_review, ...) are REPORTED below, never
+    # flipped, because auto-flipping them would bypass their graduation
+    # governance. External/optional integrations (hindsight, v3) stay
+    # untouched.
+    ms_cfg = dict(cfg.get("memory_sources") or {})
+    if not ms_cfg.get("enabled"):
+        ms_cfg["enabled"] = True
+        cfg["memory_sources"] = ms_cfg
+        changed.append(
+            "memory_sources.enabled: False → True (core disclosure ledger; "
+            "metadata_only, required by the attribution observation chain)"
+        )
+
+    # Drift visibility for the graduated-mode core switches: report current
+    # values so an upgrade never silently runs with a core surface off, while
+    # leaving every decision with the owner/graduation flow.
+    core_mode_report = {
+        "memory_sources.enabled": bool((cfg.get("memory_sources") or {}).get("enabled")),
+        "low_clue_recall.enabled": bool((cfg.get("low_clue_recall") or {}).get("enabled")),
+        "context_router.mode": str((cfg.get("context_router") or {}).get("mode") or ""),
+        "recall_arbitration.mode": str((cfg.get("recall_arbitration") or {}).get("mode") or ""),
+        "owner_review.enabled": bool((cfg.get("owner_review") or {}).get("enabled")),
+        "owner_review.mode": str((cfg.get("owner_review") or {}).get("mode") or ""),
+    }
+
     if not changed:
-        return {"status": "already_current", "changes": changed}
+        return {
+            "status": "already_current",
+            "changes": changed,
+            "core_mode_report": core_mode_report,
+        }
 
     if not dry_run:
-        save_config(cfg, hermes_home)
+        config_path.write_text(
+            json.dumps(cfg, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     return {
         "status": "updated" if not dry_run else "would_update",
         "changes": changed,
+        "core_mode_report": core_mode_report,
     }
 
 

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -13,7 +13,7 @@ import json
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -460,6 +460,20 @@ CLEAN_HOST_WARN_CLASSIFICATIONS: dict[str, dict[str, str]] = {
     "living_memory_stale_open_evaluation_unavailable": {
         "classification": "expected_clean_host",
         "reason": "clean-host may not have a warmed crystallized-record store, so stale-open evaluation can be unavailable during compatibility smoke",
+        "production_behavior": "fail_if_production",
+    },
+    # CE: core-switch guard family. On a clean host the disclosure ledger is
+    # legitimately off/quiet; on production a disabled recorder or a frozen
+    # ledger beside fresh conversation traffic is the four-day-outage
+    # signature and must go red.
+    "memory_sources_recording_disabled": {
+        "classification": "expected_clean_host",
+        "reason": "clean-host smoke may run with the disclosure recorder at its safe-off default",
+        "production_behavior": "fail_if_production",
+    },
+    "memory_sources_disclosure_outage": {
+        "classification": "expected_clean_host",
+        "reason": "clean-host smoke has no production conversation traffic, so a quiet ledger there is idle, not an outage",
         "production_behavior": "fail_if_production",
     },
 }
@@ -3259,6 +3273,44 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
             passed.append({"code": "memory_sources_stats_ok"})
         else:
             warn.append({"code": "memory_sources_no_records_yet", "value": memory_sources})
+        # CE: core-switch guard + disclosure-outage detector. The July config
+        # rewrite turned memory_sources.enabled off and NOTHING alarmed for
+        # four days -- the ledger froze while conversation events kept
+        # flowing, and record_count: 0 sat in every snapshot unread. Two
+        # complementary checks:
+        #   1. the switch itself (from status.memory_sources_recording;
+        #      absent on old snapshots -> silent, value-guarded), and
+        #   2. the outage signature: zero disclosures in the stats window
+        #      while a provider-captured conversation happened inside that
+        #      same window (timestamps parsed, not string-compared).
+        # Both are WARN codes registered fail_if_production, mirroring BD.1.
+        recording = (
+            snapshot.get("status", {}).get("memory_sources_recording")
+            if isinstance(snapshot.get("status"), dict)
+            else None
+        )
+        recording = recording if isinstance(recording, dict) else {}
+        if recording.get("enabled") is False:
+            warn.append({"code": "memory_sources_recording_disabled", "value": recording})
+        elif int(memory_sources.get("record_count") or 0) == 0:
+            latest_turn_raw = str(
+                (session_mirror or {}).get("latest_conversation_turn_ts") or ""
+            )
+            latest_turn_at = _parse_utc_timestamp(latest_turn_raw)
+            window_hours = int(memory_sources.get("hours") or 0)
+            if (
+                latest_turn_at is not None
+                and window_hours > 0
+                and datetime.now(timezone.utc) - latest_turn_at <= timedelta(hours=window_hours)
+            ):
+                warn.append({
+                    "code": "memory_sources_disclosure_outage",
+                    "value": {
+                        "latest_conversation_turn_ts": latest_turn_raw,
+                        "window_hours": window_hours,
+                        "record_count": 0,
+                    },
+                })
         memory_sources_surface = (
             snapshot.get("owner_review_surface", {})
             .get("operations", {})
@@ -7148,6 +7200,14 @@ provider_counts = count_groups(
         if event.get("kind") == "conversation_turn"
     ]
 )
+# Disclosure-outage detector input (CE): the newest provider-captured
+# conversation timestamp. String max is safe here because every event ts is
+# produced by the same datetime.isoformat() writer (uniform format); the
+# classifier parses it before comparing against the stats window.
+latest_conversation_turn_ts = max(
+    (str(event.get("ts") or "") for event in event_records if event.get("kind") == "conversation_turn"),
+    default="",
+)
 mirrored_counts = count_groups(
     [
         " ".join(
@@ -7173,6 +7233,7 @@ result = {
     "status": "ok",
     "dry_run_only": True,
     "raw_private_body_printed": False,
+    "latest_conversation_turn_ts": latest_conversation_turn_ts,
     "written_event_ids_count": 0,
     "state_rebuilt": bool(state_rebuilt),
     "finding_count": len(findings),
@@ -7399,6 +7460,7 @@ def session_mirror_summary():
       "correlation_schema_version": correlation.get("schema_version") if isinstance(correlation, dict) else None,
       "correlation_status": correlation.get("status") if isinstance(correlation, dict) else None,
       "correlation_finding_count": correlation.get("finding_count") if isinstance(correlation, dict) else None,
+      "latest_conversation_turn_ts": correlation.get("latest_conversation_turn_ts") if isinstance(correlation, dict) else None,
       "raw_private_body_printed": correlation.get("raw_private_body_printed") if isinstance(correlation, dict) else None,
       "written_event_ids_count": correlation.get("written_event_ids_count") if isinstance(correlation, dict) else None,
       "apply_status_schema_version": apply_status.get("schema_version") if isinstance(apply_status, dict) else None,

--- a/tests/scripts/test_memory_os_core_switch_guard.py
+++ b/tests/scripts/test_memory_os_core_switch_guard.py
@@ -1,0 +1,195 @@
+"""CE: core-switch guard — upgrades re-enable the core disclosure ledger, and
+the monitor alarms on the four-day-outage signature.
+
+Background: a July config rewrite flipped ``memory_sources.enabled`` off. The
+provider caches config at initialize, so the flip lay dormant until an Aug 1
+gateway restart — then the disclosure ledger froze for four days while
+conversation events kept flowing, and ``record_count: 0`` sat in every monitor
+snapshot with no reader. Three layers close that hole:
+
+1. installer upgrades auto-re-enable the one core, non-graduated switch;
+2. CLI status exposes the recorder state so the monitor has something to read;
+3. the monitor alarms on both the switch (``memory_sources_recording_disabled``)
+   and the outage signature itself (``memory_sources_disclosure_outage``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import scripts.memory_os_3_200_monitor as monitor
+from scripts.install_memory_os_plugin import _ensure_config_defaults
+
+
+# ── Layer 1: installer ─────────────────────────────────────────────────────
+
+
+def test_ensure_config_defaults_re_enables_core_disclosure_ledger(tmp_path: Path):
+    """Counterfactual: without the fix the upgrade leaves enabled=False and
+    reports nothing about core modes.
+
+    The dual is as load-bearing as the flip: graduated modes
+    (recall_arbitration / context_router / owner_review) must be REPORTED,
+    never auto-flipped — flipping them would bypass their graduation
+    governance.
+    """
+    home = tmp_path / "home"
+    (home / "memory-os").mkdir(parents=True)
+    (home / "memory-os" / "config.json").write_text(json.dumps({
+        "prefetch_char_budget": 6000,
+        "memory_sources": {"enabled": False, "mode": "metadata_only", "retention_days": 30},
+        "recall_arbitration": {"mode": "shadow"},
+        "context_router": {"enabled": True, "mode": "apply"},
+    }), encoding="utf-8")
+
+    report = _ensure_config_defaults(home)
+
+    assert report["status"] == "updated"
+    assert any("memory_sources.enabled" in change for change in report["changes"])
+    saved = json.loads((home / "memory-os" / "config.json").read_text(encoding="utf-8"))
+    assert saved["memory_sources"]["enabled"] is True
+    # Graduated modes untouched on disk, visible in the report.
+    assert saved["recall_arbitration"]["mode"] == "shadow"
+    assert saved["context_router"]["mode"] == "apply"
+    assert report["core_mode_report"]["recall_arbitration.mode"] == "shadow"
+    assert report["core_mode_report"]["context_router.mode"] == "apply"
+    assert report["core_mode_report"]["memory_sources.enabled"] is True
+
+    # Second run: nothing left to change, but the drift report still ships.
+    report_again = _ensure_config_defaults(home)
+    assert report_again["status"] == "already_current"
+    assert report_again["core_mode_report"]["memory_sources.enabled"] is True
+
+
+def test_ensure_config_defaults_dry_run_reports_without_writing(tmp_path: Path):
+    home = tmp_path / "home"
+    (home / "memory-os").mkdir(parents=True)
+    (home / "memory-os" / "config.json").write_text(json.dumps({
+        "prefetch_char_budget": 6000,
+        "memory_sources": {"enabled": False, "mode": "metadata_only"},
+    }), encoding="utf-8")
+
+    report = _ensure_config_defaults(home, dry_run=True)
+
+    assert report["status"] == "would_update"
+    saved = json.loads((home / "memory-os" / "config.json").read_text(encoding="utf-8"))
+    assert saved["memory_sources"]["enabled"] is False
+
+
+# ── Layer 2: CLI status exposes the recorder state ─────────────────────────
+
+
+def test_status_report_exposes_memory_sources_recording_state(tmp_path: Path):
+    from plugins.memory.memory_os.cli import build_status_report
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    home = tmp_path / "home"
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(home, profile="default"))
+    store.initialize()
+
+    # Default config: recorder off.
+    status = build_status_report(store)
+    assert status["memory_sources_recording"]["enabled"] is False
+
+    (home / "memory-os" / "config.json").write_text(json.dumps({
+        "memory_sources": {"enabled": True, "mode": "metadata_only"},
+    }), encoding="utf-8")
+    status = build_status_report(store)
+    assert status["memory_sources_recording"] == {
+        "enabled": True,
+        "raw_enabled": True,
+        "mode": "metadata_only",
+    }
+
+
+# ── Layer 3: monitor alarms ────────────────────────────────────────────────
+
+
+def _stats_block(record_count: int) -> dict:
+    return {
+        "schema_version": "memory-os.memory_sources_stats.v0",
+        "ledger_exists": True,
+        "record_count": record_count,
+        "hours": 24,
+    }
+
+
+def test_recording_disabled_is_alarmed():
+    """Counterfactual: before CE this exact production state (recorder off,
+    everything else green) produced zero warnings for four days."""
+    snapshot = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "status": {"memory_sources_recording": {"enabled": False, "mode": "metadata_only"}},
+        "memory_sources": _stats_block(record_count=0),
+    })
+    assert any(
+        item["code"] == "memory_sources_recording_disabled"
+        for item in snapshot["warn"] + snapshot["fail"]
+    )
+    # The registry escalates it on production rather than leaving it advisory.
+    entry = monitor.CLEAN_HOST_WARN_CLASSIFICATIONS["memory_sources_recording_disabled"]
+    assert entry["production_behavior"] == "fail_if_production"
+
+
+def test_disclosure_outage_signature_is_alarmed():
+    """Zero disclosures in the stats window while a provider-captured
+    conversation happened inside that window: the outage signature."""
+    fresh_turn = datetime.now(timezone.utc).isoformat()
+    snapshot = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "status": {"memory_sources_recording": {"enabled": True, "mode": "metadata_only"}},
+        "session_mirror": {
+            "schema_version": "memory-os.session_mirror_monitor_summary.v0",
+            "latest_conversation_turn_ts": fresh_turn,
+        },
+        "memory_sources": _stats_block(record_count=0),
+    })
+    outage = [
+        item for item in snapshot["warn"] + snapshot["fail"]
+        if item["code"] == "memory_sources_disclosure_outage"
+    ]
+    assert outage, "fresh conversation + zero disclosures must alarm"
+    assert outage[0]["value"]["window_hours"] == 24
+    entry = monitor.CLEAN_HOST_WARN_CLASSIFICATIONS["memory_sources_disclosure_outage"]
+    assert entry["production_behavior"] == "fail_if_production"
+
+
+def test_disclosure_outage_stays_silent_without_the_signature():
+    """A quiet ledger is only an outage when conversation traffic existed in
+    the same window — idle is not broken (backlog 15's lesson, config side)."""
+    stale_turn = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
+
+    # Conversation older than the window: quiet ledger is idle, not broken.
+    idle = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "status": {"memory_sources_recording": {"enabled": True, "mode": "metadata_only"}},
+        "session_mirror": {
+            "schema_version": "memory-os.session_mirror_monitor_summary.v0",
+            "latest_conversation_turn_ts": stale_turn,
+        },
+        "memory_sources": _stats_block(record_count=0),
+    })
+    # Disclosures present: no outage regardless of conversation freshness.
+    healthy = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "status": {"memory_sources_recording": {"enabled": True, "mode": "metadata_only"}},
+        "session_mirror": {
+            "schema_version": "memory-os.session_mirror_monitor_summary.v0",
+            "latest_conversation_turn_ts": datetime.now(timezone.utc).isoformat(),
+        },
+        "memory_sources": _stats_block(record_count=3),
+    })
+    # Old snapshot without the recording block: value-guarded silence, and no
+    # fabricated disabled alarm either.
+    legacy = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "memory_sources": _stats_block(record_count=0),
+    })
+    for result in (idle, healthy, legacy):
+        for code in ("memory_sources_disclosure_outage", "memory_sources_recording_disabled"):
+            assert not any(
+                item["code"] == code for item in result["warn"] + result["fail"]
+            ), code

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -708,7 +708,16 @@ def test_installer_can_write_memory_sources_test_host_preset(tmp_path):
     assert config["session_mirror"]["production_apply_owner_ref_required"] is True
 
 
-def test_installer_memory_sources_production_safe_preset_is_explicitly_off(tmp_path):
+def test_installer_memory_sources_production_safe_preset_enables_metadata_only(tmp_path):
+    """CE semantics change: production-safe ENABLES the disclosure ledger.
+
+    "Safe" lives in mode=metadata_only (no raw bodies), not in switching the
+    recorder off — this preset was the only one shipping it dark, and a
+    production-safe install could silently flip a live host's recorder off
+    (the four-day outage of CD.E). Counterfactual: with the old preset table
+    this asserts False and the whole attribution chain starves on any host
+    installed with this preset.
+    """
     report = install_plugin(
         hermes_home=tmp_path / "home",
         memory_sources_preset="production-safe",
@@ -716,7 +725,8 @@ def test_installer_memory_sources_production_safe_preset_is_explicitly_off(tmp_p
 
     config = json.loads((tmp_path / "home" / "memory-os" / "config.json").read_text(encoding="utf-8"))
     assert report["memory_sources_config_written"] is True
-    assert config["memory_sources"]["enabled"] is False
+    assert config["memory_sources"]["enabled"] is True
+    assert config["memory_sources"]["mode"] == "metadata_only"
     assert config["memory_sources"]["record_live_prefetch"] is True
     assert report["session_mirror_preset"] == "production-safe"
     assert report["session_mirror_config_written"] is True


### PR DESCRIPTION
The four-day disclosure outage (CD.E) traced to the production-safe install preset itself -- the only preset shipping memory_sources.enabled=false. Safe means metadata_only, not recorder-off.

- production-safe preset now enables the disclosure ledger (metadata_only unchanged)
- upgrades auto-re-enable memory_sources.enabled; graduated modes (context_router / recall_arbitration / owner_review) are reported, never auto-flipped; external/optional integrations untouched
- _ensure_config_defaults reads/writes raw JSON: the load/save round-trip stripped out-of-schema keys (preset markers) -- reproduced as a KeyError by an existing test, now fixed
- CLI status exposes memory_sources_recording; monitor adds memory_sources_recording_disabled + memory_sources_disclosure_outage (fail_if_production, clean-host classified)
- cron registration chain audited: existing snapshot-regen + due-window freshness + drift classification already cover missing core jobs; onboarding stays owner-gated

Tests: 6 new (revert-FAIL verified) + preset-semantics test flipped; full suite 3158 passed with 1 known concurrency flake (isolated rerun green); all four static gates pass.