### PR TITLE
fix: E8b 锚点池结晶优先(通用命中被事件淹没)

### DIFF
--- a/plugins/memory/memory_os/index.py
+++ b/plugins/memory/memory_os/index.py
@@ -214,7 +214,11 @@ class MemoryOSIndex:
         finally:
             conn.close()
 
-    def search(self, query: str, *, limit: int = 5) -> dict[str, Any]:
+    def search(self, query: str, *, limit: int = 5, record_type: str | None = None) -> dict[str, Any]:
+        """Search the FTS projection. *record_type* optionally restricts hits
+        to one record class (E8b: the anchor collector uses
+        record_type="crystallized_record" because edge density lives in the
+        crystallized layer while generic hits drown in event volume)."""
         if not self.roots.index_path.exists():
             return {"mode": "missing", "tokenizer": "", "hits": []}
         conn = sqlite3.connect(self.roots.index_path)
@@ -222,9 +226,9 @@ class MemoryOSIndex:
         try:
             _initialize_schema(conn)
             tokenizer = _metadata_value(conn, "fts_tokenizer") or "unknown"
-            hits = _fts_hits(conn, query, limit=limit)
+            hits = _fts_hits(conn, query, limit=limit, record_type=record_type)
             if not hits:
-                hits = _like_hits(conn, query, limit=limit)
+                hits = _like_hits(conn, query, limit=limit, record_type=record_type)
             return {"mode": "indexed", "tokenizer": tokenizer, "hits": hits}
         finally:
             conn.close()
@@ -1179,35 +1183,55 @@ def _normalize_projection_text(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
-def _fts_hits(conn: sqlite3.Connection, query: str, *, limit: int) -> list[dict[str, str]]:
+def _fts_hits(
+    conn: sqlite3.Connection,
+    query: str,
+    *,
+    limit: int,
+    record_type: str | None = None,
+) -> list[dict[str, str]]:
     if not query.strip():
         return []
+    type_clause = " and record_type = ?" if record_type else ""
+    params: tuple = (query, record_type, limit) if record_type else (query, limit)
     try:
         rows = conn.execute(
-            """
+            f"""
             select record_type, record_id, title, text
             from memory_fts
-            where memory_fts match ?
+            where memory_fts match ?{type_clause}
             limit ?
             """,
-            (query, limit),
+            params,
         ).fetchall()
     except sqlite3.Error:
         return []
     return [_row_to_hit(row) for row in rows]
 
 
-def _like_hits(conn: sqlite3.Connection, query: str, *, limit: int) -> list[dict[str, str]]:
+def _like_hits(
+    conn: sqlite3.Connection,
+    query: str,
+    *,
+    limit: int,
+    record_type: str | None = None,
+) -> list[dict[str, str]]:
     if not query.strip():
         return []
+    type_clause = " and record_type = ?" if record_type else ""
+    params: tuple = (
+        (f"%{query}%", f"%{query}%", record_type, limit)
+        if record_type
+        else (f"%{query}%", f"%{query}%", limit)
+    )
     rows = conn.execute(
-        """
+        f"""
         select record_type, record_id, title, text
         from memory_fts
-        where title like ? or text like ?
+        where (title like ? or text like ?){type_clause}
         limit ?
         """,
-        (f"%{query}%", f"%{query}%", limit),
+        params,
     ).fetchall()
     return [_row_to_hit(row) for row in rows]
 

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -1903,9 +1903,12 @@ def _collect_anchor_ids(query: str, index: object | None) -> list[str]:
     if not search_query:
         return []
 
-    def _hits_of(term: str, *, limit: int) -> list[str]:
+    def _hits_of(term: str, *, limit: int, record_type: str | None = None) -> list[str]:
         try:
-            result = index.search(term, limit=limit)
+            if record_type is None:
+                result = index.search(term, limit=limit)
+            else:
+                result = index.search(term, limit=limit, record_type=record_type)
         except Exception:
             return []
         found: list[str] = []
@@ -1917,9 +1920,16 @@ def _collect_anchor_ids(query: str, index: object | None) -> list[str]:
                 found.append(rid)
         return found
 
+    # E8b:结晶限定段优先 — FTS 通用命中被事件量级淹没(生产实测 top 8
+    # 清一色 event),而边密度在结晶层;锚点池 = 结晶命中(前)∪ 通用命中,
+    # cap 5。旧 index/mock 不支持 record_type 时 fail-open 降级为空段。
+    crystallized_ids = _hits_of(
+        search_query, limit=2, record_type="crystallized_record",
+    )
     ids = _hits_of(search_query, limit=5)
-    if ids:
-        return ids
+    merged = _dedupe(crystallized_ids + ids)[:5]
+    if merged:
+        return merged
 
     # ── E8 回退(2026-08-07 生产实锤)────────────────────────────────
     # 派生的多词 search_query 在 FTS AND 语义下经常 0 命中(实测

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -1929,16 +1929,20 @@ def test_r1_structural_source_has_no_candidate_state():
 
 
 class _E8MockIndex:
-    """可编程 search mock:按查询词返回预设命中。"""
+    """可编程 search mock:按 (查询词[, record_type]) 返回预设命中。"""
 
-    def __init__(self, hits_by_query):
+    def __init__(self, hits_by_query, typed_hits=None):
         self.hits_by_query = hits_by_query
+        self.typed_hits = typed_hits or {}
         self.queries = []
 
-    def search(self, query, limit=5):
-        self.queries.append(query)
-        hits = self.hits_by_query.get(query, [])
-        return {"hits": [{"record_id": rid, "record_type": "crystallized_record"} for rid in hits]}
+    def search(self, query, limit=5, record_type=None):
+        self.queries.append((query, record_type))
+        if record_type is not None:
+            hits = self.typed_hits.get((query, record_type), [])
+        else:
+            hits = self.hits_by_query.get(query, [])
+        return {"hits": [{"record_id": rid, "record_type": record_type or "event"} for rid in hits]}
 
 
 def test_e8_and_failure_falls_back_to_per_term_union():
@@ -1977,13 +1981,15 @@ def test_e8_chinese_keywords_recovered_when_latin_terms_miss():
 
 
 def test_e8_direct_hit_needs_no_fallback():
-    """回归:派生查询直接命中时不回退(单次 search,行为不变)。"""
+    """回归:派生查询直接命中时不做逐词回退(双段主查询后即返回)。"""
     index = _E8MockIndex({"Memory-OS Hermes": ["cry_direct"]})
     anchors = _collect_anchor_ids("聊聊 Memory-OS 和 Hermes", index)
     assert anchors == ["cry_direct"]
-    assert index.queries == ["Memory-OS Hermes"], (
-        f"no fallback queries expected on direct hit: {index.queries}"
-    )
+    # 双段主查询(结晶限定 + 通用)各一次,无逐词回退查询
+    assert index.queries == [
+        ("Memory-OS Hermes", "crystallized_record"),
+        ("Memory-OS Hermes", None),
+    ], f"no per-term fallback expected on direct hit: {index.queries}"
 
 
 def test_e8_fallback_bounded():
@@ -1994,6 +2000,29 @@ def test_e8_fallback_bounded():
     # 构造派生出 6 个拉丁词的 query
     anchors = _collect_anchor_ids("check w0 w1 w2 w3 w4 w5 please", index)
     assert len(anchors) <= 5, f"anchor cap must hold: {anchors}"
+
+
+def test_e8_crystallized_hits_prioritized_into_anchor_pool():
+    """E8b counterfactual:结晶命中必须进锚点池并排在前面。
+
+    生产实锤(2026-08-07):FTS 通用命中被事件量级淹没(top 8 清一色
+    event),而边密度在结晶层(active 边端点:9 结晶 vs 26 事件,后者是
+    仅 30 条溯源边的固定集合)——通用锚点几乎永远落不到带边节点上。
+    修复:锚点收集用双段查询,record_type='crystallized_record' 限定段
+    优先,通用段补足。无修复:mock 的通用命中全 event → 锚点无结晶 → 必红。
+    """
+    index = _E8MockIndex(
+        {"Memory-OS Hermes": ["evt_1", "evt_2", "evt_3", "evt_4", "evt_5"]},
+        typed_hits={("Memory-OS Hermes", "crystallized_record"): ["cry_hot"]},
+    )
+    anchors = _collect_anchor_ids("聊聊 Memory-OS 和 Hermes", index)
+    assert "cry_hot" in anchors, (
+        f"crystallized hits must enter the anchor pool: {anchors}"
+    )
+    assert anchors[0] == "cry_hot", (
+        f"crystallized hits must be prioritized (edge density lives there): {anchors}"
+    )
+    assert len(anchors) <= 5
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
E8 回退后锚点有了但清一色 event(FTS 通用命中被事件量级淹没),边密度在结晶层。index.search 加 record_type 过滤,锚点收集双段查询(结晶限定优先+通用补足)。全量 3245 passed。