### PR TITLE
monitor(M1): host-side cron registry snapshot membership drift detection

### DIFF
--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -281,6 +281,11 @@ MEMORY_PROJECTION_55G_REQUIRED_PAYLOAD_FIELDS: dict[str, set[str]] = {
     },
 }
 CLEAN_HOST_WARN_CLASSIFICATIONS: dict[str, dict[str, str]] = {
+    "cron_registry_snapshot_member_drift": {
+        "classification": "next_lane",
+        "reason": "deployed cron registry snapshot resolves fewer group members than the installed registry defines - regenerate the snapshot (install/onboarding step)",
+        "production_behavior": "warn_if_production",
+    },
     "left_brain_pipeline_check_warn": {
         "classification": "next_lane",
         "reason": "left_brain_pipeline is present but still reports warning on clean-host warmup",
@@ -2563,6 +2568,35 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
                     {
                         "code": "execution_gate_memory_os_cron_registry_snapshot_missing_or_invalid",
                         "status": str(execution_gate_cron.get("registry_snapshot_status") or ""),
+                    }
+                )
+            parity = (
+                execution_gate_cron.get("registry_snapshot_parity")
+                if isinstance(execution_gate_cron.get("registry_snapshot_parity"), dict)
+                else {}
+            )
+            parity_status = str(parity.get("status") or "")
+            if parity_status == "drift":
+                warn.append(
+                    {
+                        "code": "cron_registry_snapshot_member_drift",
+                        "value": {
+                            "silently_missing_lane_ids": parity.get("silently_missing_lane_ids") or {},
+                            "unknown_in_snapshot": parity.get("unknown_in_snapshot") or {},
+                            "fallback_group_keys": parity.get("fallback_group_keys") or [],
+                        },
+                    }
+                )
+            elif parity_status == "ok":
+                passed.append({"code": "cron_registry_snapshot_member_parity_ok"})
+            elif parity_status:
+                # snapshot_groups_unavailable / registry_import_unavailable:
+                # no basis to judge parity — surface as INFO (healthy_no_sample
+                # class), never as PASS bought by an empty gated set.
+                info.append(
+                    {
+                        "code": "cron_registry_snapshot_parity_no_sample",
+                        "value": {"status": parity_status},
                     }
                 )
             if helper_boundary_true > 0:
@@ -7600,6 +7634,7 @@ def execution_gate_cron_summary():
         "schema_version": "memory-os.execution_gate_cron_summary.v0",
         "status": "ok",
         "registry_snapshot_status": "ok" if specs else "missing_or_invalid",
+        "registry_snapshot_parity": _cron_registry_snapshot_parity(),
         "classification_source": "registry_snapshot",
         "adapter_probe_status": str(adapter_probe.get("status") or ""),
         "adapter_owner": str(adapter_probe.get("adapter_owner") or ""),
@@ -7700,6 +7735,76 @@ def _memory_os_cron_specs_from_snapshot():
     if isinstance(specs, list) and specs:
         return [dict(item) for item in specs if isinstance(item, dict)]
     return []
+
+def _cron_registry_snapshot_parity():
+    """Host-side snapshot-vs-installed-registry membership diff (M1 detector).
+
+    Mirrors cron_group_runner._load_group resolution exactly: the snapshot
+    wins for a group only when its member list resolves to >=1 spec (member
+    keys missing from the snapshot's own specs are silently dropped there);
+    a missing group, empty member list, or fully-unresolvable member list
+    falls back to the compiled registry and is therefore NOT silent. The
+    silent set per group is (compiled members - snapshot-RESOLVED members)
+    whenever the snapshot wins -- this covers both a stale member list and a
+    member listed without a matching spec. Both sides are read on the host
+    (deployed snapshot vs installed package registry), so a dev-tree lane
+    not yet deployed can never fire a false drift signal.
+    """
+    snapshot_path = Path(_hermes_home) / "memory-os" / "system" / "memory_os_cron_registry.json"
+    try:
+        loaded = json.loads(snapshot_path.read_text(encoding="utf-8")) if snapshot_path.exists() else {}
+    except Exception:
+        loaded = {}
+    if not isinstance(loaded, dict):
+        loaded = {}
+    snapshot_groups = {}
+    for group in loaded.get("groups") or []:
+        if isinstance(group, dict) and str(group.get("key") or ""):
+            snapshot_groups[str(group["key"])] = [
+                str(member) for member in (group.get("member_keys") or [])
+            ]
+    snapshot_spec_keys = {
+        str(item.get("key") or "")
+        for item in (loaded.get("specs") or [])
+        if isinstance(item, dict)
+    }
+    if not snapshot_groups:
+        return {"status": "snapshot_groups_unavailable"}
+    try:
+        from plugins.memory.memory_os.cron_registry import MEMORY_OS_CRON_GROUPS
+
+        compiled_groups = {
+            group.key: [str(member) for member in group.member_keys]
+            for group in MEMORY_OS_CRON_GROUPS
+        }
+    except Exception:
+        return {"status": "registry_import_unavailable"}
+    silently_missing = {}
+    unknown_in_snapshot = {}
+    fallback_group_keys = []
+    for key, compiled_members in compiled_groups.items():
+        listed = snapshot_groups.get(key)
+        resolved = [m for m in (listed or []) if m in snapshot_spec_keys]
+        if not resolved:
+            # Missing group / empty list / nothing resolvable: _load_group
+            # falls back to the compiled registry, so every compiled member
+            # still runs -- visible fallback, not silent drift.
+            fallback_group_keys.append(key)
+            continue
+        missing = [m for m in compiled_members if m not in resolved]
+        if missing:
+            silently_missing[key] = missing
+        unknown = [m for m in resolved if m not in set(compiled_members)]
+        if unknown:
+            unknown_in_snapshot[key] = unknown
+    return {
+        "status": "drift" if silently_missing else "ok",
+        "silently_missing_lane_ids": silently_missing,
+        "unknown_in_snapshot": unknown_in_snapshot,
+        "fallback_group_keys": sorted(fallback_group_keys),
+        "snapshot_group_count": len(snapshot_groups),
+        "compiled_group_count": len(compiled_groups),
+    }
 
 def _legacy_per_lane_cron_jobs():
     """Pre-consolidation per-lane job name -> its legacy wrapper script.

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -7991,3 +7991,203 @@ def test_recent_window_carries_natural_traffic_volume_alongside_era_denominator(
     )
     assert entry["value"]["rolling_7d_natural_record_count"] == 5
     assert entry["value"]["rolling_7d_attribution_era_record_count"] == 3
+
+
+# ── M1: cron registry snapshot membership parity (probe + grading) ──────────
+
+
+def _parity_probe_namespace(tmp_path) -> dict:
+    namespace: dict[str, Any] = {}
+    original_sys_path = list(sys.path)
+    try:
+        exec(
+            monitor._remote_probe_script(str(tmp_path)).split("\n# ---begin-probe-invocations---", 1)[0],
+            namespace,
+        )
+    finally:
+        sys.path[:] = original_sys_path
+    namespace["_hermes_home"] = str(tmp_path)
+    return namespace
+
+
+def _write_registry_snapshot(tmp_path, snapshot: dict) -> None:
+    path = tmp_path / "memory-os" / "system" / "memory_os_cron_registry.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+
+def test_snapshot_parity_partially_stale_member_list_is_silent_drift(tmp_path):
+    """Counterfactual (M1): _load_group prefers the snapshot whenever a
+    group's member list resolves to >=1 spec, so a stale-but-non-empty list
+    silently never runs the dropped lane. The parity probe must name it."""
+    from plugins.memory.memory_os.cron_registry import cron_registry_snapshot
+
+    snapshot = cron_registry_snapshot()
+    victim_group = next(g for g in snapshot["groups"] if len(g["member_keys"]) >= 2)
+    dropped = victim_group["member_keys"].pop()
+    _write_registry_snapshot(tmp_path, snapshot)
+
+    parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
+
+    assert parity["status"] == "drift"
+    assert parity["silently_missing_lane_ids"] == {victim_group["key"]: [dropped]}
+
+
+def test_snapshot_parity_member_without_spec_is_silent_drift(tmp_path):
+    """The _load_group line-319 case: a member listed in the group but with no
+    matching spec in the snapshot is silently dropped while the rest of the
+    group still runs from the snapshot."""
+    from plugins.memory.memory_os.cron_registry import cron_registry_snapshot
+
+    snapshot = cron_registry_snapshot()
+    victim_group = next(g for g in snapshot["groups"] if len(g["member_keys"]) >= 2)
+    victim_member = victim_group["member_keys"][-1]
+    snapshot["specs"] = [s for s in snapshot["specs"] if s["key"] != victim_member]
+    _write_registry_snapshot(tmp_path, snapshot)
+
+    parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
+
+    assert parity["status"] == "drift"
+    assert victim_member in parity["silently_missing_lane_ids"][victim_group["key"]]
+
+
+def test_snapshot_parity_fallback_groups_are_not_drift(tmp_path):
+    """An emptied member list and a missing group both make _load_group fall
+    back to the compiled registry — every lane still runs, so neither may be
+    reported as drift."""
+    from plugins.memory.memory_os.cron_registry import cron_registry_snapshot
+
+    snapshot = cron_registry_snapshot()
+    emptied = snapshot["groups"][0]
+    emptied["member_keys"] = []
+    removed = snapshot["groups"].pop(1)
+    _write_registry_snapshot(tmp_path, snapshot)
+
+    parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
+
+    assert parity["status"] == "ok"
+    assert emptied["key"] in parity["fallback_group_keys"]
+    assert removed["key"] in parity["fallback_group_keys"]
+
+
+def test_snapshot_parity_complete_snapshot_is_ok(tmp_path):
+    from plugins.memory.memory_os.cron_registry import cron_registry_snapshot
+
+    _write_registry_snapshot(tmp_path, cron_registry_snapshot())
+
+    parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
+
+    assert parity["status"] == "ok"
+    assert parity["silently_missing_lane_ids"] == {}
+    assert parity["fallback_group_keys"] == []
+
+
+def test_snapshot_parity_missing_snapshot_reports_no_sample(tmp_path):
+    parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
+
+    assert parity["status"] == "snapshot_groups_unavailable"
+
+
+def test_classify_snapshot_member_drift_warns_with_lane_ids():
+    snapshot = _healthy_snapshot()
+    snapshot["execution_gate_cron"] = {
+        "schema_version": "memory-os.execution_gate_cron_summary.v0",
+        "registry_snapshot_status": "ok",
+        "registry_snapshot_parity": {
+            "status": "drift",
+            "silently_missing_lane_ids": {"tick_evidence": ["session_fact_extraction"]},
+            "unknown_in_snapshot": {},
+            "fallback_group_keys": [],
+        },
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    entry = next(
+        item for item in classification["warn"]
+        if item["code"] == "cron_registry_snapshot_member_drift"
+    )
+    assert entry["value"]["silently_missing_lane_ids"] == {
+        "tick_evidence": ["session_fact_extraction"]
+    }
+    assert not any(
+        item["code"] == "cron_registry_snapshot_member_parity_ok"
+        for item in classification["pass"]
+    )
+
+
+def test_classify_snapshot_member_parity_ok_passes():
+    snapshot = _healthy_snapshot()
+    snapshot["execution_gate_cron"] = {
+        "schema_version": "memory-os.execution_gate_cron_summary.v0",
+        "registry_snapshot_parity": {"status": "ok", "silently_missing_lane_ids": {}},
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    assert any(
+        item["code"] == "cron_registry_snapshot_member_parity_ok"
+        for item in classification["pass"]
+    )
+
+
+def test_classify_snapshot_parity_no_sample_is_info_not_pass():
+    """An unjudgeable parity (registry unimportable on the host) must surface
+    as INFO — never a PASS bought by an empty gated set, never a WARN."""
+    snapshot = _healthy_snapshot()
+    snapshot["execution_gate_cron"] = {
+        "schema_version": "memory-os.execution_gate_cron_summary.v0",
+        "registry_snapshot_parity": {"status": "registry_import_unavailable"},
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    assert any(
+        item["code"] == "cron_registry_snapshot_parity_no_sample"
+        for item in classification["info"]
+    )
+    for bucket in ("pass", "warn", "fail"):
+        assert not any(
+            str(item.get("code", "")).startswith("cron_registry_snapshot_")
+            for item in classification[bucket]
+        )
+
+
+def test_classify_snapshot_without_parity_key_stays_silent():
+    """Backward compat: payloads from an older probe (no parity key) must not
+    grow any of the new parity codes."""
+    snapshot = _healthy_snapshot()
+    snapshot["execution_gate_cron"] = {
+        "schema_version": "memory-os.execution_gate_cron_summary.v0",
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    for bucket in ("pass", "warn", "fail", "info"):
+        assert not any(
+            str(item.get("code", "")).startswith("cron_registry_snapshot_")
+            for item in classification[bucket]
+        )
+
+
+def test_clean_host_member_drift_stays_classified_warn():
+    snapshot = _healthy_snapshot()
+    snapshot["monitor_profile"] = "clean_host"
+    snapshot["execution_gate_cron"] = {
+        "schema_version": "memory-os.execution_gate_cron_summary.v0",
+        "registry_snapshot_parity": {
+            "status": "drift",
+            "silently_missing_lane_ids": {"tick_daily": ["exposure_rollup"]},
+        },
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    assert any(
+        item["code"] == "cron_registry_snapshot_member_drift"
+        for item in classification["warn"]
+    )
+    assert not any(
+        item["code"] == "clean_host_warn_unclassified"
+        for item in classification["fail"]
+    )


### PR DESCRIPTION
PR-A of the open-items roadmap (advisor-amended design). Probe-side parity diff (host snapshot vs host-installed registry), WARN cron_registry_snapshot_member_drift with silent lane_ids, PASS on parity, INFO no-sample when unjudgeable; fallback cases correctly not drift. 10 tests (9 red on HEAD; 1 backward-compat). Full suite 3185 passed / 13 skipped; four static gates green.