### PR TITLE
Provenance-less candidates must not crash the aggregation lane

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -3576,6 +3576,64 @@ public checkout probe --strict）、`git diff --check` 干净。
 证据级别：`local_pass`；monitor 双检查的 `live_monitor_pass` 待下一次
 统一部署后取得。
 
+## CF — 生产首个 FAIL 的根因修复：无溯源候选与聚合 lane 崩溃（2026-08-05）
+
+CE 部署后的 Full Monitor 出现新 FAIL
+`execution_gate_memory_os_cron_helper_completion_error`（lane =
+`candidate_aggregation`，12:12Z 起 rc=1 无 helper 报告）。手动复现拿到实锤：
+`CrystallizedApprovalError: crystallized records require source_event_ids`。
+
+### 根因链（三层，各自都是真缺陷）
+
+1. **产出侧**：`session_fact_extraction` 首跑写入的 5 个候选
+   `source_event_ids=[]`——事实来自会话而非事件，CB 实现时留空。但结晶
+   写门在**所有**批准路径（含 Owner）都要求非空溯源 ⇒ 这些事实**永远
+   无法结晶**，缺陷在候选出生时就注定。
+2. **通道侧**：sfe 候选带 durable_fact 裁决，走聚合 lane 的
+   durable-fact 单条 bypass 被 resolver 自动批准——自动批准一个结构上
+   不可能写入的候选，唯一可能的结局就是撞门。
+3. **隔离侧**：`_write_resolver_provisional` 失败后 re-raise 无人接住，
+   单个坏候选把整条聚合 tick 打崩（rc=1），且每次 due 都在同一候选上
+   重复崩——**队头卡死家族的聚合版**：一个坏候选永久饿死其后所有候选。
+
+### 修复（三层各修 + 反事实）
+
+- **产出侧**：lane 为每个产出事实的会话惰性铸造一个
+  `session_fact_extracted` 溯源事件（每会话每 tick 一个、metadata-only、
+  `candidate_allowed=False` 防止 heartbeat 二次造候选——形制照
+  session_mirror 事件），事件**先于**候选写入（反序会造出无锚候选），
+  所有该会话事实候选共享引用。溯源链自此完整：crystallized → event → session。
+- **通道侧**：`_resolver_verdict` 头部新增资格判定——空 `source_event_ids`
+  即 `approve=False / missing_source_event_ids`，三条通道（cluster、
+  durable bypass、no_keyword singleton）一处全覆盖，候选改道 owner review。
+- **隔离侧**：新 `_try_write_resolver_provisional` 边界——写失败记
+  `provisional_write_failed` error_record（进 lane 报告的
+  `suppressed_error_count`，monitor error observability 既有读者）、
+  候选 triage 为 `owner_eligible`、tick 继续。
+  `_write_resolver_provisional` 内部的 failed envelope 闭合语义保持不变。
+- **语义变更测试更新**：既有
+  `test_resolver_write_exception_records_failure_completion` 原钉"写异常
+  必须冒顶"，按新契约反转为"必须不冒顶 + failed 完成记录仍在 +
+  error_record 上报"（断言集为旧测试的严格超集减去传播）。
+
+### 生产处置（代码合并部署后执行）
+
+5 个存量坏候选 demote（理由记 missing_source_event_ids）+ 从
+`processed_sessions.jsonl` 移除对应会话指纹 ⇒ 修复后的 lane 下个 due tick
+重抽这些会话，事实以带溯源形态重生，**不丢失**。
+
+### CF 反事实覆盖与测试
+
+4 条新反事实全部 revert→FAIL 实测且失败模式各自精确（verdict 反转、
+生产同款 CrystallizedApprovalError、TypeError、空 source_event_ids）+
+1 条语义反转测试。定向 102 passed（聚合两文件 + sfe 两文件 + 新文件），
+四门全过。**全量首跑抓到定向漏网的一个真回归**：新的
+`candidate_aggregation` error_record 发射点未登记
+`ERROR_RECORD_EMITTING_COMPONENTS`（守卫测试
+`..._constant_matches_source` 当场红，即该登记的现成反事实）——
+再一次证明"定向绿≠全量绿"（BV/CC 同款教训）。登记后
+monitor 文件 235 passed，全量 3162+1 → **3163 passed / 13 skipped**。
+
 ## 待办
 
 BC 代码评审（对 `abcce26` 的 15 项发现）已全部完成：P0×3（BD）、P1×4（BE）、
@@ -4396,6 +4454,15 @@ PR #19 合并为 `53880cd` 后统一部署（含此前未部署的 BZ/CA/CB/CC/C
   monitor 新增 `memory_sources_recording_disabled` + `memory_sources_disclosure_outage`
   两红线（CD.E 那四天的形状今后活不过一次 monitor）。cron 注册链核查为已有
   兜底，不改。6+1 反事实实测，四门全过。
+- `（CF，本节）`：CE 部署后 monitor 抓到的生产 FAIL 根因三层修复——
+  sfe 候选出生即无溯源（结晶写门在所有批准路径都会拒，事实永远无法结晶）、
+  durable bypass 自动批准结构上不可能写入的候选、写失败 re-raise 让单个
+  坏候选每个 due tick 重复打崩整条聚合 lane（队头卡死的聚合版）。
+  修：惰性铸造 `session_fact_extracted` 溯源事件（先于候选写入）、
+  `_resolver_verdict` 溯源资格门（三通道一处覆盖）、
+  `_try_write_resolver_provisional` 隔离边界（error_record + owner review 改道）。
+  4 反事实 revert 全红实测 + 1 语义反转测试更新。存量 5 坏候选
+  demote+指纹清理重抽（部署后执行），事实不丢失。
 
 ### CD.E — 披露断流四天的根因、修复与归因链首次全绿（2026-08-05）
 

--- a/plugins/modules/cognition/session_fact_extraction.py
+++ b/plugins/modules/cognition/session_fact_extraction.py
@@ -97,8 +97,10 @@ from pathlib import Path
 from typing import Any
 
 from plugins.memory.memory_os.crystallized import CrystallizedCandidate, append_candidate_queue
+from plugins.memory.memory_os.ids import new_event_id
 from plugins.memory.memory_os.jsonl_io import build_error_record, read_jsonl
 from plugins.memory.memory_os.low_clue_recall import _call_hermes_runtime_model, _extract_json_object
+from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.structural_write_gate import append_governed_jsonl
 
@@ -478,6 +480,52 @@ def extract_fact_from_message(
 # ── Candidate construction ──────────────────────────────────────────────
 
 
+def _build_provenance_event(
+    *,
+    store: MemoryOSStore,
+    session_id: str,
+    platform: str,
+    fingerprint: str,
+) -> EventEnvelope:
+    """Build the per-session provenance event that extracted facts cite.
+
+    CE.2: the crystallized write gate requires non-empty source_event_ids on
+    EVERY approval path (owner included), so a candidate born without event
+    provenance can never be crystallized -- the lane's first five production
+    candidates took the durable-fact bypass and crashed every
+    candidate_aggregation tick. One metadata-only event per session per tick
+    gives the whole chain a real anchor: crystallized -> event -> session.
+    Mirrors session_mirror's event shape: candidate_allowed=False so the
+    heartbeat candidate generator cannot mint a SECOND candidate from the
+    provenance event itself (the facts already became candidates directly).
+    """
+    now = datetime.now(timezone.utc)
+    unique = hashlib.sha256(f"{fingerprint}|{session_id}".encode("utf-8")).hexdigest()[:10]
+    safe_session_id = _clip(str(session_id), 120)
+    return EventEnvelope(
+        schema_version=EVENT_SCHEMA_VERSION,
+        id=new_event_id(now, unique=unique),
+        ts=now.isoformat(),
+        profile=store.roots.profile or "default",
+        source="session_fact_extraction",
+        kind="session_fact_extracted",
+        summary=f"Durable facts extracted from session {safe_session_id} ({platform or 'unknown'}).",
+        safe_ref={
+            "source_module": "session_fact_extraction",
+            "session_id": safe_session_id,
+            "platform": str(platform or "unknown"),
+            "session_fingerprint": fingerprint,
+            "candidate_allowed": False,
+            "body_policy": "bounded_summary",
+        },
+        tags=["session", "fact_extraction", str(platform or "unknown")],
+        sensitivity="private",
+        body_policy="bounded_summary",
+        hashes={},
+        promotion_state="raw",
+    )
+
+
 def _build_candidate(
     *,
     session_id: str,
@@ -486,6 +534,7 @@ def _build_candidate(
     message_index: int,
     role: str,
     fact_text: str,
+    source_event_ids: list[str],
 ) -> CrystallizedCandidate:
     # Identity material deliberately EXCLUDES the session fingerprint: the
     # fingerprint carries mtime, so an appended-to session gets a new one, and
@@ -503,7 +552,9 @@ def _build_candidate(
         candidate_id=candidate_id,
         kind="moment",
         body=body,
-        source_event_ids=[],
+        # CE.2: never empty -- the crystallized write gate rejects
+        # provenance-less candidates on every approval path.
+        source_event_ids=list(source_event_ids),
         sensitivity="private",
         tags=["session_fact_extraction", "long_message_fact", str(platform or "unknown")],
         bridge_state="inner_drive_candidate",
@@ -771,6 +822,7 @@ def run_session_fact_extraction_lane(
 
         session_fact_count = 0
         session_llm_failed = False
+        provenance_event_id: str | None = None
         for idx, message, redacted_content in bounded_eligible:
             if session_fact_count >= max_facts_per_session:
                 break
@@ -812,6 +864,19 @@ def run_session_fact_extraction_lane(
             session_fact_count += 1
 
             try:
+                # Lazy per-session provenance event: minted once, on the first
+                # fact, and cited by every fact candidate from this session.
+                # Written BEFORE the candidate so a candidate can never exist
+                # without its anchor (the reverse order could).
+                if provenance_event_id is None:
+                    provenance_event = _build_provenance_event(
+                        store=store,
+                        session_id=session_id,
+                        platform=platform,
+                        fingerprint=fingerprint,
+                    )
+                    store.append_event(provenance_event)
+                    provenance_event_id = provenance_event.id
                 candidate = _build_candidate(
                     session_id=session_id,
                     platform=platform,
@@ -819,6 +884,7 @@ def run_session_fact_extraction_lane(
                     message_index=idx,
                     role=str(message.get("role") or "unknown"),
                     fact_text=fact_text,
+                    source_event_ids=[provenance_event_id],
                 )
                 append_candidate_queue(store, candidate)
                 candidates_written += 1

--- a/plugins/modules/governance/candidate_aggregation.py
+++ b/plugins/modules/governance/candidate_aggregation.py
@@ -57,6 +57,7 @@ from plugins.memory.memory_os.crystallized import (
     resolve_candidate_effective_state,
 )
 from plugins.memory.memory_os.audit import append_audit
+from plugins.memory.memory_os.jsonl_io import build_error_record
 from plugins.memory.memory_os.store import MemoryOSStore
 
 # V3a: knob override resolution (imported here; resolve_knob called at runtime)
@@ -304,6 +305,44 @@ def _write_resolver_provisional(
     return path
 
 
+def _try_write_resolver_provisional(
+    store: MemoryOSStore,
+    candidate: CrystallizedCandidate,
+    decision: Any,
+    *,
+    error_records: list[dict[str, Any]] | None = None,
+) -> bool:
+    """Write a resolver provisional; on failure record and contain, never raise.
+
+    CE.2 isolation: one candidate that the crystallized write gate rejects
+    must not kill the whole aggregation tick -- before this, a single bad
+    candidate re-crashed the lane on every due tick (rc=1, no helper report),
+    permanently starving every other candidate behind it. The envelope inside
+    _write_resolver_provisional already closes itself as failed; this boundary
+    turns the re-raise into a bounded error record so the caller can route the
+    candidate to owner review and keep going.
+    """
+    try:
+        _write_resolver_provisional(store, candidate, decision)
+        return True
+    except Exception as exc:
+        record = build_error_record(
+            component="candidate_aggregation",
+            operation="write_resolver_provisional",
+            error_code="provisional_write_failed",
+            severity="error",
+            recoverable=True,
+            details={
+                "candidate_id": candidate.candidate_id,
+                "error_type": type(exc).__name__,
+                "message": str(exc)[:200],
+            },
+        )
+        if error_records is not None:
+            error_records.append(record)
+        return False
+
+
 # Auto-demote candidates that have been rejected N+ times by owner
 _REJECTION_THRESHOLD = 3
 
@@ -393,7 +432,7 @@ def run_candidate_aggregation_lane(
     processed_ids: set[str] = set()
 
     rejected_results = _auto_demote_rejected(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records)
-    promote_results = _cluster_and_promote(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now)
+    promote_results = _cluster_and_promote(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, error_records=candidate_error_records)
     demote_results = _demote_aged(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records)
     fleeting_results = _tag_fleeting(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records)
 
@@ -536,6 +575,7 @@ def _cluster_and_promote(
     envelope_id: str = "",
     now: datetime | None = None,
     min_cluster_size: int | None = None,
+    error_records: list[dict[str, Any]] | None = None,
     _override_store_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Cluster pending candidates by theme, promote high-signal clusters.
@@ -730,8 +770,13 @@ def _cluster_and_promote(
                     expires_at=_default_provisional_expires_at(member, _now),
                     recurrence=0,
                 )
-                _write_resolver_provisional(store, member, decision)
-                provisional_write_count += 1
+                if _try_write_resolver_provisional(
+                    store, member, decision, error_records=error_records,
+                ):
+                    provisional_write_count += 1
+                else:
+                    target_state = "owner_eligible"
+                    reason = f"{reason}; provisional_write_failed (kept for owner review)"
             else:
                 target_state = "owner_eligible"
                 if verdict.get("approve"):
@@ -886,8 +931,13 @@ def _cluster_and_promote(
                     expires_at=_default_provisional_expires_at(c, _now),
                     recurrence=0,
                 )
-                _write_resolver_provisional(store, c, decision)
-                provisional_write_count += 1
+                if _try_write_resolver_provisional(
+                    store, c, decision, error_records=error_records,
+                ):
+                    provisional_write_count += 1
+                else:
+                    target_state = "owner_eligible"
+                    reason = f"{reason}; provisional_write_failed (kept for owner review)"
             else:
                 target_state = "owner_eligible"
                 if verdict.get("approve"):
@@ -1018,8 +1068,13 @@ def _cluster_and_promote(
                 expires_at=_default_provisional_expires_at(c, _now),
                 recurrence=0,
             )
-            _write_resolver_provisional(store, c, _decision2)
-            provisional_write_count += 1
+            if _try_write_resolver_provisional(
+                store, c, _decision2, error_records=error_records,
+            ):
+                provisional_write_count += 1
+            else:
+                target_state = "owner_eligible"
+                reason = f"{reason}; provisional_write_failed (kept for owner review)"
         else:
             target_state = "owner_eligible"
             if verdict.get("approve"):
@@ -1206,6 +1261,16 @@ def _resolver_verdict(
     behavior (default approve for gate-passing candidates).
     """
     from plugins.memory.memory_os.resolver_gate import resolver_eligible
+
+    # CE.2: crystallized writes require event provenance -- the write gate
+    # (`_ensure_crystallized_approval`) raises on empty source_event_ids, for
+    # Owner approvals as much as resolver ones. Auto-approving a provenance-less
+    # candidate therefore cannot succeed; it can only crash the lane (measured
+    # on production: session_fact_extraction's first five candidates took the
+    # durable-fact bypass and killed every candidate_aggregation tick from
+    # 12:12Z on). Route such candidates to owner review instead of the cliff.
+    if not list(candidate.source_event_ids or []):
+        return {"approve": False, "reason": "missing_source_event_ids"}
 
     if not resolver_eligible(candidate, store=store):
         return {"approve": False, "reason": "failed_resolver_gate"}

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -4433,6 +4433,9 @@ ERROR_RECORD_EMITTING_COMPONENTS = frozenset({
     "provisional_sweep",
     "runtime",
     "session_fact_extraction",
+    # CF: provisional_write_failed containment records from the aggregation
+    # lane's _try_write_resolver_provisional boundary.
+    "candidate_aggregation",
     "session_mirror",
     "shadow_recall",
     "sqlite",

--- a/tests/plugins/memory/test_candidate_aggregation_logic.py
+++ b/tests/plugins/memory/test_candidate_aggregation_logic.py
@@ -805,11 +805,22 @@ class TestA1Boundary:
             raise OSError("synthetic canonical write failure")
 
         monkeypatch.setattr(CrystallizedMemoryService, "write_approved_record", fail_write)
-        with pytest.raises(OSError, match="synthetic canonical write failure"):
-            run_candidate_aggregation_lane(
-                store,
-                execution_gate_envelope_id=_VALID_ENVELOPE_ID,
-            )
+        # CE.2 semantics change: the write failure must still leave a "failed"
+        # envelope completion (asserted below, unchanged), but it must no
+        # longer propagate out of the tick -- on production one gate-rejected
+        # candidate re-crashed the lane on every due tick (rc=1, no helper
+        # report), starving every other candidate. The failure now surfaces as
+        # a bounded provisional_write_failed error record on the lane report
+        # and the candidate is routed to owner review.
+        result = run_candidate_aggregation_lane(
+            store,
+            execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        )
+        assert result["status"] == "warning"
+        assert any(
+            record.get("error_code") == "provisional_write_failed"
+            for record in result["error_records"]
+        )
 
         gate_path = store.roots.memory_os_root / "system" / "execution_gate_envelopes.jsonl"
         records = [json.loads(line) for line in gate_path.read_text().splitlines() if line.strip()]

--- a/tests/plugins/memory/test_memory_os_candidate_provenance.py
+++ b/tests/plugins/memory/test_memory_os_candidate_provenance.py
@@ -1,0 +1,146 @@
+"""CE.2: provenance-less candidates must not crash the aggregation lane.
+
+Production shape being pinned: session_fact_extraction's first five candidates
+carried ``source_event_ids=[]`` and durable_fact verdicts; the durable-fact
+bypass auto-approved them, the crystallized write gate raised
+``CrystallizedApprovalError`` (crystallized records require source_event_ids),
+nothing caught it, and every candidate_aggregation tick from 12:12Z on died
+with rc=1 and no helper report — one bad candidate starving the whole lane on
+every due tick.
+
+Two independent fixes, each with its own counterfactual here:
+1. eligibility: ``_resolver_verdict`` refuses provenance-less candidates
+   (they cannot be crystallized on ANY approval path, so auto-approving them
+   can only crash), routing them to owner review;
+2. containment: a provisional write failure is recorded as a bounded
+   error_record and the candidate re-routed, never re-raised out of the tick.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import plugins.modules.governance.candidate_aggregation as aggregation
+from plugins.memory.memory_os.crystallized import (
+    CrystallizedCandidate,
+    read_candidate_triage,
+)
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+_VALID_ENVELOPE_ID = "xgate_test_candidate_provenance_envelope"
+
+
+def _store_with_gate(tmp_path) -> MemoryOSStore:
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    now = datetime.now(timezone.utc)
+    expires_at = now.replace(year=now.year + 1).isoformat().replace("+00:00", "Z")
+    envelope = {
+        "schema_version": "memory-os.execution_gate_envelope.v0",
+        "stage": "permit",
+        "execution_gate_envelope_id": _VALID_ENVELOPE_ID,
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "expires_at": expires_at,
+        "profile": "memoryos-test",
+        "lane_id": "candidate_aggregation",
+        "trigger_surface": "hermes_cron",
+        "risk_class": "bounded_reversible_queue",
+        "human_approval_required": False,
+        "why_no_human_approval": "test",
+        "scope": {"registry_key": "candidate_aggregation", "raw_script": "test"},
+        "boundary": {
+            "actual_send": False,
+            "actual_execute": False,
+            "actual_identity_write": False,
+            "actual_unapproved_crystallized_approval": False,
+        },
+        "boundary_true": False,
+        "precheck": {"helper_present": True},
+        "permit_decision": "allowed",
+        "permit_reason": "boundary_false",
+    }
+    gate_path = roots.hermes_home / "memory-os" / "system" / "execution_gate_envelopes.jsonl"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    with gate_path.open("a") as handle:
+        handle.write(json.dumps(envelope, sort_keys=True) + "\n")
+    return store
+
+
+def _candidate(candidate_id: str, *, source_event_ids: list[str]) -> CrystallizedCandidate:
+    return CrystallizedCandidate(
+        candidate_id=candidate_id,
+        kind="moment",
+        body="Extracted from session s-1 (telegram): the owner prefers rsync backups.",
+        source_event_ids=source_event_ids,
+        sensitivity="private",
+        tags=["session_fact_extraction", "long_message_fact"],
+        bridge_state="inner_drive_candidate",
+        created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def test_resolver_verdict_refuses_provenance_less_candidates(tmp_path):
+    store = _store_with_gate(tmp_path)
+    verdict = aggregation._resolver_verdict(
+        _candidate("cand_sfe_noprov", source_event_ids=[]), store=store,
+    )
+    assert verdict["approve"] is False
+    assert verdict["reason"] == "missing_source_event_ids"
+
+
+def test_provenance_less_durable_fact_routes_to_owner_review_not_the_cliff(tmp_path, monkeypatch):
+    """The exact production shape. Counterfactual: without the eligibility
+    check this raises CrystallizedApprovalError out of the pipeline stage —
+    the crash that killed every tick."""
+    store = _store_with_gate(tmp_path)
+    bad = _candidate("cand_sfe_noprov_e2e", source_event_ids=[])
+    monkeypatch.setattr(
+        "plugins.modules.governance.fact_judge.read_fact_judge_verdicts",
+        lambda _store: {"cand_sfe_noprov_e2e": True},
+    )
+
+    result = aggregation._cluster_and_promote(
+        [bad], store, set(), envelope_id=_VALID_ENVELOPE_ID, min_cluster_size=2,
+    )
+
+    assert result["provisional_crystallized_write_count"] == 0
+    triage = read_candidate_triage(store)
+    latest = next(rec for rec in triage if rec.get("candidate_id") == "cand_sfe_noprov_e2e")
+    assert latest.get("target_state") == "owner_eligible", (
+        "a provenance-less durable fact must reach owner review, not crash the lane"
+    )
+
+
+def test_provisional_write_failure_is_contained_and_reported(tmp_path, monkeypatch):
+    """Counterfactual: without _try_write_resolver_provisional the injected
+    failure re-raises out of the stage and the second candidate is never
+    processed — one bad candidate starving the lane."""
+    store = _store_with_gate(tmp_path)
+    good = _candidate("cand_ok_provenance", source_event_ids=["evt-real-001"])
+    monkeypatch.setattr(
+        "plugins.modules.governance.fact_judge.read_fact_judge_verdicts",
+        lambda _store: {"cand_ok_provenance": True},
+    )
+
+    def _boom(store, candidate, decision):
+        raise RuntimeError("injected write failure")
+
+    monkeypatch.setattr(aggregation, "_write_resolver_provisional", _boom)
+
+    error_records: list[dict] = []
+    result = aggregation._cluster_and_promote(
+        [good], store, set(),
+        envelope_id=_VALID_ENVELOPE_ID, min_cluster_size=2,
+        error_records=error_records,
+    )
+
+    assert result["provisional_crystallized_write_count"] == 0
+    assert any(
+        record.get("error_code") == "provisional_write_failed"
+        and record.get("component") == "candidate_aggregation"
+        for record in error_records
+    ), "the failure must surface as a bounded error record, not a crash"
+    triage = read_candidate_triage(store)
+    latest = next(rec for rec in triage if rec.get("candidate_id") == "cand_ok_provenance")
+    assert latest.get("target_state") == "owner_eligible"

--- a/tests/plugins/memory/test_memory_os_session_fact_extraction.py
+++ b/tests/plugins/memory/test_memory_os_session_fact_extraction.py
@@ -891,3 +891,50 @@ def test_new_ledgers_are_retention_registered_and_timestamp_readable(tmp_path, m
                 "registered but zero records counted -- the planned path does not "
                 "match where the lane actually writes"
             )
+
+
+def test_candidates_cite_a_real_provenance_event(tmp_path, monkeypatch):
+    """CE.2: the crystallized write gate requires non-empty source_event_ids on
+    EVERY approval path (owner included), so a candidate born without event
+    provenance can never be crystallized. The lane's first five production
+    candidates shipped with source_event_ids=[] and crashed every
+    candidate_aggregation tick from 12:12Z on.
+
+    Counterfactual: without the fix, candidates[0].source_event_ids == [] and
+    no session_fact_extracted event exists.
+    """
+    envelope_id = "xgate_test_sfe_provenance"
+    store = _store_with_gate(tmp_path, envelope_id)
+    _write_session_file(
+        store.roots.hermes_home,
+        "session_prov.json",
+        messages=[
+            {"role": "user", "content": _LONG_MARKER_TEXT},
+            {"role": "user", "content": _LONG_NO_MARKER_TEXT},
+        ],
+    )
+    monkeypatch.setattr(
+        "plugins.modules.cognition.session_fact_extraction._call_hermes_runtime_model",
+        _fake_llm_always_durable,
+    )
+
+    report = run_session_fact_extraction_lane(store, execution_gate_envelope_id=envelope_id)
+
+    assert report["candidates_written"] == 2
+    candidates = read_candidate_queue(store)
+    assert len(candidates) == 2
+
+    events = {event.id: event for event in store.read_events()}
+    provenance_events = [
+        event for event in events.values() if event.kind == "session_fact_extracted"
+    ]
+    # One provenance event per session per tick, shared by both facts.
+    assert len(provenance_events) == 1
+    provenance = provenance_events[0]
+    for candidate in candidates:
+        assert candidate.source_event_ids == [provenance.id], (
+            "every fact candidate must cite the session provenance event"
+        )
+    # The anchor must not itself spawn a second candidate generation pass.
+    assert provenance.safe_ref.get("candidate_allowed") is False
+    assert provenance.source == "session_fact_extraction"


### PR DESCRIPTION
Root-causes and fixes the production FAIL that appeared after the CE deploy: sfe candidates born without source_event_ids crashed every candidate_aggregation tick via the durable-fact bypass. Three layers: provenance event minted per session (crystallized -> event -> session chain complete), resolver eligibility gate (missing_source_event_ids -> owner review), and per-candidate write containment (bounded error record, no re-raise). 4 revert-verified counterfactuals + 1 semantics-flip test; full suite 3163 passed; gates green. Post-deploy production follow-up: demote the 5 stranded candidates + clear their fingerprints for re-extraction.