### PR TITLE
fix: E8 锚点管线回退——图谱注入对中文对话无感的根因

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -3857,6 +3857,32 @@ OwnerGate 永久边界,错误的边应由使用信号淘汰而非人工把关。
 active→注入消费+反馈遗忘、invalidated 终态;digest 不再是任何边状态的
 消费者(census 断言 `EDGE_REVIEW_DIGEST_STATE` 不复存在)。
 
+### CH.4 —— E8 锚点管线失效:图谱注入"无感"的最后一公里(2026-08-07)
+
+Owner 部署后实测"完全没感觉到动态图谱注入",三层诊断(全部生产实锤):
+
+1. **测试话术走 casual 兜底路由且无检索命中** — 04:01-04:17Z 三次
+   prefetch 的 selected 段无 Indexed Recall → FTS 零命中 → 锚点空 →
+   图谱一跳展开无起点(匹配才注入的设计行为,非故障)。
+2. **E8(真缺陷):锚点管线对中文对话结构性失效**。
+   `plan_query_route` 的 `entities or chinese_keywords` 短路 — query 含
+   任何拉丁词时中文实词整体丢弃;派生出的多词 search_query 在 FTS AND
+   语义下断崖式 0 命中(实测 'Memory-OS Hermes':两词单查各 5 命中,
+   AND 交集 0;'审批 闭环' 同样 0)。双重作用 → 锚点恒空 → **shadow
+   月命中仅 4 条、历史 1019 次 prefetch 仅 19.5% 有 FTS 命中的根因**。
+   修复:`_collect_anchor_ids` 增加有界回退(派生词逐词并集 + 中文
+   关键词表补词;词 ≤6/每词 limit 3/锚点 ≤5),**不碰全局共享的
+   plan_query_route 谓词**(W 规则:改共享谓词前全面 grep;Indexed
+   Recall 的派生行为不变,中文丢词的通用改进另议)。4 条反事实
+   (AND 回退/中文补词/直接命中不回退/有界)先红后绿。
+3. ~~Gateway 24 天未重启~~ **实测更正(owner 指出后复查)**:初判把主机上
+   无关测试容器的 s6 监督进程误认作 gateway——真实 gateway 进程为
+   `/usr/local/lib/hermes-agent/venv/.../gateway run`,owner 重启有效
+   (复查时 etime 40 分钟),runtime 布局 prefetch.py 带 W7 标记 —— 今日
+   新代码**已加载**。教训:**监督进程的 etime 不是被监督进程的 etime**,
+   判断进程年龄必须找到真实子进程,不能拿 supervisor/wrapper 凑数。
+   E8 部署后需再重启一次 gateway 以加载(时机归 owner)。
+
 **CH.3 部署与生产验证(2026-08-07 03:26Z 实测)**:PR #38 → main
 `766d797`(CI dispatch success);deploy apply+postcheck 全绿;
 `graph_layer_injection_enabled` override 写入

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -1902,18 +1902,59 @@ def _collect_anchor_ids(query: str, index: object | None) -> list[str]:
     search_query = str(route.get("search_query", "")).strip()
     if not search_query:
         return []
-    try:
-        result = index.search(search_query, limit=5)
-    except Exception:
-        return []
-    ids: list[str] = []
-    for hit in result.get("hits", []):
-        if not isinstance(hit, dict):
-            continue
-        rid = str(hit.get("record_id", "")).strip()
-        if rid:
-            ids.append(rid)
-    return ids
+
+    def _hits_of(term: str, *, limit: int) -> list[str]:
+        try:
+            result = index.search(term, limit=limit)
+        except Exception:
+            return []
+        found: list[str] = []
+        for hit in (result.get("hits", []) if isinstance(result, dict) else []):
+            if not isinstance(hit, dict):
+                continue
+            rid = str(hit.get("record_id", "")).strip()
+            if rid:
+                found.append(rid)
+        return found
+
+    ids = _hits_of(search_query, limit=5)
+    if ids:
+        return ids
+
+    # ── E8 回退(2026-08-07 生产实锤)────────────────────────────────
+    # 派生的多词 search_query 在 FTS AND 语义下经常 0 命中(实测
+    # 'Memory-OS Hermes' 两词单查各 5 命中、AND 交集 0),而
+    # plan_query_route 的 `entities or chinese_keywords` 短路又把中文
+    # 实词整体丢弃 — 双重作用下锚点恒空,图谱一跳展开永不触发
+    # (shadow 月命中仅 4 条的根因)。回退:①派生词逐词并集;②仍空则
+    # 用中文关键词表匹配原 query 逐词并集。全程有界:词 ≤6、每词
+    # limit 3、锚点 ≤5。只改锚点收集,不碰全局共享的 plan_query_route。
+    # 派生词逐词(单词派生无 AND 问题,重查等于原查询,跳过)…
+    derived_terms = [t for t in search_query.split() if t]
+    if len(derived_terms) <= 1:
+        derived_terms = []
+    # …加上被 entities 短路丢弃的中文关键词(仅用于锚点回退)
+    effective_keywords = (
+        _fast_path_keywords_override
+        if _fast_path_keywords_override is not None
+        else _FAST_PATH_CHINESE_KEYWORDS
+    )
+    redacted = _redact(" ".join(str(query).split()))
+    chinese_terms = [
+        kw for kw in effective_keywords
+        if kw in redacted and kw not in _FAST_PATH_STOP_WORDS
+    ]
+    fallback_terms = _dedupe(derived_terms + chinese_terms)[:6]
+    seen_ids: list[str] = []
+    for term in fallback_terms:
+        if len(seen_ids) >= 5:
+            break
+        for rid in _hits_of(term, limit=3):
+            if rid not in seen_ids:
+                seen_ids.append(rid)
+            if len(seen_ids) >= 5:
+                break
+    return seen_ids
 
 
 # W3 词表守卫锚点:图谱注入只消费此状态的边;owner approve(active 化)

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -1916,6 +1916,87 @@ def test_r1_structural_source_has_no_candidate_state():
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# E8 — 锚点收集回退:多词 AND 失效与中文丢词(图谱注入的最后一公里)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# 生产实锤(2026-08-07):plan_query_route 的 `entities or chinese_keywords`
+# 在 query 含任何拉丁词时把中文实词整体丢弃;派生出的多词 search_query
+# (如 'Memory-OS Hermes')在 FTS AND 语义下 0 命中(两词单查各 5 命中,
+# 交集空)。锚点恒空 → 图谱一跳展开永不触发 → shadow 月命中仅 4 条、
+# owner 实测"完全没感觉到注入"。历史 1019 次 prefetch 仅 19.5% 有 FTS
+# 命中。修复只动 _collect_anchor_ids(锚点专用回退),不碰全局共享的
+# plan_query_route 谓词(改共享谓词前须全面 grep — W 规则)。
+
+
+class _E8MockIndex:
+    """可编程 search mock:按查询词返回预设命中。"""
+
+    def __init__(self, hits_by_query):
+        self.hits_by_query = hits_by_query
+        self.queries = []
+
+    def search(self, query, limit=5):
+        self.queries.append(query)
+        hits = self.hits_by_query.get(query, [])
+        return {"hits": [{"record_id": rid, "record_type": "crystallized_record"} for rid in hits]}
+
+
+def test_e8_and_failure_falls_back_to_per_term_union():
+    """E8 counterfactual:多词派生查询 0 命中时,必须逐词并集回退。
+
+    无修复:_collect_anchor_ids 一次 AND 查询 0 命中即返回 [] → 必红。
+    """
+    index = _E8MockIndex({
+        "Memory-OS Hermes": [],
+        "Memory-OS": ["cry_a"],
+        "Hermes": ["cry_b"],
+    })
+    anchors = _collect_anchor_ids("聊聊 Memory-OS 和 Hermes 的联动", index)
+    assert "cry_a" in anchors and "cry_b" in anchors, (
+        f"per-term fallback must recover anchors from AND-failed query: {anchors}"
+    )
+
+
+def test_e8_chinese_keywords_recovered_when_latin_terms_miss():
+    """E8 counterfactual:拉丁词短路丢弃的中文关键词必须参与锚点回退。"""
+    from plugins.memory.memory_os.prefetch import set_fast_path_keywords
+
+    index = _E8MockIndex({
+        "Hermes": [],          # 派生查询(单拉丁词)未命中
+        "部署": ["cry_zh"],    # 中文关键词命中
+    })
+    set_fast_path_keywords(["部署"])
+    try:
+        anchors = _collect_anchor_ids("Hermes 的部署情况怎么样了", index)
+    finally:
+        set_fast_path_keywords(None)
+    assert anchors == ["cry_zh"], (
+        f"Chinese keywords dropped by the entities-or short-circuit must be "
+        f"retried for anchors: {anchors}"
+    )
+
+
+def test_e8_direct_hit_needs_no_fallback():
+    """回归:派生查询直接命中时不回退(单次 search,行为不变)。"""
+    index = _E8MockIndex({"Memory-OS Hermes": ["cry_direct"]})
+    anchors = _collect_anchor_ids("聊聊 Memory-OS 和 Hermes", index)
+    assert anchors == ["cry_direct"]
+    assert index.queries == ["Memory-OS Hermes"], (
+        f"no fallback queries expected on direct hit: {index.queries}"
+    )
+
+
+def test_e8_fallback_bounded():
+    """回退有界:锚点总数 ≤5,查询词数有上限。"""
+    hits = {f"w{i}": [f"cry_{i}"] for i in range(10)}
+    hits[" ".join(f"w{i}" for i in range(6))] = []
+    index = _E8MockIndex(hits)
+    # 构造派生出 6 个拉丁词的 query
+    anchors = _collect_anchor_ids("check w0 w1 w2 w3 w4 w5 please", index)
+    assert len(anchors) <= 5, f"anchor cap must hold: {anchors}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # W1 (E2/E3) — 去重下沉写入口 + structural 收回语义提名权 + 配对去偏置
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
锚点收集对中文 query 结构性失效(拉丁词短路丢中文 + FTS 多词 AND 零命中)→ 图谱展开永不触发。修复:_collect_anchor_ids 有界回退(逐词并集+中文关键词补词),不碰全局 plan_query_route。4 条反事实先红后绿,全量 3244 passed。含 gateway 误判如实更正(CH.4)。