### PR TITLE
monitor(M1-followup): registry-owned profile exclusions vs snapshot drift

### DIFF
--- a/plugins/memory/memory_os/cron_registry.py
+++ b/plugins/memory/memory_os/cron_registry.py
@@ -90,6 +90,28 @@ LEGACY_PER_LANE_CRON_JOBS = {
 LEGACY_PER_LANE_CRON_JOB_NAMES = frozenset(LEGACY_PER_LANE_CRON_JOBS)
 LEGACY_PER_LANE_CRON_SCRIPT_NAMES = frozenset(LEGACY_PER_LANE_CRON_JOBS.values())
 
+# Registry keys deliberately withheld from the active-closure cron profile.
+# Owned here (not in the onboarding script) so every consumer that can import
+# the registry — onboarding, the monitor's host-side snapshot-parity probe,
+# dashboards — reads ONE intent record: a compiled member absent from the
+# deployed snapshot is silent drift ONLY when it is not documented here.
+# A key belongs here ONLY for a documented, deliberate reason — never merely
+# because the spec happens to be new.
+#
+#   - module_cadence_report: the cadence report artifact is already produced
+#     on demand by build_cadence_report() from both the monitor dashboard
+#     snapshot and the 3.200 full monitor, so a dedicated periodic cron job
+#     is redundant; it remains available under the "full" cron profile.
+#   - clearance_cycle: DEFERRED ACTIVATION, not a permanent exclusion. The
+#     helper/gate scripts are deployed and the M3 watermark fix removed the
+#     technical blocker, but switching the lane on is an owner decision that
+#     must not ride in as a side effect of an unrelated change. To enable:
+#     delete this one line (and regenerate the deployed snapshot).
+ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS = frozenset({
+    "module_cadence_report",
+    "clearance_cycle",
+})
+
 DUE_POLICY_INTERVAL = "interval"
 DUE_POLICY_CALENDAR = "calendar"
 

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -7771,15 +7771,20 @@ def _cron_registry_snapshot_parity():
     if not snapshot_groups:
         return {"status": "snapshot_groups_unavailable"}
     try:
-        from plugins.memory.memory_os.cron_registry import MEMORY_OS_CRON_GROUPS
+        from plugins.memory.memory_os.cron_registry import (
+            ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS,
+            MEMORY_OS_CRON_GROUPS,
+        )
 
         compiled_groups = {
             group.key: [str(member) for member in group.member_keys]
             for group in MEMORY_OS_CRON_GROUPS
         }
+        documented_exclusions = {str(key) for key in ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS}
     except Exception:
         return {"status": "registry_import_unavailable"}
     silently_missing = {}
+    documented_exclusions_absent = {}
     unknown_in_snapshot = {}
     fallback_group_keys = []
     for key, compiled_members in compiled_groups.items():
@@ -7792,14 +7797,24 @@ def _cron_registry_snapshot_parity():
             fallback_group_keys.append(key)
             continue
         missing = [m for m in compiled_members if m not in resolved]
-        if missing:
-            silently_missing[key] = missing
+        # A member absent from the snapshot is drift ONLY when the registry
+        # does not document the absence as a deliberate profile exclusion
+        # (clearance_cycle deferred activation fired a false alarm on the
+        # detector's first production run without this split). Documented
+        # absences stay visible in the payload, deliberately ungraded.
+        undocumented = [m for m in missing if m not in documented_exclusions]
+        documented = [m for m in missing if m in documented_exclusions]
+        if undocumented:
+            silently_missing[key] = undocumented
+        if documented:
+            documented_exclusions_absent[key] = documented
         unknown = [m for m in resolved if m not in set(compiled_members)]
         if unknown:
             unknown_in_snapshot[key] = unknown
     return {
         "status": "drift" if silently_missing else "ok",
         "silently_missing_lane_ids": silently_missing,
+        "documented_exclusions_absent": documented_exclusions_absent,
         "unknown_in_snapshot": unknown_in_snapshot,
         "fallback_group_keys": sorted(fallback_group_keys),
         "snapshot_group_count": len(snapshot_groups),

--- a/scripts/memory_os_monitor_dashboard_snapshot.py
+++ b/scripts/memory_os_monitor_dashboard_snapshot.py
@@ -83,7 +83,8 @@ OPTIONAL_MEMORY_OS_CRON_KEYS = frozenset({
     "l3_probe_verification",
     "expression_feedback_request",
     # Kept OPTIONAL for as long as active-closure onboarding defers it (see
-    # ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS in memory_os_owner_cron_onboarding.py).
+    # ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS in cron_registry.py — the registry
+    # owns the profile-exclusion intent record).
     # Classifying a job we deliberately do not install as CORE would raise a
     # permanent missing_core WARN for its expected absence. Promote it to CORE
     # in the same change that enables the cron.

--- a/scripts/memory_os_owner_cron_onboarding.py
+++ b/scripts/memory_os_owner_cron_onboarding.py
@@ -30,6 +30,7 @@ if str(IMPORT_ROOT) not in sys.path:
     sys.path.insert(0, str(IMPORT_ROOT))
 
 from plugins.memory.memory_os.cron_registry import (
+    ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS,
     LEGACY_PER_LANE_CRON_JOBS,
     RETIRED_MEMORY_OS_CRON_SCRIPT_NAMES,
     groups_for_specs,
@@ -42,43 +43,14 @@ from plugins.seam.hermes_memory_os.cron_adapter import HermesCronAdapter
 SCHEMA_VERSION = "memory-os.owner_cron_onboarding.v0"
 
 # Registry keys deliberately withheld from the active-closure cron profile.
-# A key belongs here ONLY for a documented, deliberate reason -- never
-# merely because the spec happens to be new. Every OTHER key returned by
-# memory_os_cron_specs() is onboarded on active-closure hosts by default, so
-# a future registry addition defaults to being installed and visible rather
-# than silently skipped (a hand-typed inclusion allowlist is exactly the
-# "unknown spec silently dropped" trap this derivation avoids).
-#
-#   - module_cadence_report: the cadence report artifact itself is already
-#     produced on-demand by build_cadence_report() from both the monitor
-#     dashboard snapshot and the 3.200 full monitor on every run, so a
-#     dedicated periodic cron job is redundant. It remains available under
-#     the "full" cron profile for hosts that want a standalone report cron.
-ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS = frozenset({
-    # Permanent exclusion: its report is already generated on demand elsewhere.
-    "module_cadence_report",
-    # DEFERRED ACTIVATION, not a permanent exclusion.
-    #
-    # clearance_cycle is a real registered spec whose helper/gate scripts the
-    # installer already deploys, but it was never added to the (previously
-    # hand-typed) active-closure key set -- an oversight, since every sibling
-    # spec was classified in the same commit that registered it. So the job has
-    # never actually been created on a production host, and the lane has never
-    # run there.
-    #
-    # It is held back here on purpose rather than switched on as a side effect
-    # of the registry-drift fix: the same change set also repaired
-    # `append_terminal(detail=...)`, which means
-    # `sweep_unavailable_open_proposals_on_flag_flip` -- which REVOKES open
-    # proposals and lives in clearance_cycle.py -- went from raising TypeError
-    # on every call to actually working. Enabling the cron in the same step
-    # would make two never-exercised paths live at once on 3.200, so a failure
-    # could not be attributed to either.
-    #
-    # To enable: delete this one line. The drift guard below still guarantees a
-    # newly registered spec can never be silently omitted again.
-    "clearance_cycle",
-})
+# The intent record moved to cron_registry.ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS
+# so the monitor's host-side snapshot-parity probe (which can only import the
+# runtime plugins tree, never this script) reads the same single source.
+# Every OTHER key returned by memory_os_cron_specs() is onboarded on
+# active-closure hosts by default, so a future registry addition defaults to
+# being installed and visible rather than silently skipped (a hand-typed
+# inclusion allowlist is exactly the "unknown spec silently dropped" trap
+# this derivation avoids). Rationale per excluded key lives at the constant.
 ACTIVE_CLOSURE_CRON_KEYS = frozenset(
     spec.key for spec in memory_os_cron_specs()
 ) - ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -8082,6 +8082,31 @@ def test_snapshot_parity_complete_snapshot_is_ok(tmp_path):
     assert parity["fallback_group_keys"] == []
 
 
+def test_snapshot_parity_documented_exclusion_is_not_drift(tmp_path):
+    """Counterfactual for the detector's first-production-run false alarm:
+    clearance_cycle is a DOCUMENTED deferred activation (registry-owned
+    ACTIVE_CLOSURE_EXCLUDED_CRON_KEYS), so its absence from the deployed
+    snapshot — exactly production's shape — must be reported, not graded
+    as drift. An UNdocumented absence in the same group must still drift."""
+    from plugins.memory.memory_os.cron_registry import cron_registry_snapshot
+
+    snapshot = cron_registry_snapshot()
+    governance = next(g for g in snapshot["groups"] if g["key"] == "tick_governance")
+    assert "clearance_cycle" in governance["member_keys"]
+    governance["member_keys"] = [
+        m for m in governance["member_keys"] if m != "clearance_cycle"
+    ]
+    _write_registry_snapshot(tmp_path, snapshot)
+
+    parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
+
+    assert parity["status"] == "ok"
+    assert parity["silently_missing_lane_ids"] == {}
+    assert parity["documented_exclusions_absent"] == {
+        "tick_governance": ["clearance_cycle"]
+    }
+
+
 def test_snapshot_parity_missing_snapshot_reports_no_sample(tmp_path):
     parity = _parity_probe_namespace(tmp_path)["_cron_registry_snapshot_parity"]()
 


### PR DESCRIPTION
Follow-up to PR #27 after the detector's first production run correctly mechanized but wrongly graded clearance_cycle's documented deferred activation. Exclusion intent moves to cron_registry (single source reachable by the host-side probe; scripts/ tree verified unimportable there); probe splits undocumented (WARN) from documented (visible, ungraded). Counterfactual mirrors production's exact snapshot shape. Full suite 3190/13/0; gates green.