### PR TITLE
pins(anti-drift): T1/T2/T4/R1/D5/D8 census guards + docstring truth

### DIFF
--- a/plugins/memory/memory_os/migrator.py
+++ b/plugins/memory/memory_os/migrator.py
@@ -39,9 +39,15 @@ _SECRET_PATTERNS = (
     re.compile(r"(?i)(secret\s*[:=]\s*)\S+"),
 )
 
+# Assigned states (census-pinned by test_migrator_state_literals_census):
+# scan_only, redacted_bundle, shadow_bundle, shadow_import, shadow_replay,
+# diff_report. The last three below are RESERVED — declared for the
+# owner-approved apply/rollback phases that were never built; no code path
+# assigns them. Implementing one means consciously updating the census test.
 MIGRATOR_STATES = (
     "scan_only",
     "redacted_bundle",
+    "shadow_bundle",
     "shadow_import",
     "shadow_replay",
     "diff_report",

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -1474,9 +1474,11 @@ def _rrf_union(
     score = 1 / (k + rank + 1)
     Higher k reduces the impact of high rankings; k=60 is standard.
 
-    Returns a set of record_ids ordered by RRF score descending, capped
-    at top_n. If one input list is empty, the other is returned as a set
-    (truncated to top_n).
+    Returns an UNORDERED set of the top_n record_ids by RRF score. RRF here
+    only decides WHICH records enter the crystallized section — the caller
+    uses the result purely as a membership filter (final ordering comes from
+    the section builder), so set semantics are deliberate: a list would make
+    the per-turn membership checks linear for zero consumer benefit.
     """
     scores: dict[str, float] = {}
     for rank, rid in enumerate(fts_ids):
@@ -2554,6 +2556,13 @@ def _event_source_class(event: Any) -> str:
 
 
 def _indexed_lines(
+    # Intentional divergence from retrievers/indexed_fts.py (pinned by
+    # test_memory_os_fts_path_pins.py): this path feeds the raw query to
+    # index.search(), whose LIKE fallback guarantees deterministic floor
+    # recall on malformed or FTS-missed queries. The retriever sanitizes and
+    # cross-validates against canonical bodies instead — an O(corpus) read
+    # that must stay off this per-turn path. Do not "unify" one into the
+    # other without deciding which recall guarantee survives.
     query: str,
     index: object | None,
     *,

--- a/plugins/memory/memory_os/recall_types.py
+++ b/plugins/memory/memory_os/recall_types.py
@@ -43,6 +43,30 @@ _L2_RECALL_TYPES: frozenset[RecallType] = frozenset({
     RecallType.EXTERNAL_EVIDENCE,
 })
 
+# Every enum member's actual implementation home, pinned at module scope so a
+# census test can assert both directions (no member without a disposition, no
+# disposition without a member). The enum alone over-promises: only the
+# "registered" members are reachable through RetrieverFacade.
+#   registered       — retriever class registered with the production facade
+#   inlined_prefetch — served by a prefetch-internal section builder, not the
+#                      facade (WORKING: _working_lines; VECTOR: RRF lane in
+#                      _crystallized_lines, vector_retrieval_enabled-gated)
+#   probe_only       — retriever class exists for the recall probe CLI and its
+#                      tests; production recall goes through the substrate
+#                      path instead (HINDSIGHT)
+#   unimplemented_reserved — declared, no channel implementation anywhere
+RECALL_TYPE_DISPOSITION: dict[RecallType, str] = {
+    RecallType.STATE_OVERLAY: "registered",
+    RecallType.CRYSTALLIZED: "registered",
+    RecallType.WORKING: "inlined_prefetch",
+    RecallType.INDEXED_FTS: "registered",
+    RecallType.VECTOR: "inlined_prefetch",
+    RecallType.ENTITY_GRAPH: "registered",
+    RecallType.TEMPORAL: "registered",
+    RecallType.HINDSIGHT: "probe_only",
+    RecallType.EXTERNAL_EVIDENCE: "unimplemented_reserved",
+}
+
 
 def is_core_recall(recall_type: RecallType) -> bool:
     """Return True for L1 (always-available) recall types."""

--- a/plugins/memory/memory_os/schema.py
+++ b/plugins/memory/memory_os/schema.py
@@ -61,6 +61,10 @@ class EventEnvelope:
     sensitivity: str = "private"
     body_policy: str = "summary_only"
     hashes: dict[str, Any] = field(default_factory=dict)
+    # RESERVED: every producer writes "raw" and nothing migrates it — the
+    # promotion state machine this field implies was never built. A census
+    # test pins that ("raw"-only across all producers); implementing real
+    # promotion states means consciously updating producer + census together.
     promotion_state: str = "raw"
 
     @classmethod

--- a/scripts/memory_os_execution_gate_runner.py
+++ b/scripts/memory_os_execution_gate_runner.py
@@ -29,6 +29,13 @@ from typing import Any
 
 
 SCHEMA_VERSION = "memory-os.execution_gate_envelope.v0"
+# Keys the core writer (execution_gate.start_execution_gate_envelope) emits on
+# permit records that this runner deliberately omits: the runner's scope IS the
+# registry row (nothing worth hashing) and it carries no evidence refs. The
+# dual-writer guard test pins this gap exactly — growing either writer's permit
+# schema must touch this constant consciously, or the shared-file contract
+# drifts silently.
+RUNNER_OMITTED_PERMIT_KEYS = frozenset({"scope_hash", "evidence_refs"})
 HELPER_REPORT_SCHEMA_VERSION = "memory-os.helper_execution_report.v0"
 SIDECAR_LOCK_TIMEOUT_SECONDS = 15.0
 # Backstop for lanes whose registry entry carries no explicit timeout.

--- a/tests/plugins/memory/test_memory_os_fts_path_pins.py
+++ b/tests/plugins/memory/test_memory_os_fts_path_pins.py
@@ -1,0 +1,80 @@
+"""T4 pins: the two FTS query paths are deliberately divergent — keep it loud.
+
+`retrievers/indexed_fts.py::_fts5_safe_query` sanitizes + prefix-expands and
+cross-validates hits against canonical bodies, with NO LIKE fallback;
+`index.py::search` runs the raw query through FTS5 MATCH and falls back to a
+LIKE scan when FTS returns nothing OR raises (malformed MATCH). Nothing pinned
+either behavior before — this file is the first coverage of the fallback, so a
+future "unification" must consciously break these tests rather than silently
+change recall results.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.memory.memory_os.index import MemoryOSIndex
+from plugins.memory.memory_os.retrievers.indexed_fts import _fts5_safe_query
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
+
+def _indexed_store(tmp_path, body: str):
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="fts-pin-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    store.append_crystallized_record(
+        "fts_pin.md",
+        {
+            "schema_version": "memory-os.crystallized.v0",
+            "id": "cry_fts_pin_001",
+            "kind": "note",
+            "created_at": "2026-08-01T00:00:00Z",
+            "approved_by": "owner",
+            "approved_at": "2026-08-01T00:00:00Z",
+            "source_event_ids": [],
+            "tags": [],
+            "sensitivity": "private",
+            "hindsight_indexed": False,
+        },
+        body,
+    )
+    index = MemoryOSIndex(roots)
+    index.rebuild_from_store(store)
+    return index
+
+
+def test_fts5_safe_query_sanitizes_and_prefix_matches():
+    assert _fts5_safe_query("hello (world)!") == "hello* world*"
+    # Single-character terms stay bare (no prefix star).
+    assert _fts5_safe_query("a beta") == "a beta*"
+    # Fully-special input degrades to a harmless empty phrase, never a MATCH error.
+    assert _fts5_safe_query("()!*") == '""'
+
+
+def test_index_search_like_fallback_fires_on_fts_syntax_error(tmp_path):
+    """index.search feeds the RAW query to MATCH; a malformed query raises
+    inside _fts_hits (swallowed) and the LIKE scan answers instead. The
+    retriever path would have sanitized first — this asymmetry is the pinned
+    divergence."""
+    index = _indexed_store(tmp_path, "syntax (error) probe body")
+
+    result = index.search("(error", limit=5)
+
+    assert result["mode"] == "indexed"
+    assert result["hits"], "LIKE fallback must answer when MATCH raises"
+    assert result["hits"][0]["record_id"] == "cry_fts_pin_001"
+
+
+def test_index_search_like_fallback_fires_on_zero_fts_hits(tmp_path):
+    """A two-character query cannot match the trigram tokenizer (3-gram
+    minimum) and unicode61 treats it as a distinct token — either way FTS
+    returns nothing and the LIKE substring scan answers."""
+    index = _indexed_store(tmp_path, "memory event body")
+
+    result = index.search("em", limit=5)
+
+    assert result["hits"], "LIKE fallback must answer when FTS finds nothing"
+    assert result["hits"][0]["record_id"] == "cry_fts_pin_001"

--- a/tests/plugins/memory/test_memory_os_hermes_cron_adapter.py
+++ b/tests/plugins/memory/test_memory_os_hermes_cron_adapter.py
@@ -324,3 +324,40 @@ def test_seam_and_memory_adapters_agree_on_legacy_per_lane_classification():
         == memory["known_optional_jobs"][0]["known_optional_reason"]
         == "superseded_by_group_tick"
     )
+
+
+def test_seam_and_legacy_adapter_classify_identically_across_all_buckets():
+    """T2 pin: production reads the seam copy, tooling reads the in-package
+    copy — two near-identical implementations of the same classifier. This
+    full-dict equality over one fixture spanning every bucket turns any
+    future one-sided edit into a loud failure instead of silent vocabulary
+    drift. (The monitor's embedded third copy is DELIBERATELY divergent and
+    is pinned separately in tests/scripts/test_memory_os_3_200_monitor.py —
+    never assert equality against it.)"""
+    from plugins.memory.memory_os.cron_registry import (
+        LEGACY_PER_LANE_CRON_JOBS,
+        RETIRED_MEMORY_OS_CRON_SCRIPTS,
+    )
+
+    cadence = memory_os_cron_spec_by_key("module_cadence_report")
+    governance = memory_os_cron_spec_by_key("proposal_followups_opsgate")
+    legacy_name, legacy_script = sorted(LEGACY_PER_LANE_CRON_JOBS.items())[0]
+    retired_name, retired_script = sorted(RETIRED_MEMORY_OS_CRON_SCRIPTS.items())[0]
+    jobs = [
+        {"name": cadence.name, "script": cadence.wrapper_script, "enabled": True},
+        {"name": governance.name, "script": governance.raw_script, "enabled": True},
+        {"name": legacy_name, "script": legacy_script, "enabled": False},
+        {"name": retired_name, "script": retired_script, "enabled": False},
+        {"name": "hermes-heartbeat", "script": "hermes_heartbeat.py", "enabled": True},
+        {"name": "backup-nightly", "script": "backup.sh", "enabled": True},
+        {"name": "memory-os-mystery", "script": "mystery_helper.py", "enabled": True},
+    ]
+
+    seam = classify_hermes_cron_jobs(jobs, memory_os_cron_specs())
+    legacy = legacy_cron_adapter.classify_hermes_cron_jobs(jobs, memory_os_cron_specs())
+
+    assert seam == legacy, (
+        "seam and in-package classify_hermes_cron_jobs diverged — every "
+        "change must be applied to both copies (and reviewed against the "
+        "monitor's embedded third copy)"
+    )

--- a/tests/plugins/memory/test_memory_os_migrator.py
+++ b/tests/plugins/memory/test_memory_os_migrator.py
@@ -196,3 +196,35 @@ def test_migrate_cli_scan_emits_stage_report(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["state"] == "scan_only"
     assert report["source_count"] >= 9
+
+
+def test_migrator_state_literals_census():
+    """D8 census: every state literal the migrator assigns must be declared in
+    MIGRATOR_STATES (shadow_bundle was assigned for months without being in
+    the table), and the three reserved apply/rollback states must stay
+    unassigned until actually implemented — implementing one is a conscious
+    change that updates this census."""
+    import re
+    from pathlib import Path
+
+    from plugins.memory.memory_os.migrator import MIGRATOR_STATES
+
+    source = (
+        Path(__file__).resolve().parents[3] / "plugins" / "memory" / "memory_os" / "migrator.py"
+    ).read_text(encoding="utf-8")
+    assigned: set[str] = set()
+    for primary, alternate in re.findall(
+        r"\"state\":\s*\"(\w+)\"(?:\s+if\s+\w+\s+else\s+\"(\w+)\")?", source
+    ):
+        assigned.add(primary)
+        if alternate:
+            assigned.add(alternate)
+
+    assert assigned <= set(MIGRATOR_STATES), (
+        f"migrator assigns states missing from MIGRATOR_STATES: {assigned - set(MIGRATOR_STATES)}"
+    )
+    reserved = {"owner_review", "approved_apply", "rollback_ready"}
+    assert assigned == set(MIGRATOR_STATES) - reserved, (
+        "assigned-state census changed — either a reserved state got "
+        f"implemented or a real state was dropped: assigned={sorted(assigned)}"
+    )

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -3491,3 +3491,17 @@ def test_build_prefetch_sections_scans_events_once(tmp_path):
     assert calls["n"] == 1, (
         f"prefetch sections must share one event scan, got {calls['n']}"
     )
+
+
+def test_rrf_union_returns_membership_set_capped_at_top_n():
+    """Pin the deliberate set semantics: RRF selects WHICH records enter the
+    crystallized section (membership filter); ordering is the section
+    builder's job. Changing the return type to an ordered list is a hot-path
+    pessimization with no consumer — do it only with a consumer in hand."""
+    from plugins.memory.memory_os.prefetch import _rrf_union
+
+    result = _rrf_union(["a", "b", "c"], ["b", "d"], top_n=3)
+
+    assert isinstance(result, set)
+    assert len(result) == 3
+    assert "b" in result  # appears in both lists → highest fused score

--- a/tests/plugins/memory/test_memory_os_recall_type_census.py
+++ b/tests/plugins/memory/test_memory_os_recall_type_census.py
@@ -1,0 +1,101 @@
+"""R1 census: every RecallType member has one explicit, true disposition.
+
+The enum declares nine recall lanes; the production facade registers five.
+Without this census the gap is a false contract — a caller reading the enum
+cannot tell a facade lane from an inlined prefetch section from a reserved
+name. Each test pins one direction of the table so a new member, a new
+retriever registration, or a deleted class must touch the table consciously.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.memory.memory_os.recall_facade import RetrieverFacade
+from plugins.memory.memory_os.recall_types import RECALL_TYPE_DISPOSITION, RecallType
+from plugins.memory.memory_os.retrievers import (
+    CrystallizedRetriever,
+    EntityGraphRetriever,
+    IndexedFTSRetriever,
+    StateOverlayRetriever,
+    TemporalRetriever,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_PRODUCTION_RETRIEVER_CLASSES = (
+    StateOverlayRetriever,
+    IndexedFTSRetriever,
+    CrystallizedRetriever,
+    EntityGraphRetriever,
+    TemporalRetriever,
+)
+
+_ALLOWED_DISPOSITIONS = {
+    "registered",
+    "inlined_prefetch",
+    "probe_only",
+    "unimplemented_reserved",
+}
+
+
+def test_every_recall_type_has_explicit_disposition():
+    assert set(RECALL_TYPE_DISPOSITION) == set(RecallType)
+    assert set(RECALL_TYPE_DISPOSITION.values()) <= _ALLOWED_DISPOSITIONS
+
+
+def test_registered_dispositions_match_production_facade_tuple():
+    """Two-way bite: the table's `registered` set must equal exactly the
+    recall types of the classes the provider registers, and the provider
+    source must register exactly those classes."""
+    registered_in_table = {
+        member for member, disposition in RECALL_TYPE_DISPOSITION.items()
+        if disposition == "registered"
+    }
+    registered_by_classes = {cls().recall_type for cls in _PRODUCTION_RETRIEVER_CLASSES}
+    assert registered_in_table == registered_by_classes
+
+    provider_source = (
+        REPO_ROOT / "plugins" / "memory" / "memory_os" / "__init__.py"
+    ).read_text(encoding="utf-8")
+    for cls in _PRODUCTION_RETRIEVER_CLASSES:
+        assert cls.__name__ in provider_source, (
+            f"{cls.__name__} not registered in the provider — update "
+            "RECALL_TYPE_DISPOSITION and this census together"
+        )
+
+
+def test_inlined_prefetch_types_have_no_registered_retriever():
+    facade = RetrieverFacade()
+    for cls in _PRODUCTION_RETRIEVER_CLASSES:
+        facade.register(cls())
+    for member, disposition in RECALL_TYPE_DISPOSITION.items():
+        if disposition == "inlined_prefetch":
+            assert facade.get(member) is None, (
+                f"{member} is marked inlined_prefetch but a retriever is "
+                "registered — move it to `registered` in the table"
+            )
+
+
+def test_probe_only_type_has_real_probe_consumer():
+    """HINDSIGHT's retriever class is deliberately outside the production
+    facade (substrate path owns production recall) but is a real, consumed
+    class — the recall probe registers it. Deleting it is an owner decision,
+    not dead-code cleanup."""
+    from plugins.memory.memory_os.retrievers.hindsight import HindsightRetriever
+
+    assert RECALL_TYPE_DISPOSITION[RecallType.HINDSIGHT] == "probe_only"
+    probe_source = (
+        REPO_ROOT / "scripts" / "memory_os_recall_probe.py"
+    ).read_text(encoding="utf-8")
+    assert "HindsightRetriever" in probe_source
+    assert HindsightRetriever not in _PRODUCTION_RETRIEVER_CLASSES
+
+
+def test_unimplemented_reserved_has_no_implementation():
+    assert RECALL_TYPE_DISPOSITION[RecallType.EXTERNAL_EVIDENCE] == "unimplemented_reserved"
+    retrievers_dir = REPO_ROOT / "plugins" / "memory" / "memory_os" / "retrievers"
+    for path in retrievers_dir.glob("*.py"):
+        assert "EXTERNAL_EVIDENCE" not in path.read_text(encoding="utf-8"), (
+            f"{path.name} implements EXTERNAL_EVIDENCE — update the census table"
+        )

--- a/tests/plugins/memory/test_memory_os_schema.py
+++ b/tests/plugins/memory/test_memory_os_schema.py
@@ -78,3 +78,25 @@ def test_ids_are_prefixed_and_sortable_for_supplied_times():
     assert new_audit_id(early, unique="a").startswith("audit_")
     assert new_view_id(early, unique="a").startswith("view_")
     assert new_event_id(early, unique="a") < new_event_id(later, unique="a")
+
+
+def test_promotion_state_is_reserved_every_producer_writes_raw():
+    """D5 census: promotion_state is a RESERVED field — the state machine it
+    implies was never built, so every literal assignment in the codebase must
+    be "raw". A producer writing any other value is half-implementing the
+    machine without the migration/consumer side; that must be a conscious,
+    census-updating change, not silent drift."""
+    import re
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[3]
+    pattern = re.compile(r"promotion_state[\"']?\s*[:=]\s*[\"'](\w+)[\"']")
+    offenders: list[str] = []
+    for path in (repo_root / "plugins").rglob("*.py"):
+        for value in pattern.findall(path.read_text(encoding="utf-8")):
+            if value != "raw":
+                offenders.append(f"{path}: {value}")
+    assert not offenders, (
+        "promotion_state literals other than 'raw' found — the promotion "
+        f"state machine is unimplemented; offenders: {offenders}"
+    )

--- a/tests/plugins/memory/test_memory_os_v3_privacy_boundaries.py
+++ b/tests/plugins/memory/test_memory_os_v3_privacy_boundaries.py
@@ -35,6 +35,28 @@ def test_v3_external_speech_has_exactly_one_speak_gate_adapter():
     assert speak_gate_users == ["v3_outlet.py"]
 
 
+def test_resolve_owner_channel_callers_are_symbol_enumerated():
+    """The v3_*.py glob above cannot see non-v3 callers of speak_gate's
+    private ``_resolve_owner_channel`` — cognitive_loop.py was an invisible
+    second cross-module caller for months. Enumerate consumers BY SYMBOL over
+    the whole plugin tree so a new caller (or a removed one) must touch this
+    census consciously, instead of widening a directory glob that drifts from
+    reality."""
+    expected = {
+        "plugins/modules/expression/speak_gate.py",  # the defining module
+        "plugins/memory/memory_os/cognitive_loop.py",
+        "plugins/memory/memory_os/v3_outlet.py",
+    }
+    actual = set()
+    for path in (REPO_ROOT / "plugins").rglob("*.py"):
+        if "_resolve_owner_channel" in path.read_text(encoding="utf-8"):
+            actual.add(path.relative_to(REPO_ROOT).as_posix())
+    assert actual == expected, (
+        f"_resolve_owner_channel caller set changed: added={sorted(actual - expected)} "
+        f"removed={sorted(expected - actual)} — update this census consciously"
+    )
+
+
 def test_private_store_names_do_not_appear_in_ragflow_or_backup_payload_builders():
     private_names = ("wandering_journal.jsonl", "v3_body_packet_manifests.jsonl")
     candidates = [

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -8191,3 +8191,59 @@ def test_clean_host_member_drift_stays_classified_warn():
         item["code"] == "clean_host_warn_unclassified"
         for item in classification["fail"]
     )
+
+
+# ── T2: the monitor's embedded classifier copy — pinned, not equalized ──────
+#
+# classify_hermes_cron_jobs has three copies: the seam (production), the
+# in-package adapter (tooling), and the monitor's embedded probe copy. The
+# first two are pinned equal in test_memory_os_hermes_cron_adapter.py; the
+# monitor copy is DELIBERATELY divergent (it buckets retired jobs as
+# known_optional via injected specs) and its adapter-probe overwrite gives
+# the adapter copies precedence whenever the probe payload is available.
+# These pins make either contract change loud.
+
+
+def test_monitor_probe_buckets_retired_job_known_optional(tmp_path):
+    from plugins.memory.memory_os.cron_registry import RETIRED_MEMORY_OS_CRON_SCRIPTS
+
+    retired_name, retired_script = sorted(RETIRED_MEMORY_OS_CRON_SCRIPTS.items())[0]
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir(parents=True)
+    cron_dir.joinpath("jobs.json").write_text(
+        json.dumps({"jobs": [{"name": retired_name, "script": retired_script, "enabled": False}]}),
+        encoding="utf-8",
+    )
+
+    namespace = _parity_probe_namespace(tmp_path)
+    summary = namespace["execution_gate_cron_summary"]()
+
+    assert summary["memory_os_like_unregistered_count"] == 0
+    known_optional_scripts = {job["script"] for job in summary["known_optional_jobs"]}
+    assert retired_script in known_optional_scripts
+
+
+def test_monitor_adapter_probe_counts_take_precedence(tmp_path):
+    """When the adapter probe payload is valid, its classification counts
+    overwrite the monitor's own and classification_source flips — grading of
+    a job therefore follows the adapter copies whenever the probe runs. This
+    is intended behavior; changing it must break this test."""
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir(parents=True)
+    cron_dir.joinpath("jobs.json").write_text(json.dumps({"jobs": []}), encoding="utf-8")
+
+    namespace = _parity_probe_namespace(tmp_path)
+    namespace["_execution_gate_cron_adapter_probe_summary"] = lambda: {
+        "schema_version": "memory-os.hermes_cron_adapter_probe.v0",
+        "status": "pass",
+        "adapter_owner": "hermes_memory_os_seam",
+        "classification": {
+            "memory_os_owned_wrapped_count": 42,
+            "memory_os_like_unregistered_count": 7,
+        },
+    }
+    summary = namespace["execution_gate_cron_summary"]()
+
+    assert summary["classification_source"] == "hermes_cron_adapter_probe"
+    assert summary["memory_os_owned_wrapped_count"] == 42
+    assert summary["memory_os_like_unregistered_count"] == 7

--- a/tests/scripts/test_memory_os_execution_gate_runner.py
+++ b/tests/scripts/test_memory_os_execution_gate_runner.py
@@ -485,3 +485,138 @@ def test_sidecar_index_prune_is_a_noop_below_the_cap():
     index = {"xgate_a": {"envelope_id": "xgate_a"}, "xgate_b": {"envelope_id": "xgate_b"}}
 
     assert module.prune_sidecar_index(index, max_entries=10) == index
+
+
+# ── T1: dual-writer schema parity (runner vs core execution_gate) ───────────
+#
+# Both writers append to the SAME execution_gate_envelopes.jsonl and sidecar
+# index, from two independent implementations. These guards build one record
+# through each real producer (no hand fixtures) and pin the shared-file
+# contract: silent divergence here corrupts every full-scan validation.
+
+
+_FALSE_BOUNDARY = {
+    "owner_delivery_attempted": False,
+    "external_action_executed": False,
+    "actual_identity_write": False,
+    "actual_unapproved_crystallized_approval": False,
+}
+
+
+def _runner_permit_and_completion(module, hermes_home):
+    permit = module._append_permit(
+        hermes_home=hermes_home,
+        registry_key="index_sync",
+        lane_id="index_sync",
+        risk_class="local_helper",
+        raw_script="memory_os_index_sync.py",
+        helper_present=True,
+        smoke_mode="off",
+        boundary=dict(_FALSE_BOUNDARY),
+    )
+    module._append_completion(
+        hermes_home=hermes_home,
+        envelope_id=permit["execution_gate_envelope_id"],
+        lane_id="index_sync",
+        execution_status="completed",
+        returncode=0,
+        smoke_mode="off",
+        boundary=dict(_FALSE_BOUNDARY),
+        helper_report={},
+        requires_boundary_report=False,
+    )
+    records = [
+        json.loads(line)
+        for line in module._records_path(hermes_home).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    completion = next(r for r in records if r["stage"] == "completion")
+    return permit, completion
+
+
+def _core_permit_and_completion(tmp_path):
+    from plugins.memory.memory_os.execution_gate import (
+        complete_execution_gate_envelope,
+        execution_gate_records_path,
+        start_execution_gate_envelope,
+    )
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path))
+    store.initialize()
+    permit = start_execution_gate_envelope(
+        store,
+        lane_id="index_sync",
+        trigger_surface="memory_os_local_helper",
+        risk_class="local_helper",
+        human_approval_required=False,
+        why_no_human_approval="dual-writer schema parity guard",
+        scope={"write_surface": "guard_test"},
+        boundary=dict(_FALSE_BOUNDARY),
+    )
+    complete_execution_gate_envelope(
+        store,
+        envelope_id=permit["execution_gate_envelope_id"],
+        lane_id="index_sync",
+        execution_status="completed",
+        postcheck={"boundary_true": False},
+        result_summary={"guard": "test"},
+    )
+    records = [
+        json.loads(line)
+        for line in execution_gate_records_path(store.roots).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    completion = next(r for r in records if r["stage"] == "completion")
+    return store, permit, completion
+
+
+def test_dual_writer_schema_version_comes_from_one_constant(tmp_path):
+    from plugins.memory.memory_os.execution_gate import EXECUTION_GATE_SCHEMA_VERSION
+
+    module = _load_runner_module()
+    assert module.SCHEMA_VERSION == EXECUTION_GATE_SCHEMA_VERSION
+
+
+def test_dual_writer_completion_key_sets_are_identical(tmp_path):
+    module = _load_runner_module()
+    _, runner_completion = _runner_permit_and_completion(module, tmp_path / "runner-home")
+    _, _, core_completion = _core_permit_and_completion(tmp_path / "core-home")
+
+    assert set(runner_completion) == set(core_completion), (
+        "completion-stage records from the two writers diverged — the shared "
+        "envelopes file no longer has one completion schema"
+    )
+
+
+def test_dual_writer_permit_gap_is_exactly_the_pinned_constant(tmp_path):
+    module = _load_runner_module()
+    runner_permit, _ = _runner_permit_and_completion(module, tmp_path / "runner-home")
+    _, core_permit, _ = _core_permit_and_completion(tmp_path / "core-home")
+
+    assert set(runner_permit) <= set(core_permit), (
+        "runner permit grew keys the core writer lacks — update the core or "
+        "RUNNER_OMITTED_PERMIT_KEYS consciously"
+    )
+    assert set(core_permit) - set(runner_permit) == set(module.RUNNER_OMITTED_PERMIT_KEYS)
+
+
+def test_dual_writer_sidecar_entries_have_identical_shape(tmp_path):
+    module = _load_runner_module()
+    runner_home = tmp_path / "runner-home"
+    runner_permit, _ = _runner_permit_and_completion(module, runner_home)
+    core_store, core_permit, _ = _core_permit_and_completion(tmp_path / "core-home")
+
+    runner_index = json.loads(
+        (runner_home / "memory-os" / "system" / "execution_gate_index.json").read_text(encoding="utf-8")
+    )
+    core_index = json.loads(
+        (core_store.roots.memory_os_root / "system" / "execution_gate_index.json").read_text(encoding="utf-8")
+    )
+    runner_entry = runner_index[runner_permit["execution_gate_envelope_id"]]
+    core_entry = core_index[core_permit["execution_gate_envelope_id"]]
+
+    assert set(runner_entry) == set(core_entry), (
+        "sidecar index entries from the two writers diverged in shape"
+    )


### PR DESCRIPTION
PR-B of the open-items roadmap (advisor-amended). Zero production behavior change; 19 new tests converting six silent-drift classes into loud failures: dual ExecutionGate writer parity (RUNNER_OMITTED_PERMIT_KEYS pinned), seam/adapter classifier equality + monitor-copy precedence pinned as intended (NOT equalized — that would suppress a live WARN), first coverage of index.search LIKE fallback, RECALL_TYPE_DISPOSITION census (hindsight retriever = probe_only, not dead), MIGRATOR_STATES aligned (stray shadow_bundle) + census, promotion_state only-raw census, RRF set-semantics docstring truth, symbol-enumerated speak_gate callers. Full suite 3204 passed / 13 skipped; gates green; D8 census red-verified against origin/main.