### PR TITLE
Graph injection quality: direction-normalized Chinese rendering, shadow v1 true-hit feedback, tiered birth weights + exploration slots

### DIFF
--- a/plugins/memory/memory_os/edge_provenance.py
+++ b/plugins/memory/memory_os/edge_provenance.py
@@ -94,13 +94,15 @@ def run_edge_provenance(
                 continue
             in_run.add(key)
             if index and hasattr(index, "write_governed_edge"):
+                from .edge_weights import birth_weight
+
                 result = index.write_governed_edge(
                     from_record_type="event",
                     from_record_id=event_id,
                     to_record_type="crystallized_record",
                     to_record_id=record_id,
                     relation_type="evidence_for",
-                    weight=1.0,
+                    weight=birth_weight("provenance", "source_event_provenance"),
                     source_event_id=event_id,
                     proposed_by="provenance",
                     # 元数据在结晶批准时已过 OwnerGate → auto-active;

--- a/plugins/memory/memory_os/edge_weight_feedback.py
+++ b/plugins/memory/memory_os/edge_weight_feedback.py
@@ -5,18 +5,23 @@ Owner 决策 2026-08-06:「动态图谱应该是动态去更新关系的…不�
 治理机制:
 
   - **强化**:prefetch 注入命中(``system/graph_layer_shadow.jsonl``,由
-    ``_record_graph_layer_shadow`` 真实生产)→ 命中边 weight +HIT_BOOST
-    (cap 1.0),经 W0 同款 canonical 写回持久;
+    ``_record_graph_layer_shadow`` 真实生产)→ 命中边 weight 强化,经 W0
+    同款 canonical 写回持久。**只有 ``injected=True`` 的边算命中**(shadow
+    v1/F2):knob 关闭、被权重下限过滤、目标解析失败的边都会落账但不算
+    命中 — v0 时代「查到边」与「注入命中」共用一份语义,从未展示过的边
+    也被当命中强化过。缺 ``injected`` 字段的历史行按旧语义(算命中)。
   - **遗忘**:active 边 ``FORGET_AFTER_DAYS`` 无命中 → invalidated
     (G3 不删,每轮上限 FORGET_MAX_PER_RUN)。遗忘水位取
-    max(created_at, last_hit, 闭环首跑时间) — 「60 天无命中」必须从开始
-    记录命中之日起算,否则闭环上线首日会屠杀所有存量老边;且只有
-    shadow 账本存在(注入路径活跃过)才执行遗忘,注入关闭期间无命中
-    数据 ≠ 边没价值。
+    max(created_at, last_hit, first_injection_at) — 「60 天无命中」必须从
+    **首次真实注入**之日起算(v0 用闭环首跑时间,但 knob 关闭期间 shadow
+    照样有行,守卫 ``shadow_exists and lines`` 会在从未展示过任何东西的
+    时期放行遗忘);无 first_injection_at(注入从未活跃)不遗忘。
 
 Durable state: ``system/edge_weight_feedback_state.json``
-(processed_line_count cursor + per-edge last_hit + first_run_at)。
-Completion Is Not Output: closed outcome + production counters.
+(processed_line_count cursor + per-edge last_hit + first_run_at +
+first_injection_at)。Completion Is Not Output: closed outcome +
+production counters(含 already_saturated / skipped_not_injected /
+invalidated_never_hit / forget_eligible_backlog)。
 
 Runs as a cognitive-loop step.
 """
@@ -70,11 +75,22 @@ def run_edge_weight_feedback(
     processed = int(state.get("processed_line_count") or 0)
     last_hit: dict[str, str] = dict(state.get("edge_last_hit") or {})
     first_run_at = str(state.get("first_run_at") or "") or current.isoformat()
+    # v0→v1 state 迁移:v0 只有 first_run_at(闭环首跑)。生产的 shadow 自
+    # E8c 起才有真实注入,首跑(2026-08-07)与首次注入同日,保守继承。
+    # 只对 v0 状态迁移:v1 状态里 first_injection_at 为空是「注入从未活跃」
+    # 的真实信号(knob 关闭期),回落 first_run_at 会误开遗忘。
+    first_injection_at = str(state.get("first_injection_at") or "")
+    if not first_injection_at and str(state.get("schema_version") or "").endswith(".v0"):
+        first_injection_at = str(state.get("first_run_at") or "")
 
     reinforced = 0
     forgotten = 0
     failed = 0
     unresolved_hits = 0
+    skipped_not_injected = 0
+    already_saturated = 0
+    invalidated_never_hit = 0
+    forget_eligible = 0
 
     shadow_exists = shadow_path.exists()
     lines: list[str] = []
@@ -111,6 +127,14 @@ def run_edge_weight_feedback(
             for edge_ref in record.get("edges") or []:
                 if not isinstance(edge_ref, dict):
                     continue
+                # Shadow v1(F2):只有真实进入 agent 上下文的边算命中。
+                # 缺字段的历史 v0 行按旧语义(算命中),已消费 cursor 之前
+                # 的行不受影响。
+                if edge_ref.get("injected", True) is False:
+                    skipped_not_injected += 1
+                    continue
+                if not first_injection_at:
+                    first_injection_at = hit_at
                 try:
                     row = conn.execute(
                         "select edge_id, weight from memory_edges"
@@ -131,16 +155,25 @@ def run_edge_weight_feedback(
                 result = update_edge_weight(
                     conn, edge_id, float(row["weight"]) + HIT_BOOST, roots=roots,
                 )
-                if result:
+                if result and result.get("weight_update_noop"):
+                    # F3:权重已在目标值(饱和)— 强化没有发生,不许计成
+                    # reinforced(生产首轮报 32 条「强化」,全部是此类
+                    # no-op)。但命中是真实的:必须刷新 last_hit,否则被
+                    # 高频使用的饱和边会被遗忘环处决。
+                    already_saturated += 1
+                    last_hit[edge_id] = hit_at
+                elif result:
                     reinforced += 1
                     last_hit[edge_id] = hit_at
                 else:
                     failed += 1
 
         # ── 2. Forget long-idle active edges ───────────────────────────
-        # Only when the injection path has ever been live (shadow ledger
-        # exists): no hit data while injection is off ≠ worthless edges.
-        if shadow_exists and lines:
+        # Only when injection has EVER really delivered lines to the agent
+        # (first_injection_at):v0 守卫是「shadow 文件存在且非空」,但 knob
+        # 关闭期间 shadow 照样有行(v1 更是每次都落账)— 那个守卫会在从未
+        # 展示过任何东西的时期放行遗忘,正是它要防的「上线首日屠杀存量」。
+        if first_injection_at:
             cutoff = (current - timedelta(days=FORGET_AFTER_DAYS)).isoformat()
             try:
                 actives = conn.execute(
@@ -150,30 +183,42 @@ def run_edge_weight_feedback(
             except sqlite3.Error:
                 actives = []
             for row in actives:
-                if forgotten >= FORGET_MAX_PER_RUN:
-                    break
                 edge_id = str(row["edge_id"])
                 anchor = max(
                     str(row["created_at"] or ""),
                     last_hit.get(edge_id, ""),
-                    first_run_at,
+                    first_injection_at,
                 )
-                if anchor and anchor < cutoff:
-                    result = transition_edge_state(
-                        conn, edge_id, "invalidated", roots=roots,
-                    )
-                    if result and result.get("state") == "invalidated":
-                        forgotten += 1
-                        last_hit.pop(edge_id, None)
-                    else:
-                        failed += 1
+                if not anchor or anchor >= cutoff:
+                    continue
+                # 全量计数 eligible(积压可见性):cap 只限制本轮处决数,
+                # 大规模遗忘潮会摊成多轮 — 监控要能看到待遗忘积压,否则
+                # 看起来像闭环卡住。
+                forget_eligible += 1
+                if forgotten >= FORGET_MAX_PER_RUN:
+                    continue
+                never_hit = edge_id not in last_hit
+                result = transition_edge_state(
+                    conn, edge_id, "invalidated", roots=roots,
+                )
+                if result and result.get("state") == "invalidated":
+                    forgotten += 1
+                    if never_hit:
+                        # 从未获得任何展示机会就被判「无命中」— 该计数若
+                        # 居高不下,说明探索轮转覆盖不足(饿死信号),不是
+                        # 边没价值。
+                        invalidated_never_hit += 1
+                    last_hit.pop(edge_id, None)
+                else:
+                    failed += 1
     finally:
         conn.close()
 
     # ── 3. Persist cursor + hit watermarks (durable state) ─────────────
     state_out = {
-        "schema_version": "memory-os.edge_weight_feedback_state.v0",
+        "schema_version": "memory-os.edge_weight_feedback_state.v1",
         "first_run_at": first_run_at,
+        "first_injection_at": first_injection_at,
         "processed_line_count": len(lines),
         "edge_last_hit": last_hit,
         "updated_at": current.isoformat(),
@@ -183,10 +228,12 @@ def run_edge_weight_feedback(
     except Exception:
         failed += 1
 
-    if reinforced or forgotten:
+    if reinforced or forgotten or already_saturated:
         outcome = "reinforced"
     elif not shadow_exists:
         outcome = "no_shadow_ledger"
+    elif not first_injection_at:
+        outcome = "injection_never_live"
     else:
         outcome = "no_new_hits"
 
@@ -196,7 +243,11 @@ def run_edge_weight_feedback(
         "outcome": outcome,
         "new_hit_record_count": len(new_lines),
         "reinforced_count": reinforced,
+        "already_saturated_count": already_saturated,
+        "skipped_not_injected_count": skipped_not_injected,
         "forgotten_count": forgotten,
+        "invalidated_never_hit_count": invalidated_never_hit,
+        "forget_eligible_backlog": max(0, forget_eligible - forgotten),
         "unresolved_hit_count": unresolved_hits,
         "failed_count": failed,
         "tracked_edge_count": len(last_hit),

--- a/plugins/memory/memory_os/edge_weight_feedback.py
+++ b/plugins/memory/memory_os/edge_weight_feedback.py
@@ -35,7 +35,11 @@ from typing import Any
 from .audit import append_audit
 from .state_overlay import _atomic_write_json
 
-HIT_BOOST = 0.05
+# 乘性强化:w += RATE × (1 − w)。1.0 是不可达渐近线 — 高分区并列消失
+# (排序始终有区分度),且 weight==1.0 从此可判定为未迁移遗留行。出生
+# 0.55 起 5 次命中 ≈0.76、10 次 ≈0.86、20 次 ≈0.96。旧版加性 +0.05 在
+# 全 1.0 出生权重下永远抬不动任何边(P3)。
+HIT_LEARNING_RATE = 0.12
 FORGET_AFTER_DAYS = 60
 FORGET_MAX_PER_RUN = 50
 STATE_FILENAME = "edge_weight_feedback_state.json"
@@ -152,8 +156,12 @@ def run_edge_weight_feedback(
                     unresolved_hits += 1
                     continue
                 edge_id = str(row["edge_id"])
+                current_weight = float(row["weight"])
                 result = update_edge_weight(
-                    conn, edge_id, float(row["weight"]) + HIT_BOOST, roots=roots,
+                    conn,
+                    edge_id,
+                    current_weight + HIT_LEARNING_RATE * (1.0 - current_weight),
+                    roots=roots,
                 )
                 if result and result.get("weight_update_noop"):
                     # F3:权重已在目标值(饱和)— 强化没有发生,不许计成

--- a/plugins/memory/memory_os/edge_weights.py
+++ b/plugins/memory/memory_os/edge_weights.py
@@ -1,0 +1,55 @@
+"""Edge birth weights — 按证据强度分层的出生权重(P3 2026-08-07)。
+
+背景:三个 proposer 曾全部以 weight=1.0 产边 = 反馈 cap。后果:
+`query_edges` 的 `order by weight desc` 全并列,退化成「最新优先」;
+命中强化(cap 1.0)永远抬不动已在顶的边 — R4 提升半环生来 no-op,
+只有 60 天遗忘半环在工作;注入的 weight<0.3 噪声下限过滤不了任何
+东西。出生权重按证据强度分层且留出爬升空间后,权重才真正承担排序
+职责:命中的边向 1.0 渐近(乘性强化,cap 不可达),没命中的停在
+出生位直到遗忘。
+
+守卫契约(见 test_memory_os_edge_weights.py):
+- 每个 producer 产边分支的 (proposed_by, evidence_kind) 必须在表内
+  (未知键 KeyError,fail loud);
+- min(出生权重) >= prefetch.GRAPH_INJECTION_WEIGHT_FLOOR(下限是不设防
+  安全底线,不是真实过滤);
+- max(出生权重及 llm 上界) < 1.0(weight==1.0 从此可判定为未迁移
+  遗留行 — 重归一脚本与监控依赖此不变量);
+- vector 例外:weight=cosine 相似度(本就有区分度),不走本表。
+"""
+from __future__ import annotations
+
+# (proposed_by, evidence_kind) → 出生权重。证据强度排序:
+#   explicit_reference      正文显式引用对方 record_id(硬证据,误报率最低)
+#   source_event_provenance event→crystallized 溯源(硬证据)
+#   shared_source_event     共享 source_event(同源 ≠ 相关)
+#   body_similarity         词面重叠(dice)
+#   temporal_proximity      仅时间邻近(最弱信号,「无其他信号」兜底分支)
+EDGE_BIRTH_WEIGHTS: dict[tuple[str, str], float] = {
+    ("structural", "explicit_reference"): 0.70,
+    ("structural", "shared_source_event"): 0.55,
+    ("structural", "body_similarity"): 0.45,
+    ("structural", "temporal_proximity"): 0.35,
+    ("provenance", "source_event_provenance"): 0.70,
+}
+
+# llm 边:confidence 本就被 _call_llm 采集,旧实现在写入时硬编码 1.0
+# 丢弃(「confidence is provenance only」)— 复用而非重建。
+# confidence ∈ [0,1] → weight ∈ [0.45, 0.75]。
+LLM_BIRTH_BASE = 0.45
+LLM_BIRTH_CONFIDENCE_SPAN = 0.30
+
+
+def birth_weight(proposed_by: str, evidence_kind: str) -> float:
+    """查表出生权重;未知键抛 KeyError — 新 producer 分支必须先登记,
+    守卫测试对照 producer 实际产出钉死(词表漂移的 gate 什么也不检查)。"""
+    return EDGE_BIRTH_WEIGHTS[(str(proposed_by), str(evidence_kind))]
+
+
+def llm_birth_weight(confidence: object) -> float:
+    """llm 边出生权重:0.45 + 0.30 × confidence(越界/非法值按 0)。"""
+    try:
+        bounded = min(1.0, max(0.0, float(confidence)))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        bounded = 0.0
+    return round(LLM_BIRTH_BASE + LLM_BIRTH_CONFIDENCE_SPAN * bounded, 4)

--- a/plugins/memory/memory_os/index.py
+++ b/plugins/memory/memory_os/index.py
@@ -1585,8 +1585,13 @@ def update_edge_weight(
     col_names = [str(c[1]) for c in conn.execute("pragma table_info(memory_edges)").fetchall()]
     current = dict(zip(col_names, row))
     bounded = min(1.0, max(0.0, float(new_weight)))
-    if float(current.get("weight") or 0.0) == bounded:
-        return current  # no-op
+    if abs(float(current.get("weight") or 0.0) - bounded) < 0.005:
+        # No-op must be DISTINGUISHABLE from a real write(F3):旧版返回真值
+        # dict,R4 把从未发生的强化计成 reinforced(生产首轮 32 条全部如此)。
+        # 0.005 最小增量下限同时防止乘性强化在 cap 附近每次命中都向
+        # graph/edges.jsonl 追加一条几乎相同的 canonical 行(index_sync 每
+        # 30 分钟全量重投影该文件)。
+        return {**current, "weight_update_noop": True}
     updated_edge = {
         "edge_id": str(current.get("edge_id", "")),
         "from_record_type": str(current.get("from_record_type", "")),

--- a/plugins/memory/memory_os/knob_overrides.py
+++ b/plugins/memory/memory_os/knob_overrides.py
@@ -69,9 +69,15 @@ OVERRIDABLE_KNOBS: dict[str, dict[str, Any]] = {
         "scope": "upper_layer",
         "ab_metric": None,
     },
+    # Graph injection. Default True: owner 裁定(2026-08-06/07)图谱为永久
+    # 能力,不需要人工介入 — the switch exists for rollback, not for
+    # graduation(同 lane_continuity_freshness_enabled 先例)。旧默认 False
+    # 靠一条无过期 override 撑着:override 一旦丢失/误撤,注入静默变暗且
+    # 监控结构上看不见(E5 事故形状)。注意 resolve_knob 用调用点传入的
+    # default,此处仅元数据 — 与 prefetch 调用点同步翻转。
     "graph_layer_injection_enabled": {
         "module": "prefetch",
-        "default": False,
+        "default": True,
         "kind": "lane_switch",
         "allowed": [True, False],
         "meta": False,

--- a/plugins/memory/memory_os/llm_edge_proposer.py
+++ b/plugins/memory/memory_os/llm_edge_proposer.py
@@ -309,15 +309,19 @@ def run_llm_proposer(
             # 取代旧的 §6/G4/T2.3.2 需审契约 — 动态图谱不占审批带宽)。
             init_state = "active"
 
-            # Write edge — weight=1.0 for Phase 1-2 (confidence is provenance only)
+            # P3:出生权重 = 0.45 + 0.30 × confidence — confidence 本就被
+            # _call_llm 采集,旧实现写入时硬编码 1.0 丢弃(出生即饱和,
+            # 权重排序与命中强化双双失效)。
             if index and hasattr(index, "write_governed_edge"):
+                from .edge_weights import llm_birth_weight
+
                 edge = index.write_governed_edge(
                     from_record_type="crystallized_record",
                     from_record_id=records[i]["id"],
                     to_record_type="crystallized_record",
                     to_record_id=records[j]["id"],
                     relation_type=rtype,
-                    weight=1.0,
+                    weight=llm_birth_weight(confidence),
                     source_event_id=None,
                     proposed_by="llm",
                     state=init_state,

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -2009,6 +2009,20 @@ GRAPH_DEDUP_PREVIEW_CHARS = 60
 
 _GRAPH_CRYSTALLIZED_TYPES = frozenset({"crystallized_record", "crystallized"})
 
+# Shadow v1 每边 outcome 的封闭集(Completion Is Not Output:无输出的边
+# 必须能从账本读出原因,不需要重跑或读源码)。emitted_* 两值 injected=True,
+# 其余 injected=False。守卫测试对照渲染器实际产出双向钉死。
+GRAPH_SHADOW_OUTCOMES = frozenset({
+    "emitted_full",
+    "emitted_stub",
+    "below_weight_floor",
+    "target_inactive",
+    "non_crystallized_target",
+    "unresolved",
+    "not_selected",
+    "knob_disabled",
+})
+
 
 def _graph_layer_shadow_lines(
     store: MemoryOSStore,
@@ -2048,9 +2062,6 @@ def _graph_layer_shadow_lines(
     if not edges:
         return []
 
-    # ── Shadow log ALWAYS written (audit trail) ─────────────────
-    _record_graph_layer_shadow(store, anchor_ids, edges)
-
     # ── Knob gate ──────────────────────────────────────────────
     from .knob_overrides import resolve_knob as _resolve_knob
     injection_enabled = _resolve_knob(
@@ -2059,9 +2070,18 @@ def _graph_layer_shadow_lines(
         roots=store.roots,
     )
     if not injection_enabled:
+        # Shadow v1:knob 关闭也落账,但每条边标记 injected=False/
+        # knob_disabled — 旧版在 knob 门之前写入,「查到边」与「注入命中」
+        # 共用一份语义,权重反馈闭环会把从未展示过的边当命中强化(F2)。
+        decisions = [
+            {"edge": edge, "injected": False, "outcome": "knob_disabled"}
+            for edge in edges
+            if isinstance(edge, dict)
+        ]
+        _record_graph_layer_shadow(store, anchor_ids, decisions)
         return []
 
-    lines, _decisions = _render_graph_layer_lines(
+    lines, decisions = _render_graph_layer_lines(
         store,
         edges,
         anchor_ids=anchor_ids,
@@ -2069,6 +2089,8 @@ def _graph_layer_shadow_lines(
         source_ids=source_ids,
         events=events,
     )
+    # ── Shadow log written AFTER rendering (audit trail, v1) ────
+    _record_graph_layer_shadow(store, anchor_ids, decisions)
     return lines
 
 
@@ -2309,11 +2331,17 @@ def _render_graph_layer_lines(
 def _record_graph_layer_shadow(
     store: MemoryOSStore,
     anchor_ids: list[str],
-    edges: list[dict],
+    decisions: list[dict],
 ) -> None:
     """Append a bounded shadow record to system/graph_layer_shadow.jsonl.
 
-    Matches the SubstrateRecall shadow-log pattern but for graph edges.
+    Schema v1(F2 2026-08-07):写入发生在渲染**之后**,每条边带
+    ``injected``(是否真实进入 agent 上下文)与封闭 ``outcome``
+    (GRAPH_SHADOW_OUTCOMES)。v0 在 knob 门之前落账,「查到边」与「注入
+    命中」混用一份文件 — 权重反馈闭环把 knob 关闭/被过滤的边也当命中
+    强化。anchor_ids 同步写入(v0 只有 anchor_count,F1 类方向问题在生产
+    数据上无法回溯测量)。
+
     This is purely audit/inspection data — NOT injected into agent context.
     """
     path = store.roots.memory_os_root / "system" / "graph_layer_shadow.jsonl"
@@ -2322,29 +2350,40 @@ def _record_graph_layer_shadow(
     except Exception:
         return  # fail-open: shadow loss must not break prefetch
     _now_stamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    edge_rows = []
+    injected_count = 0
+    for decision in decisions:
+        if not isinstance(decision, dict):
+            continue
+        edge = decision.get("edge")
+        if not isinstance(edge, dict):
+            continue
+        injected = bool(decision.get("injected", False))
+        if injected:
+            injected_count += 1
+        edge_rows.append({
+            "relation_type": str(edge.get("relation_type", "unknown")),
+            "from_record_type": str(edge.get("from_record_type", "")),
+            "from_record_id": str(edge.get("from_record_id", "")),
+            "to_record_type": str(edge.get("to_record_type", "")),
+            "to_record_id": str(edge.get("to_record_id", "")),
+            "weight": float(edge.get("weight", 1.0)),
+            "injected": injected,
+            "outcome": str(decision.get("outcome", "") or "unknown"),
+        })
     record = {
-        "schema_version": "memory-os.graph_layer_shadow.v0",
-        "phase": "1",
+        "schema_version": "memory-os.graph_layer_shadow.v1",
         "anchor_count": len(anchor_ids),
-        "edge_count": len(edges),
+        "anchor_ids": [str(a) for a in anchor_ids],
+        "edge_count": len(edge_rows),
+        "injected_count": injected_count,
         # created_at is the name metadata_retention._record_created_at ages on
         # (backlog 9); recorded_at stays for existing readers of this ledger.
         # Forward-only: historical recorded_at-only rows remain unaged -- an
         # owner decision, recorded in the backlog.
         "created_at": _now_stamp,
         "recorded_at": _now_stamp,
-        "edges": [
-            {
-                "relation_type": str(edge.get("relation_type", "unknown")),
-                "from_record_type": str(edge.get("from_record_type", "")),
-                "from_record_id": str(edge.get("from_record_id", "")),
-                "to_record_type": str(edge.get("to_record_type", "")),
-                "to_record_id": str(edge.get("to_record_id", "")),
-                "weight": float(edge.get("weight", 1.0)),
-            }
-            for edge in edges
-            if isinstance(edge, dict)
-        ],
+        "edges": edge_rows,
     }
     try:
         from .jsonl_io import append_jsonl_locked

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -662,7 +662,12 @@ def _build_prefetch_sections(
         sections,
         "Related Memory",
         _graph_layer_shadow_lines(
-            store, _first_anchors, index=index, seen=seen, source_ids=graph_ids
+            store,
+            _first_anchors,
+            index=index,
+            seen=seen,
+            source_ids=graph_ids,
+            events=events_cache,
         ),
     )
     if graph_ids:
@@ -1975,6 +1980,35 @@ def _collect_anchor_ids(query: str, index: object | None) -> list[str]:
 # PROMOTION_TARGET_STATE 一起被双向守卫测试钉死。
 GRAPH_INJECTION_EDGE_STATE = "active"
 
+# 图谱注入行的方向敏感关系短语表(主语固定为锚点侧)。Module 级:短语词表
+# 必须能被守卫测试对照 producer 实际产出的 relation_type 全集双向校验——
+# 词表与 producer 漂移的 gate 什么也不检查(CLAUDE.md「词表漂移」教训)。
+GRAPH_RELATION_PHRASES: dict[tuple[str, str], str] = {
+    ("co_occurs", "anchor_is_from"): "同源共现于",
+    ("co_occurs", "anchor_is_to"): "同源共现于",
+    ("depends_on", "anchor_is_from"): "依赖于",
+    ("depends_on", "anchor_is_to"): "被以下内容依赖",
+    ("refines", "anchor_is_from"): "细化了",
+    ("refines", "anchor_is_to"): "被以下内容细化",
+    ("evidence_for", "anchor_is_from"): "佐证了",
+    ("evidence_for", "anchor_is_to"): "其证据为",
+    ("contradicts", "anchor_is_from"): "与以下内容冲突",
+    ("contradicts", "anchor_is_to"): "与以下内容冲突",
+}
+# 未知 relation_type 的兜底短语(方向无关)。
+GRAPH_FALLBACK_PHRASE = "关联于"
+
+# 注入的权重噪声下限。出生权重分层后这是不设防的安全底线(守卫测试钉
+# min(出生权重) >= 此值),真实排序依赖权重本身,不依赖它。
+GRAPH_INJECTION_WEIGHT_FLOOR = 0.3
+GRAPH_MAX_LINES = 8
+GRAPH_ANCHOR_PREVIEW_CHARS = 12
+# 跨段去重命中的短预览长度:是结晶段同一正文 220 字符裁剪的精确前缀,
+# 对阅读方 LLM 是零歧义对齐键(比 record_id 可靠——其它区段不显示 id)。
+GRAPH_DEDUP_PREVIEW_CHARS = 60
+
+_GRAPH_CRYSTALLIZED_TYPES = frozenset({"crystallized_record", "crystallized"})
+
 
 def _graph_layer_shadow_lines(
     store: MemoryOSStore,
@@ -1983,16 +2017,14 @@ def _graph_layer_shadow_lines(
     index: object | None = None,
     seen: set[tuple[str, str]] | None = None,
     source_ids: list[str] | None = None,
+    events: list[Any] | None = None,
 ) -> list[str]:
-    """Phase 2: knob-gated graph layer edge injection with shadow audit.
+    """Knob-gated graph layer edge injection with shadow audit.
 
-    Under Phase 1 (knob disabled): writes candidate edges to
-    system/graph_layer_shadow.jsonl for audit and returns [] so no
-    hash-record-id pairs enter the agent's memory-context block.
-
-    Under Phase 2 (knob enabled): resolves edge targets to human-readable
-    body previews, applies cross-section dedup, and returns injection lines
-    for the Related Memory section. Shadow log is written regardless.
+    Knob disabled: writes candidate edges to system/graph_layer_shadow.jsonl
+    for audit and returns []. Knob enabled: renders direction-normalized,
+    human-readable Related Memory lines (see _render_graph_layer_lines).
+    Shadow log is written regardless.
 
     Rules:
     - anchor_ids: 第一跳选出的 record_id 集合(来自 FTS5 hit)
@@ -2003,6 +2035,7 @@ def _graph_layer_shadow_lines(
     - anchor_ids 为空 → 直接返回 [] (空 shadow 是诚实信号)
     - Config gate: graph_layer_injection_enabled knob (default=False)
     - Cross-section dedup via `seen` set
+    - events: 调用方的 events 缓存,用于事件类锚点/邻居的预览解析
     """
     if not anchor_ids:
         return []
@@ -2028,133 +2061,249 @@ def _graph_layer_shadow_lines(
     if not injection_enabled:
         return []
 
-    # ── Phase 2 injection ──────────────────────────────────────
-    return _graph_layer_injection_lines(store, edges, seen=seen, source_ids=source_ids)
+    lines, _decisions = _render_graph_layer_lines(
+        store,
+        edges,
+        anchor_ids=anchor_ids,
+        seen=seen,
+        source_ids=source_ids,
+        events=events,
+    )
+    return lines
 
 
-def _resolve_edge_target_preview(
+def _batch_resolve_crystallized(
     store: MemoryOSStore,
+    record_ids: set[str] | list[str],
+) -> dict[str, Any]:
+    """Resolve a bounded id set in ONE pass over the crystallized store.
+
+    逐 id 调 CrystallizedMemoryService.find_record 会对每个 id 重新 glob 全部
+    结晶文件(热路径最坏 2×8 次全量扫描);这里一次遍历建 {id: record} 映射,
+    预览解析与 inactive 判定共用同一份 record。fail-open:异常返回已收集的
+    部分映射。
+    """
+    wanted = {str(r).strip() for r in record_ids if str(r or "").strip()}
+    found: dict[str, Any] = {}
+    if not wanted:
+        return found
+    try:
+        svc = CrystallizedMemoryService(store)
+        root = store.roots.crystallized_root
+        if not root.exists():
+            return found
+        for path in sorted(root.glob("*.md")):
+            for record in svc.read_records(path.name):
+                rid = str(record.frontmatter.get("id") or "")
+                if rid in wanted and rid not in found:
+                    found[rid] = record
+            if len(found) == len(wanted):
+                break
+    except Exception:
+        return found
+    return found
+
+
+def _graph_preview(
     record_id: str,
-) -> str | None:
-    """Resolve a record_id to a human-readable body preview for graph edges.
+    record_type: str,
+    cry_map: dict[str, Any],
+    event_summaries: dict[str, str],
+) -> tuple[str | None, str]:
+    """Resolve a graph edge endpoint to ``(redacted_preview, status)``.
 
-    Returns a clipped+redacted body preview, or None if the record
-    cannot be found / is inactive / has no parseable body.
-
-    Fail-open: any exception -> None (graph injection degrades gracefully).
+    status ∈ {"ok", "inactive", "missing"}。结晶记录走批量映射(inactive 与
+    missing 可区分),事件走调用方 events 缓存;其余一律 missing(fail-open)。
     """
     normalized = str(record_id or "").strip()
     if not normalized:
-        return None
-    try:
-        svc = CrystallizedMemoryService(store)
-        record = svc.find_record(normalized)
-        if record is None or not is_active_crystallized_frontmatter(record.frontmatter):
-            return None
-        text = _redact(_clip(record.body, 180))
-        if not text or _is_diagnostic_style_seed(text):
-            return None
-        return text
-    except Exception:
-        return None
+        return None, "missing"
+    record = cry_map.get(normalized)
+    if record is not None:
+        try:
+            if not is_active_crystallized_frontmatter(record.frontmatter):
+                return None, "inactive"
+            text = _redact(_clip(str(record.body or ""), 220))
+            if not text or _is_diagnostic_style_seed(text):
+                return None, "missing"
+            return text, "ok"
+        except Exception:
+            return None, "missing"
+    summary = event_summaries.get(normalized, "")
+    if summary:
+        text = _redact(_clip(summary, 220))
+        if text and not _is_diagnostic_style_seed(text):
+            return text, "ok"
+    return None, "missing"
 
 
-def _edge_target_is_inactive(store: MemoryOSStore, record_id: str) -> bool:
-    normalized = str(record_id or "").strip()
-    if not normalized:
-        return False
-    try:
-        record = CrystallizedMemoryService(store).find_record(normalized)
-    except Exception:
-        return False
-    return record is not None and not is_active_crystallized_frontmatter(record.frontmatter)
-
-
-def _graph_layer_injection_lines(
+def _render_graph_layer_lines(
     store: MemoryOSStore,
     edges: list[dict],
     *,
+    anchor_ids: list[str],
     seen: set[tuple[str, str]] | None = None,
     source_ids: list[str] | None = None,
-) -> list[str]:
-    """Format graph edges as human-readable injection lines for agent context.
+    events: list[Any] | None = None,
+) -> tuple[list[str], list[dict]]:
+    """Render graph edges as owner-readable Related Memory lines.
 
-    Each edge produces one line: relation_type, weight, and resolved body
-    preview of the target record. If the target cannot be resolved, falls
-    back to showing the record_id (fail-open -- hash is better than silence).
+    行文法(F1/P2 2026-08-07):方向归一 + 中文自然语言短语 + 锚点短预览:
 
-    Cross-section dedup: records already in `seen` are skipped; newly
-    emitted records are added to `seen`.
+        - 「{锚点预览}」{关系短语}:{邻居正文预览}({已列出·}关联度 {w:.2f})
 
-    Rules:
-    - Max 8 lines (matches edge query limit=8)
-    - Each line <= 220 chars (matches other section caps)
-    - Edge weight < 0.3 is skipped (low-confidence noise)
-    - Fail-open: any resolution error -> fallback to record_id
+    规则:
+    - 方向归一:展示目标永远是边上非锚点的一端(neighbor)。旧实现无条件取
+      to_record_id — 当边是「X→锚点」时会把锚点自己当"关联记忆"展示,且
+      depends_on 的方向语义读反。
+    - 永不打印 record_id:解析失败整行丢弃(诊断归 shadow 账本的 outcome,
+      不进 agent 上下文 — 旧 [unresolved:id] 行会诱导 LLM 编造引用)。
+    - 跨段去重命中不丢行(继承 E8c):降级为 60 字符短预览 + 「已列出·」
+      标记 — 短预览是结晶段同一正文的精确前缀,零歧义对齐键。
+    - 同一 (锚点,邻居) 的多条边聚合为一行,短语「、」连接,关联度取最大。
+    - 每行 ≤220 字符、最多 GRAPH_MAX_LINES 行、weight < FLOOR 跳过。
+    - 返回 (lines, decisions):decisions 给每条边一个封闭 outcome
+      (emitted_full / emitted_stub / below_weight_floor / target_inactive /
+      non_crystallized_target / unresolved / not_selected),供 shadow 账本
+      区分「注入」与「查到但未注入」。
     """
-    MAX_LINES = 8
-    lines: list[str] = []
+    anchor_set = {str(a).strip() for a in anchor_ids if str(a or "").strip()}
+    decisions: list[dict] = []
+
+    # ── 1. 方向归一 + 权重下限 ─────────────────────────────────────
+    workable: list[dict] = []
     for edge in edges:
         if not isinstance(edge, dict):
             continue
-        if len(lines) >= MAX_LINES:
-            break
-
+        from_id = str(edge.get("from_record_id") or "").strip()
+        to_id = str(edge.get("to_record_id") or "").strip()
+        if not from_id or not to_id:
+            continue
         weight = float(edge.get("weight", 1.0))
-        if weight < 0.3:
-            continue  # low-confidence edge, not worth agent context
-
-        to_type = str(edge.get("to_record_type", "unknown"))
-        to_id = str(edge.get("to_record_id", ""))
-        relation = str(edge.get("relation_type", "related"))
-
-        if not to_id:
+        if weight < GRAPH_INJECTION_WEIGHT_FLOOR:
+            decisions.append(
+                {"edge": edge, "injected": False, "outcome": "below_weight_floor"}
+            )
             continue
-
-        # Cross-section dedup — E8c: a target already shown by another
-        # section is NOT silently dropped.  "These two already-shown
-        # memories are RELATED" is information only the graph carries; in
-        # the small-graph phase the retrieval hit set and the one-hop
-        # neighborhood overlap heavily, so silent dedup kept the Related
-        # Memory section permanently empty (production 2026-08-07: edges
-        # found + shadow written, zero lines).  Emit a short relation stub
-        # (↺ = already shown above) instead of the full body.
-        if seen is not None and to_type and to_id:
-            if (to_type, to_id) in seen:
-                stub_ref = _clip(to_id, 40)
-                weight_str = f"{weight:.2f}".rstrip("0").rstrip(".")
-                lines.append(f"- [{relation}·{weight_str}] ↺ {stub_ref}")
-                if source_ids is not None:
-                    source_ids.append(f"{to_type}:{to_id}")
-                continue
-
-        # Resolve target body preview
-        body = _resolve_edge_target_preview(store, to_id)
-        if body:
-            display_text = body
-        elif _edge_target_is_inactive(store, to_id):
-            # Never turn a revoked/demoted canonical target into an unresolved
-            # identifier-only recall line; inactive targets are fully suppressed.
-            continue
-        elif to_type not in {"crystallized_record", "crystallized"}:
-            # W4: non-crystallized targets (events, working items) age out of
-            # hot storage by design (retention prunes events); an unresolved
-            # identifier line for them is pure noise, not a diagnostic.
-            continue
+        if to_id in anchor_set and from_id not in anchor_set:
+            direction = "anchor_is_to"
+            anchor_id, anchor_type = to_id, str(edge.get("to_record_type") or "")
+            neighbor_id, neighbor_type = from_id, str(edge.get("from_record_type") or "")
         else:
-            # Missing crystallized targets remain diagnosable without
-            # exposing inactive content.
-            display_text = f"[unresolved:{to_id}]"
+            # 锚点在 from 侧;两端皆锚点或(防御)两端皆非锚点时同样取 to 为
+            # 展示目标 — 行仍表达「两条已知记忆相关」这一图谱独有信息。
+            direction = "anchor_is_from"
+            anchor_id, anchor_type = from_id, str(edge.get("from_record_type") or "")
+            neighbor_id, neighbor_type = to_id, str(edge.get("to_record_type") or "")
+        workable.append({
+            "edge": edge,
+            "weight": weight,
+            "direction": direction,
+            "anchor_id": anchor_id,
+            "anchor_type": anchor_type,
+            "neighbor_id": neighbor_id,
+            "neighbor_type": neighbor_type,
+        })
 
-        weight_str = f"{weight:.2f}".rstrip("0").rstrip(".")
-        lines.append(f"- [{relation}·{weight_str}] {display_text}")
+    if not workable:
+        return [], decisions
 
-        if seen is not None and to_type and to_id:
-            seen.add((to_type, to_id))
-        if source_ids is not None and to_type and to_id:
-            source_ids.append(f"{to_type}:{to_id}")
+    # ── 2. 预览源批量解析(一次结晶扫描 + events 缓存)────────────────
+    preview_ids: set[str] = set()
+    for item in workable:
+        preview_ids.add(item["anchor_id"])
+        preview_ids.add(item["neighbor_id"])
+    cry_map = _batch_resolve_crystallized(store, preview_ids)
+    event_summaries: dict[str, str] = {}
+    for ev in events or []:
+        try:
+            ev_id = str(getattr(ev, "id", "") or "")
+            if ev_id and ev_id in preview_ids:
+                event_summaries[ev_id] = str(getattr(ev, "summary", "") or "")
+        except Exception:
+            continue
 
-    return lines
+    # ── 3. 按 (锚点,邻居) 聚合 ─────────────────────────────────────
+    groups: dict[tuple[str, str], dict] = {}
+    for item in workable:
+        key = (item["anchor_id"], item["neighbor_id"])
+        group = groups.setdefault(key, {
+            "anchor_id": item["anchor_id"],
+            "anchor_type": item["anchor_type"],
+            "neighbor_id": item["neighbor_id"],
+            "neighbor_type": item["neighbor_type"],
+            "phrases": [],
+            "weight": 0.0,
+            "items": [],
+        })
+        phrase = GRAPH_RELATION_PHRASES.get(
+            (str(item["edge"].get("relation_type") or ""), item["direction"]),
+            GRAPH_FALLBACK_PHRASE,
+        )
+        if phrase not in group["phrases"]:
+            group["phrases"].append(phrase)
+        group["weight"] = max(group["weight"], item["weight"])
+        group["items"].append(item)
+
+    # ── 4. 渲染 ────────────────────────────────────────────────────
+    lines: list[str] = []
+    for group in groups.values():
+        if len(lines) >= GRAPH_MAX_LINES:
+            for item in group["items"]:
+                decisions.append(
+                    {"edge": item["edge"], "injected": False, "outcome": "not_selected"}
+                )
+            continue
+
+        n_text, n_status = _graph_preview(
+            group["neighbor_id"], group["neighbor_type"], cry_map, event_summaries,
+        )
+        if n_status != "ok" or not n_text:
+            if n_status == "inactive":
+                # Revoked/demoted canonical targets are fully suppressed.
+                outcome = "target_inactive"
+            elif group["neighbor_type"] in _GRAPH_CRYSTALLIZED_TYPES:
+                outcome = "unresolved"
+            else:
+                # W4: 非结晶目标(事件等)按保留策略淡出热存储,解析失败的
+                # 标识符行是纯噪声,不是诊断。
+                outcome = "non_crystallized_target"
+            for item in group["items"]:
+                decisions.append(
+                    {"edge": item["edge"], "injected": False, "outcome": outcome}
+                )
+            continue
+
+        a_text, a_status = _graph_preview(
+            group["anchor_id"], group["anchor_type"], cry_map, event_summaries,
+        )
+        if a_status == "ok" and a_text:
+            anchor_label = _clip(a_text, GRAPH_ANCHOR_PREVIEW_CHARS)
+        elif group["anchor_type"] == "event":
+            anchor_label = "近期事件"
+        else:
+            anchor_label = "相关记忆"
+
+        dedup_hit = (
+            seen is not None
+            and (group["neighbor_type"], group["neighbor_id"]) in seen
+        )
+        prefix = f"- 「{anchor_label}」{'、'.join(group['phrases'])}:"
+        suffix = f"({'已列出·' if dedup_hit else ''}关联度 {group['weight']:.2f})"
+        body_budget = max(40, 220 - len(prefix) - len(suffix))
+        if dedup_hit:
+            body_budget = min(body_budget, GRAPH_DEDUP_PREVIEW_CHARS)
+        lines.append(prefix + _clip(n_text, body_budget) + suffix)
+
+        outcome = "emitted_stub" if dedup_hit else "emitted_full"
+        for item in group["items"]:
+            decisions.append({"edge": item["edge"], "injected": True, "outcome": outcome})
+        if seen is not None:
+            seen.add((group["neighbor_type"], group["neighbor_id"]))
+        if source_ids is not None:
+            source_ids.append(f"{group['neighbor_type']}:{group['neighbor_id']}")
+
+    return lines, decisions
 
 
 def _record_graph_layer_shadow(

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -6,6 +6,7 @@ import functools
 import json
 import re
 import unicodedata
+import zlib
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
@@ -2002,6 +2003,13 @@ GRAPH_FALLBACK_PHRASE = "关联于"
 # min(出生权重) >= 此值),真实排序依赖权重本身,不依赖它。
 GRAPH_INJECTION_WEIGHT_FLOOR = 0.3
 GRAPH_MAX_LINES = 8
+# 候选取数放宽到 32(SQL 已按 weight desc 排序,SQLite+索引成本可忽略),
+# Python 侧再选注入位:top-6 按权重 + 2 个探索位。探索位是反饿死机制 —
+# 分层出生权重若单独存在,排序固化后弱边永无展示 → 永无命中 → 60 天被
+# 判「无命中」处决(自我实现遗忘;生产密度约 110 边/结晶记录抢 8 名额)。
+GRAPH_EDGE_CANDIDATE_LIMIT = 32
+GRAPH_EXPLOIT_SLOTS = 6
+GRAPH_EXPLORE_SLOTS = 2
 GRAPH_ANCHOR_PREVIEW_CHARS = 12
 # 跨段去重命中的短预览长度:是结晶段同一正文 220 字符裁剪的精确前缀,
 # 对阅读方 LLM 是零歧义对齐键(比 record_id 可靠——其它区段不显示 id)。
@@ -2047,7 +2055,10 @@ def _graph_layer_shadow_lines(
     - state='active'
     - 不打断 main prefetch 路径(fail-open: 查询出错返回 [])
     - anchor_ids 为空 → 直接返回 [] (空 shadow 是诚实信号)
-    - Config gate: graph_layer_injection_enabled knob (default=False)
+    - Config gate: graph_layer_injection_enabled knob(default=True — owner
+      裁定图谱为永久能力;开关保留作回滚,写 False override 关火。旧默认
+      False 依赖一条无过期 override 撑着,override 丢失即静默变暗且监控
+      不响 — E5 事故形状)
     - Cross-section dedup via `seen` set
     - events: 调用方的 events 缓存,用于事件类锚点/邻居的预览解析
     """
@@ -2056,7 +2067,12 @@ def _graph_layer_shadow_lines(
     if index is None or not hasattr(index, "query_edges"):
         return []
     try:
-        edges = index.query_edges(anchor_ids, depth=1, state=GRAPH_INJECTION_EDGE_STATE, limit=8)
+        edges = index.query_edges(
+            anchor_ids,
+            depth=1,
+            state=GRAPH_INJECTION_EDGE_STATE,
+            limit=GRAPH_EDGE_CANDIDATE_LIMIT,
+        )
     except Exception:
         return []
     if not edges:
@@ -2064,9 +2080,11 @@ def _graph_layer_shadow_lines(
 
     # ── Knob gate ──────────────────────────────────────────────
     from .knob_overrides import resolve_knob as _resolve_knob
+    # 默认 True:注册表的 default 只是元数据,resolve_knob 用的是这里传入
+    # 的值 — 两处必须一致翻转(只改注册表运行时零变化)。
     injection_enabled = _resolve_knob(
         "graph_layer_injection_enabled",
-        default=False,
+        default=True,
         roots=store.roots,
     )
     if not injection_enabled:
@@ -2167,6 +2185,7 @@ def _render_graph_layer_lines(
     seen: set[tuple[str, str]] | None = None,
     source_ids: list[str] | None = None,
     events: list[Any] | None = None,
+    day_ordinal: int | None = None,
 ) -> tuple[list[str], list[dict]]:
     """Render graph edges as owner-readable Related Memory lines.
 
@@ -2230,7 +2249,37 @@ def _render_graph_layer_lines(
     if not workable:
         return [], decisions
 
-    # ── 2. 预览源批量解析(一次结晶扫描 + events 缓存)────────────────
+    # ── 2. 注入位选择:top-K 按权重 + 探索位(反饿死)─────────────────
+    # 权重降序(稳定排序保持 SQL 的 created_at desc 次序作并列平局);
+    # 排序尾部按天确定性轮转出 2 个探索位:无随机数(热路径必须可复现)、
+    # 不读反馈闭环的 durable state(不把热路径耦合到 cron lane)。
+    # 「从未获得展示机会」不得等价于「无命中」— 遗忘侧配套
+    # invalidated_never_hit 计数验证轮转覆盖。
+    workable.sort(key=lambda item: -item["weight"])
+    if len(workable) > GRAPH_EXPLOIT_SLOTS + GRAPH_EXPLORE_SLOTS:
+        exploit = workable[:GRAPH_EXPLOIT_SLOTS]
+        remainder = workable[GRAPH_EXPLOIT_SLOTS:]
+        if day_ordinal is None:
+            day_ordinal = datetime.now(timezone.utc).date().toordinal()
+
+        def _rotation_key(item: dict) -> int:
+            edge_id = str(
+                item["edge"].get("edge_id")
+                or f"{item['anchor_id']}:{item['neighbor_id']}"
+            )
+            # zlib.crc32:跨进程稳定(内建 hash() 对字符串带盐,重启即变)
+            return zlib.crc32(f"{day_ordinal}:{edge_id}".encode("utf-8"))
+
+        explore = sorted(remainder, key=_rotation_key)[:GRAPH_EXPLORE_SLOTS]
+        explore_marks = {id(item) for item in explore}
+        for item in remainder:
+            if id(item) not in explore_marks:
+                decisions.append(
+                    {"edge": item["edge"], "injected": False, "outcome": "not_selected"}
+                )
+        workable = exploit + explore
+
+    # ── 3. 预览源批量解析(一次结晶扫描 + events 缓存)────────────────
     preview_ids: set[str] = set()
     for item in workable:
         preview_ids.add(item["anchor_id"])
@@ -2245,7 +2294,7 @@ def _render_graph_layer_lines(
         except Exception:
             continue
 
-    # ── 3. 按 (锚点,邻居) 聚合 ─────────────────────────────────────
+    # ── 4. 按 (锚点,邻居) 聚合 ─────────────────────────────────────
     groups: dict[tuple[str, str], dict] = {}
     for item in workable:
         key = (item["anchor_id"], item["neighbor_id"])
@@ -2267,7 +2316,7 @@ def _render_graph_layer_lines(
         group["weight"] = max(group["weight"], item["weight"])
         group["items"].append(item)
 
-    # ── 4. 渲染 ────────────────────────────────────────────────────
+    # ── 5. 渲染 ────────────────────────────────────────────────────
     lines: list[str] = []
     for group in groups.values():
         if len(lines) >= GRAPH_MAX_LINES:

--- a/plugins/memory/memory_os/structural_edge_proposer.py
+++ b/plugins/memory/memory_os/structural_edge_proposer.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from .audit import append_audit
+from .edge_weights import birth_weight
 
 
 # Dice coefficient threshold for body-text similarity — above this the pair
@@ -126,7 +127,7 @@ def _detect_relation(
             "to_record_type": "crystallized_record",
             "to_record_id": rid_b,
             "relation_type": "co_occurs",
-            "weight": 1.0,
+            "weight": birth_weight("structural", "shared_source_event"),
             "source_event_id": shared_event,
             "proposed_by": "structural",
             "state": "active",
@@ -142,7 +143,7 @@ def _detect_relation(
             "to_record_type": "crystallized_record",
             "to_record_id": to_id,
             "relation_type": "depends_on",
-            "weight": 1.0,
+            "weight": birth_weight("structural", "explicit_reference"),
             "source_event_id": None,
             "proposed_by": "structural",
             "state": "active",
@@ -167,7 +168,7 @@ def _detect_relation(
                 "to_record_type": "crystallized_record",
                 "to_record_id": rid_b,
                 "relation_type": rtype,
-                "weight": 1.0,
+                "weight": birth_weight("structural", "body_similarity"),
                 "source_event_id": None,
                 "proposed_by": "structural",
                 "state": "active",
@@ -185,7 +186,7 @@ def _detect_relation(
                 "to_record_type": "crystallized_record",
                 "to_record_id": rid_b,
                 "relation_type": "co_occurs",
-                "weight": 1.0,
+                "weight": birth_weight("structural", "temporal_proximity"),
                 "source_event_id": None,
                 "proposed_by": "structural",
                 "state": "active",

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -286,9 +286,14 @@ CLEAN_HOST_WARN_CLASSIFICATIONS: dict[str, dict[str, str]] = {
         "reason": "deployed cron registry snapshot resolves fewer group members than the installed registry defines - regenerate the snapshot (install/onboarding step)",
         "production_behavior": "warn_if_production",
     },
-    "v2_output_knob_override_expired": {
+    "v2_output_knob_override_mismatch": {
         "classification": "known_optional",
-        "reason": "an output-affecting knob override expired while enabled - owner decides renewal; clean hosts have no overrides so this only fires where one was configured",
+        "reason": "an output-affecting knob's effective value differs from its expected live value - owner decides; clean hosts have no overrides so the default resolves to the expected value and this stays silent",
+        "production_behavior": "warn_if_production",
+    },
+    "v2_graph_injection_shadow_collection_failed": {
+        "classification": "known_optional",
+        "reason": "graph injection shadow ledger could not be read - collection failure surfaced instead of a fabricated zero",
         "production_behavior": "warn_if_production",
     },
     "v2_output_knob_override_collection_failed": {
@@ -1724,23 +1729,39 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
                 "code": "v2_output_knob_override_state",
                 "value": _ok_knobs,
             })
-            _expired_enabled = [
+            # P1 2026-08-07:判据从「override 是否过期」换成「生效值是否为
+            # 期望值」。旧判据两个方向都错:confirmed 行过期后 resolver 仍
+            # 生效(假警),而默认翻 True 后真正的危险态是一条 active 的
+            # override_value=False(旧判据结构上看不见)。
+            _mismatched = [
                 name for name, row in _ok_knobs.items()
-                if isinstance(row, dict)
-                and row.get("present") is True
-                and bool(row.get("override_value"))
-                and row.get("expired") is True
+                if isinstance(row, dict) and row.get("mismatch") is True
             ]
-            if _expired_enabled:
+            if _mismatched:
                 warn.append({
-                    "code": "v2_output_knob_override_expired",
-                    "knobs": _expired_enabled,
-                    "value": {name: _ok_knobs.get(name) for name in _expired_enabled},
+                    "code": "v2_output_knob_override_mismatch",
+                    "knobs": _mismatched,
+                    "value": {name: _ok_knobs.get(name) for name in _mismatched},
                 })
         else:
             warn.append({
                 "code": "v2_output_knob_override_collection_failed",
                 "value": output_knob_override_state,
+            })
+
+    _gis_raw = snapshot.get("graph_injection_shadow")
+    if isinstance(_gis_raw, dict):
+        if _gis_raw.get("collected"):
+            # deliberately ungraded INFO:healthy_no_sample 在其面上说明
+            # 无样本(不买绿);knob 侧的 mismatch WARN 才是分级信号。
+            info.append({
+                "code": "v2_graph_injection_shadow_state",
+                "value": _gis_raw,
+            })
+        else:
+            warn.append({
+                "code": "v2_graph_injection_shadow_collection_failed",
+                "value": _gis_raw,
             })
 
     _classify_left_brain_signal_weaving(snapshot, passed, warn, fail, clean_host=clean_host)
@@ -7207,10 +7228,16 @@ def cognitive_loop_step_evidence():
 
 
 def output_knob_override_state():
-    # W6 (E5): expiry visibility for output-affecting knob overrides.
-    # graph_layer_injection_enabled's enabled override expired 2026-07-01
-    # with no monitor signal — injection went silently dark.
-    _output_knobs = ("graph_layer_injection_enabled",)
+    # W6 (E5) → P1 2026-08-07: the graded signal is now "effective value !=
+    # expected live value". The expiry-only check failed both directions:
+    # the resolver only expires state=='active' rows ('confirmed' outlives
+    # its expires_at → monitor cried wolf), and after the default flip the
+    # dangerous state is an ACTIVE override_value=False, which an expiry
+    # check structurally cannot see. Effective value comes from the deployed
+    # resolver itself — a mirrored reimplementation here is exactly how the
+    # expiry-vocabulary drift happened.
+    _expected_live = {"graph_layer_injection_enabled": True}
+    _output_knobs = tuple(_expected_live)
     path = os.path.join(_hermes_home, "memory-os/system/knob_overrides.jsonl")
     try:
         rows = _read_jsonl(path)
@@ -7226,30 +7253,113 @@ def output_knob_override_state():
     now = datetime.now(timezone.utc)
     knobs = {}
     for knob in _output_knobs:
+        expected = _expected_live[knob]
+        effective = None
+        effective_source = ""
+        try:
+            from pathlib import Path as _Path
+
+            from plugins.memory.memory_os.knob_overrides import (
+                OVERRIDABLE_KNOBS as _knob_specs,
+            )
+            from plugins.memory.memory_os.knob_overrides import (
+                resolve_knob as _resolve_knob,
+            )
+
+            _default = (_knob_specs.get(knob) or {}).get("default", expected)
+            effective = _resolve_knob(
+                knob,
+                _default,
+                _store_root=_Path(_hermes_home) / "memory-os" / "system",
+            )
+            effective_source = "resolver"
+        except Exception as exc:
+            effective_source = f"resolver_unavailable:{type(exc).__name__}"
+        entry = {
+            "expected_live_value": expected,
+            "effective_value": effective,
+            "effective_source": effective_source,
+            # None (resolver unavailable) counts as mismatch: an ungradeable
+            # output knob must surface, not silently pass.
+            "mismatch": (effective is None) or (bool(effective) != bool(expected)),
+        }
         row = latest_by_knob.get(knob)
         if not row:
-            knobs[knob] = {"present": False}
-            continue
-        expires_at = str(row.get("expires_at") or "").strip()
-        expired = False
-        if expires_at:
-            try:
-                _exp = expires_at[:-1] + "+00:00" if expires_at.endswith("Z") else expires_at
-                parsed = datetime.fromisoformat(_exp)
-                if parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=timezone.utc)
-                expired = parsed <= now
-            except ValueError:
-                expired = False
-        knobs[knob] = {
-          "present": True,
-          "override_value": row.get("override_value"),
-          "expires_at": expires_at,
-          "expired": expired,
-          "state": str(row.get("state") or ""),
-          "ts": str(row.get("ts") or ""),
-        }
+            entry["present"] = False
+        else:
+            expires_at = str(row.get("expires_at") or "").strip()
+            expired = False
+            if expires_at:
+                try:
+                    _exp = expires_at[:-1] + "+00:00" if expires_at.endswith("Z") else expires_at
+                    parsed = datetime.fromisoformat(_exp)
+                    if parsed.tzinfo is None:
+                        parsed = parsed.replace(tzinfo=timezone.utc)
+                    expired = parsed <= now
+                except ValueError:
+                    expired = False
+            entry.update({
+              "present": True,
+              "override_value": row.get("override_value"),
+              "expires_at": expires_at,
+              "expired": expired,
+              "state": str(row.get("state") or ""),
+              "ts": str(row.get("ts") or ""),
+            })
+        knobs[knob] = entry
     return {"collected": True, "knobs": knobs}
+
+
+def graph_injection_shadow_state():
+    # Completion Is Not Output(shadow v1 2026-08-07):注入健康要看生产
+    # 证据(injected 行数/outcome 分布),不能只看配置端 knob。零样本必须
+    # 报 healthy_no_sample,不得算 PASS 证据(纪元边界规则:空 gated 集
+    # 不许买绿)。deliberately ungraded — 上游闲置会良性地把样本清零。
+    path = os.path.join(_hermes_home, "memory-os/system/graph_layer_shadow.jsonl")
+    if not os.path.exists(path):
+        return {
+            "collected": True,
+            "status": "healthy_no_sample",
+            "v1_rows_7d": 0,
+            "injected_count_7d": 0,
+            "outcome_distribution_7d": {},
+        }
+    try:
+        rows = _read_jsonl(path)
+    except Exception as exc:
+        return {"collected": False, "error_code": type(exc).__name__}
+    cutoff = (
+        (datetime.now(timezone.utc) - timedelta(days=7))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    v1_rows = 0
+    injected = 0
+    outcomes = {}
+    for row in rows[-2000:]:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("schema_version") or "") != "memory-os.graph_layer_shadow.v1":
+            continue
+        created = str(row.get("created_at") or "")
+        if created and created < cutoff:
+            continue
+        v1_rows += 1
+        try:
+            injected += int(row.get("injected_count") or 0)
+        except (TypeError, ValueError):
+            pass
+        for edge in row.get("edges") or []:
+            if isinstance(edge, dict):
+                oc = str(edge.get("outcome") or "unknown")
+                outcomes[oc] = outcomes.get(oc, 0) + 1
+    return {
+        "collected": True,
+        "status": "healthy_no_sample" if v1_rows == 0 else "sampled",
+        "v1_rows_7d": v1_rows,
+        "injected_count_7d": injected,
+        "outcome_distribution_7d": outcomes,
+    }
 
 def module_cadence_summary():
     reports = _read_jsonl(os.path.join(_hermes_home, "system-modules/module_cadence/reports.jsonl"))
@@ -8957,6 +9067,7 @@ print(json.dumps({
   "cognitive_loop": memory_os_cli(["cognitive-loop", "status"]),
   "cognitive_loop_step_evidence": cognitive_loop_step_evidence(),
   "output_knob_override_state": output_knob_override_state(),
+  "graph_injection_shadow": graph_injection_shadow_state(),
   "memory_sources": memory_sources,
   "rh31_eval": rh31_eval,
   "owner_review": owner_review,

--- a/scripts/memory_os_graph_edge_weight_renormalization.py
+++ b/scripts/memory_os_graph_edge_weight_renormalization.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""One-time renormalization of legacy saturated edge weights (P3 2026-08-07).
+
+背景:三个 proposer 曾全部以 weight=1.0 产边(= 反馈 cap)。分层出生权重
+(edge_weights.py)只作用于新边;存量 1.0 边**不会被遗忘环自然清掉**——
+没有任何降权路径,1.0 边只要被注入一次就刷新 last_hit,并在
+``order by weight desc limit N`` 下永久霸占排序顶端,新分层边(0.35–0.75)
+一条也上不来,P3 修复会完全惰性化。
+
+本脚本把存量 weight==1.0 的非 invalidated 边按可回溯的证据粗粒度映射回
+出生权重(mapping v1;confidence 等细粒度证据已不可回溯):
+
+  - structural + depends_on                → 0.70(显式引用)
+  - structural + co_occurs + source_event  → 0.55(共享事件源)
+  - structural + co_occurs(无事件源)      → 0.45(词面相似)
+  - structural + 其他关系(refines 等,W1 之前的词面语义提名遗产)→ 0.45
+  - llm(任意关系;confidence 不可回溯)   → 0.60
+  - provenance + evidence_for              → 0.70(溯源硬证据)
+  - vector                                 → 不动(weight=真实相似度),计数
+  - 未知 proposed_by                       → 不动,计数
+
+Durability 依赖 W0:``index.update_edge_weight`` 先向 ``graph/edges.jsonl``
+追加整行更新(last-writer-wins),再更新投影 — 结果在 index_sync/rebuild
+后保持。纪元证据落盘
+``system/graph_edge_weight_renormalization_report.json``(apply 时),含
+迁移 edge_id 全表 + 映射规则版本。
+
+Default is DRY-RUN(prints the plan, writes nothing)。Pass ``--apply`` to
+execute。Idempotent:第二次 --apply 找到 0 条待迁移(乘性强化 + 0.005
+最小增量下限使 weight==1.0 不可再生,该值从此可判定为「未迁移遗留行」)。
+
+Invocation:
+  python scripts/memory_os_graph_edge_weight_renormalization.py \
+      --hermes-home /path/to/home --profile default [--apply]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _preparse_cli_arg(argv: list[str], flag: str) -> str:
+    for i, arg in enumerate(argv):
+        if arg == flag and i + 1 < len(argv):
+            val = argv[i + 1]
+            if val.startswith("--"):
+                return ""
+            return val
+        if arg.startswith(f"{flag}="):
+            return arg.split("=", 1)[1]
+    return ""
+
+
+_CLI_HOME = _preparse_cli_arg(sys.argv, "--hermes-home")
+_ENV_HOME = os.environ.get("HERMES_HOME", "")
+_HERMES_HOME = _CLI_HOME or _ENV_HOME or str(Path.home() / ".hermes")
+
+_self = Path(__file__).absolute()
+_repo_root = _self.parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(_HERMES_HOME) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+from plugins.memory.memory_os.edge_weights import EDGE_BIRTH_WEIGHTS  # noqa: E402
+from plugins.memory.memory_os.index import (  # noqa: E402
+    MemoryOSIndex,
+    _initialize_schema,
+    update_edge_weight,
+)
+from plugins.memory.memory_os.roots import MemoryOSRoots  # noqa: E402
+
+MAPPING_VERSION = "v1"
+# weight==1.0 判定阈值:乘性强化 + update_edge_weight 的 0.005 最小增量
+# 使新路径的权重永远到不了 0.9999(0.12×(1−w)<0.005 ⇔ w>0.958 即停),
+# 该阈值只会命中遗留饱和行。
+_SATURATED_THRESHOLD = 0.9999
+
+_LLM_LEGACY_WEIGHT = 0.60
+
+
+def _effective_edges(edges_path: Path) -> dict[str, dict]:
+    """Fold the canonical ledger per edge_id, last-writer-wins in file order
+    (mirrors ``_index_edges`` projection semantics)."""
+    effective: dict[str, dict] = {}
+    if not edges_path.exists():
+        return effective
+    for raw in edges_path.read_text(encoding="utf-8").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            edge = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(edge, dict):
+            continue
+        edge_id = str(edge.get("edge_id") or "")
+        if edge_id:
+            effective[edge_id] = edge
+    return effective
+
+
+def _legacy_target_weight(edge: dict) -> tuple[float | None, str]:
+    """Map a legacy saturated edge to (target_weight, bucket) — None = skip."""
+    proposed_by = str(edge.get("proposed_by") or "structural")
+    relation = str(edge.get("relation_type") or "")
+    if proposed_by == "vector":
+        return None, "skipped_vector"
+    if proposed_by == "provenance":
+        return (
+            EDGE_BIRTH_WEIGHTS[("provenance", "source_event_provenance")],
+            "provenance_evidence",
+        )
+    if proposed_by == "llm":
+        return _LLM_LEGACY_WEIGHT, "llm_confidence_unrecoverable"
+    if proposed_by == "structural":
+        if relation == "depends_on":
+            return (
+                EDGE_BIRTH_WEIGHTS[("structural", "explicit_reference")],
+                "structural_explicit_reference",
+            )
+        if relation == "co_occurs":
+            if str(edge.get("source_event_id") or "").strip():
+                return (
+                    EDGE_BIRTH_WEIGHTS[("structural", "shared_source_event")],
+                    "structural_shared_source_event",
+                )
+            return (
+                EDGE_BIRTH_WEIGHTS[("structural", "body_similarity")],
+                "structural_body_similarity",
+            )
+        # W1 之前 structural 曾按词面重叠提名 refines 等语义关系(生产
+        # refines 占 1951/2149)— 证据强度同词面相似。
+        return (
+            EDGE_BIRTH_WEIGHTS[("structural", "body_similarity")],
+            "structural_legacy_semantic",
+        )
+    return None, "skipped_unknown_proposer"
+
+
+def renormalize_edge_weights(roots: MemoryOSRoots, *, apply: bool) -> dict:
+    edges_path = roots.memory_os_root / "graph" / "edges.jsonl"
+    effective = _effective_edges(edges_path)
+
+    planned: list[tuple[str, float, str]] = []
+    bucket_counts: dict[str, int] = {}
+    skipped_vector = 0
+    skipped_unknown = 0
+    saturated = 0
+    for edge_id, edge in sorted(effective.items()):
+        if str(edge.get("state") or "") == "invalidated":
+            continue
+        try:
+            weight = float(edge.get("weight") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if weight < _SATURATED_THRESHOLD:
+            continue
+        saturated += 1
+        target, bucket = _legacy_target_weight(edge)
+        if target is None:
+            if bucket == "skipped_vector":
+                skipped_vector += 1
+            else:
+                skipped_unknown += 1
+            continue
+        bucket_counts[bucket] = bucket_counts.get(bucket, 0) + 1
+        planned.append((edge_id, target, bucket))
+
+    report = {
+        "schema_version": "memory-os.graph_edge_weight_renormalization.v0",
+        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "mapping_version": MAPPING_VERSION,
+        "ledger_row_count": (
+            sum(1 for _ in edges_path.read_text(encoding="utf-8").splitlines())
+            if edges_path.exists()
+            else 0
+        ),
+        "effective_edge_count": len(effective),
+        "saturated_count": saturated,
+        "planned_count": len(planned),
+        "bucket_counts": bucket_counts,
+        "skipped_vector_count": skipped_vector,
+        "skipped_unknown_proposer_count": skipped_unknown,
+        "applied": bool(apply),
+        "migrated_count": 0,
+        "failed_count": 0,
+        "failed_edge_ids": [],
+        "migrated_edge_ids": [],
+    }
+
+    if not apply or not planned:
+        return report
+
+    conn = sqlite3.connect(str(roots.index_path))
+    try:
+        _initialize_schema(conn)
+        for edge_id, target, _bucket in planned:
+            result = update_edge_weight(conn, edge_id, target, roots=roots)
+            if result and not result.get("weight_update_noop"):
+                report["migrated_count"] += 1
+                report["migrated_edge_ids"].append(edge_id)
+            else:
+                report["failed_count"] += 1
+                report["failed_edge_ids"].append(edge_id)
+    finally:
+        conn.close()
+
+    # 纪元证据(apply runs only):迁移全表 + 映射版本,后续任何
+    # weight==1.0 行都可对照本报告判定为「未走本次迁移的写入口」。
+    out = roots.memory_os_root / "system" / "graph_edge_weight_renormalization_report.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hermes-home", default=_HERMES_HOME)
+    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "default"))
+    parser.add_argument("--apply", action="store_true", help="execute (default: dry-run)")
+    args = parser.parse_args(argv)
+
+    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+    if not roots.index_path.exists():
+        # No index yet — build the projection so weight updates can resolve.
+        from plugins.memory.memory_os.store import MemoryOSStore
+
+        store = MemoryOSStore(roots)
+        store.initialize()
+        MemoryOSIndex(roots).rebuild_from_store(store)
+
+    report = renormalize_edge_weights(roots, apply=bool(args.apply))
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    if report["failed_count"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugins/memory/test_memory_os_audit_benchmark_cleanup.py
+++ b/tests/plugins/memory/test_memory_os_audit_benchmark_cleanup.py
@@ -890,12 +890,16 @@ def test_metadata_retention_ages_out_both_prefetch_shadow_ledgers(tmp_path):
         store,
         ["crystallized:anchor_a"],
         [{
-            "relation_type": "refines",
-            "from_record_type": "crystallized_record",
-            "from_record_id": "a",
-            "to_record_type": "crystallized_record",
-            "to_record_id": "b",
-            "weight": 0.8,
+            "edge": {
+                "relation_type": "refines",
+                "from_record_type": "crystallized_record",
+                "from_record_id": "a",
+                "to_record_type": "crystallized_record",
+                "to_record_id": "b",
+                "weight": 0.8,
+            },
+            "injected": True,
+            "outcome": "emitted_full",
         }],
     )
     _record_substrate_shadow_recall(

--- a/tests/plugins/memory/test_memory_os_edge_provenance.py
+++ b/tests/plugins/memory/test_memory_os_edge_provenance.py
@@ -128,12 +128,12 @@ def test_w4_event_anchor_reaches_crystallized(tmp_path):
 
 
 def test_w4_injection_suppresses_unresolved_noncrystallized_targets(tmp_path):
-    """注入过滤:非 crystallized 目标解析失败时不得落 [unresolved:] 兜底行。
-
-    事件会被 retention 清出热存储 — 已归档事件作为注入目标只能产生噪音;
-    crystallized 目标的 [unresolved:] 兜底保持(可诊断性)。
+    """注入过滤:非 crystallized 邻居解析失败(已被 retention 归档)时整行
+    抑制,outcome=non_crystallized_target;解析失败的结晶邻居同样整行丢弃,
+    outcome=unresolved — record_id 不再作为兜底行出现(P2:诊断归 shadow
+    outcome,不进 agent 上下文)。
     """
-    from plugins.memory.memory_os.prefetch import _graph_layer_injection_lines
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
 
     store, _index = _store(tmp_path)
     edges = [
@@ -156,10 +156,12 @@ def test_w4_injection_suppresses_unresolved_noncrystallized_targets(tmp_path):
             "state": "active",
         },
     ]
-    lines = _graph_layer_injection_lines(store, edges, seen=set())
-    assert not any("evt_archived_404" in line for line in lines), (
-        f"unresolved non-crystallized target must be suppressed: {lines}"
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=["cry_src"], seen=set(),
     )
-    assert any("nonexistent_cry_777" in line for line in lines), (
-        "crystallized unresolved fallback must be preserved"
+    assert lines == [], (
+        f"neither neighbor is renderable — no id-fallback lines allowed: {lines}"
     )
+    by_target = {str(d["edge"]["to_record_id"]): d["outcome"] for d in decisions}
+    assert by_target["evt_archived_404"] == "non_crystallized_target"
+    assert by_target["nonexistent_cry_777"] == "unresolved"

--- a/tests/plugins/memory/test_memory_os_edge_provenance.py
+++ b/tests/plugins/memory/test_memory_os_edge_provenance.py
@@ -125,6 +125,13 @@ def test_w4_event_anchor_reaches_crystallized(tmp_path):
     edges = index.query_edges(["evt_anchor_7"], depth=1, state="active", limit=8)
     assert edges, "event anchor must reach the crystallized record via provenance edge"
     assert any(str(e.get("to_record_id")) == "cry_prov_d" for e in edges)
+    # P3:溯源边出生权重来自证据分层表(反事实:回退硬编码 1.0 即红)
+    from plugins.memory.memory_os.edge_weights import birth_weight as _bw
+
+    prov = [e for e in edges if str(e.get("to_record_id")) == "cry_prov_d"]
+    assert float(prov[0].get("weight")) == pytest.approx(
+        _bw("provenance", "source_event_provenance")
+    )
 
 
 def test_w4_injection_suppresses_unresolved_noncrystallized_targets(tmp_path):

--- a/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
+++ b/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
@@ -70,9 +70,10 @@ def _weight_of(index, edge_id):
 
 
 def test_r4_hit_reinforces_weight_durably(tmp_path):
-    """反事实:注入命中必须强化边权重,且经 W0 机制在重投影后保持。"""
+    """反事实:注入命中必须强化边权重(乘性 w += RATE×(1−w)),且经 W0
+    机制在重投影后保持。"""
     from plugins.memory.memory_os.edge_weight_feedback import (
-        HIT_BOOST,
+        HIT_LEARNING_RATE,
         run_edge_weight_feedback,
     )
 
@@ -84,32 +85,38 @@ def test_r4_hit_reinforces_weight_durably(tmp_path):
     assert result["status"] == "ok"
     assert result["reinforced_count"] == 1
 
+    expected = 0.5 + HIT_LEARNING_RATE * (1.0 - 0.5)
     weight, state = _weight_of(index, edge["edge_id"])
     assert state == "active"
-    assert weight == pytest.approx(0.5 + HIT_BOOST)
+    assert weight == pytest.approx(expected)
 
     # 持久性:重投影后权重保持(无 canonical 写回时 sync 会回滚 → 必红)
     index.sync_from_store(store)
     weight2, _ = _weight_of(index, edge["edge_id"])
-    assert weight2 == pytest.approx(0.5 + HIT_BOOST)
+    assert weight2 == pytest.approx(expected)
 
 
-def test_r4_weight_capped_at_one(tmp_path):
+def test_r4_cap_is_unreachable_asymptote(tmp_path):
+    """乘性强化下 1.0 不可达:近 cap 边的命中是 already_saturated no-op
+    (最小增量 0.005 防 canonical 行刷屏),权重保持 — weight==1.0 从此
+    可判定为未迁移遗留行。"""
     from plugins.memory.memory_os.edge_weight_feedback import run_edge_weight_feedback
 
     store, index = _store(tmp_path)
     edge = _active_edge(index, 1, weight=0.98)
     _record_hit(store, edge)
 
-    run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    result = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert result["reinforced_count"] == 0
+    assert result["already_saturated_count"] == 1
     weight, _ = _weight_of(index, edge["edge_id"])
-    assert weight == pytest.approx(1.0)
+    assert weight == pytest.approx(0.98), "near-cap weight must not creep to 1.0"
 
 
 def test_r4_cursor_prevents_double_counting(tmp_path):
     """同一条 shadow 命中记录只计一次(durable cursor)。"""
     from plugins.memory.memory_os.edge_weight_feedback import (
-        HIT_BOOST,
+        HIT_LEARNING_RATE,
         run_edge_weight_feedback,
     )
 
@@ -123,7 +130,9 @@ def test_r4_cursor_prevents_double_counting(tmp_path):
     assert second["outcome"] == "no_new_hits"
 
     weight, _ = _weight_of(index, edge["edge_id"])
-    assert weight == pytest.approx(0.5 + HIT_BOOST), "double counting detected"
+    assert weight == pytest.approx(
+        0.5 + HIT_LEARNING_RATE * (1.0 - 0.5)
+    ), "double counting detected"
 
 
 def test_r4_forgets_long_unhit_active_edges(tmp_path):
@@ -198,7 +207,7 @@ def test_f2_legacy_v0_rows_still_count_as_hits(tmp_path):
     import json as _json
 
     from plugins.memory.memory_os.edge_weight_feedback import (
-        HIT_BOOST,
+        HIT_LEARNING_RATE,
         run_edge_weight_feedback,
     )
 
@@ -229,7 +238,7 @@ def test_f2_legacy_v0_rows_still_count_as_hits(tmp_path):
     result = run_edge_weight_feedback(str(index.roots.index_path), index=index)
     assert result["reinforced_count"] == 1
     weight, _ = _weight_of(index, edge["edge_id"])
-    assert weight == pytest.approx(0.5 + HIT_BOOST)
+    assert weight == pytest.approx(0.5 + HIT_LEARNING_RATE * (1.0 - 0.5))
 
 
 def test_f3_saturated_hit_counts_separately_and_refreshes_last_hit(tmp_path):

--- a/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
+++ b/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
@@ -40,18 +40,22 @@ def _active_edge(index, i=0, *, weight=0.5):
     return edge
 
 
-def _record_hit(store, edge):
-    """经真实生产者(prefetch shadow writer)记录一次注入命中。"""
+def _record_hit(store, edge, *, injected=True, outcome="emitted_full"):
+    """经真实生产者(prefetch shadow writer v1)记录一次注入决策。"""
     from plugins.memory.memory_os.prefetch import _record_graph_layer_shadow
 
     _record_graph_layer_shadow(store, [edge["from_record_id"]], [
         {
-            "relation_type": edge["relation_type"],
-            "from_record_type": edge["from_record_type"],
-            "from_record_id": edge["from_record_id"],
-            "to_record_type": edge["to_record_type"],
-            "to_record_id": edge["to_record_id"],
-            "weight": edge["weight"],
+            "edge": {
+                "relation_type": edge["relation_type"],
+                "from_record_type": edge["from_record_type"],
+                "from_record_id": edge["from_record_id"],
+                "to_record_type": edge["to_record_type"],
+                "to_record_id": edge["to_record_id"],
+                "weight": edge["weight"],
+            },
+            "injected": injected,
+            "outcome": outcome,
         }
     ])
 
@@ -166,3 +170,145 @@ def test_r4_no_shadow_ledger_reports_outcome(tmp_path):
     result = run_edge_weight_feedback(str(index.roots.index_path), index=index)
     assert result["status"] == "ok"
     assert result["outcome"] in ("no_new_hits", "no_shadow_ledger")
+
+
+def test_f2_not_injected_edges_are_not_hits(tmp_path):
+    """F2 反事实:shadow v1 里 injected=False 的边(knob 关闭/被过滤)不得
+    被当命中强化。修复缺席时:v0 语义把「查到边」当「注入命中」,knob
+    关闭的一个月里边照样被 +HIT_BOOST、last_hit 照样刷新。"""
+    from plugins.memory.memory_os.edge_weight_feedback import run_edge_weight_feedback
+
+    store, index = _store(tmp_path)
+    edge = _active_edge(index, 10, weight=0.5)
+    _record_hit(store, edge, injected=False, outcome="knob_disabled")
+
+    result = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert result["status"] == "ok"
+    assert result["reinforced_count"] == 0
+    assert result["skipped_not_injected_count"] == 1
+
+    weight, state = _weight_of(index, edge["edge_id"])
+    assert state == "active"
+    assert weight == pytest.approx(0.5), "not-injected edge must keep its weight"
+
+
+def test_f2_legacy_v0_rows_still_count_as_hits(tmp_path):
+    """向后兼容:缺 injected 字段的历史 v0 行按旧语义算命中(cursor 之前
+    未消费完的生产历史行不能因 schema 升级而失效)。"""
+    import json as _json
+
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        HIT_BOOST,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge = _active_edge(index, 11, weight=0.5)
+    # 历史 v0 行只能手工构造:现行真实生产者只写 v1(此处手写正是被测的
+    # 遗留数据形态,不是反事实空转)。
+    shadow_path = store.roots.memory_os_root / "system" / "graph_layer_shadow.jsonl"
+    shadow_path.parent.mkdir(parents=True, exist_ok=True)
+    with shadow_path.open("a", encoding="utf-8") as fh:
+        fh.write(_json.dumps({
+            "schema_version": "memory-os.graph_layer_shadow.v0",
+            "phase": "1",
+            "anchor_count": 1,
+            "edge_count": 1,
+            "created_at": "2026-08-07T00:00:00+00:00",
+            "recorded_at": "2026-08-07T00:00:00+00:00",
+            "edges": [{
+                "relation_type": edge["relation_type"],
+                "from_record_type": edge["from_record_type"],
+                "from_record_id": edge["from_record_id"],
+                "to_record_type": edge["to_record_type"],
+                "to_record_id": edge["to_record_id"],
+                "weight": edge["weight"],
+            }],
+        }, ensure_ascii=False) + "\n")
+
+    result = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert result["reinforced_count"] == 1
+    weight, _ = _weight_of(index, edge["edge_id"])
+    assert weight == pytest.approx(0.5 + HIT_BOOST)
+
+
+def test_f3_saturated_hit_counts_separately_and_refreshes_last_hit(tmp_path):
+    """F3 反事实:权重已在目标值的命中必须计 already_saturated,不得计
+    reinforced(生产首轮报 32 条「强化」全部是 no-op);且命中是真实的 —
+    last_hit 必须刷新,否则高频使用的饱和边会被遗忘环处决。"""
+    import json as _json
+
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        STATE_FILENAME,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge = _active_edge(index, 12, weight=1.0)
+    _record_hit(store, edge)
+
+    result = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert result["status"] == "ok"
+    assert result["reinforced_count"] == 0, "saturated no-op must not count as reinforcement"
+    assert result["already_saturated_count"] == 1
+    assert result["outcome"] == "reinforced", "the lane did do work this run"
+
+    state_path = store.roots.memory_os_root / "system" / STATE_FILENAME
+    state = _json.loads(state_path.read_text(encoding="utf-8"))
+    assert edge["edge_id"] in (state.get("edge_last_hit") or {}), (
+        "saturated hit must still refresh last_hit"
+    )
+    weight, _ = _weight_of(index, edge["edge_id"])
+    assert weight == pytest.approx(1.0)
+
+
+def test_f2_injection_never_live_blocks_forgetting(tmp_path):
+    """F2 守卫反事实:shadow 只有 injected=False 行(knob 关闭期)时不得
+    遗忘。旧守卫是「shadow 文件存在且非空」— 在从未展示过任何东西的时期
+    照样放行遗忘,正是它要防的「上线首日屠杀存量」。"""
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        FORGET_AFTER_DAYS,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge = _active_edge(index, 13, weight=0.5)
+    _record_hit(store, edge, injected=False, outcome="knob_disabled")
+
+    # 第一轮消化 knob_disabled 行(建立 state,但 first_injection_at 保持空)
+    run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    # 60+ 天后:边超龄,但注入从未活跃过 → 不得遗忘
+    future = datetime.now(timezone.utc) + timedelta(days=FORGET_AFTER_DAYS + 5)
+    result = run_edge_weight_feedback(
+        str(index.roots.index_path), index=index, now=future,
+    )
+    assert result["forgotten_count"] == 0
+    assert result["outcome"] == "injection_never_live"
+    _, state = _weight_of(index, edge["edge_id"])
+    assert state == "active", "no forgetting while injection has never been live"
+
+
+def test_r4_forget_backlog_and_never_hit_counters(tmp_path):
+    """遗忘潮可见性:eligible 超出每轮上限时 forget_eligible_backlog 暴露
+    积压;从未命中即被遗忘的边计入 invalidated_never_hit_count(饿死信号)。"""
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        FORGET_AFTER_DAYS,
+        FORGET_MAX_PER_RUN,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edges = [_active_edge(index, 100 + i, weight=0.5) for i in range(FORGET_MAX_PER_RUN + 5)]
+    _record_hit(store, edges[0])  # 建立 first_injection_at(真实注入)
+
+    run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    future = datetime.now(timezone.utc) + timedelta(days=FORGET_AFTER_DAYS + 5)
+    result = run_edge_weight_feedback(
+        str(index.roots.index_path), index=index, now=future,
+    )
+    assert result["forgotten_count"] == FORGET_MAX_PER_RUN
+    assert result["forget_eligible_backlog"] == 5
+    # 55 条中仅 edges[0] 曾命中;本轮处决的 50 条按 created_at 升序选取,
+    # 其中未命中者全部计入 never_hit(edges[0] 若在本轮内且曾命中则不计)。
+    assert result["invalidated_never_hit_count"] >= FORGET_MAX_PER_RUN - 1
+    assert result["invalidated_never_hit_count"] <= result["forgotten_count"]

--- a/tests/plugins/memory/test_memory_os_edge_weights.py
+++ b/tests/plugins/memory/test_memory_os_edge_weights.py
@@ -1,0 +1,194 @@
+"""P3 — 出生权重分层的守卫测试。
+
+词表漂移教训(CLAUDE.md):gate/表配置的名字必须对照 producer 实际产出
+双向校验,否则漂移后的表什么也不约束。本文件钉死:
+- 出生权重表的数值不变量(≥ 注入下限、< 1.0 不可达 cap);
+- structural 四个产边分支逐一走真实 producer,权重 ∈ 表;
+- 短语词表 relation 全集 == producer relation 全集(双向);
+- shadow outcome 封闭集普查;
+- birth_weight 未知键 fail loud;
+- 源码级双向:每个表键有 producer 调用点,每个调用点的键在表内。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.memory_os.edge_weights import (
+    EDGE_BIRTH_WEIGHTS,
+    LLM_BIRTH_BASE,
+    LLM_BIRTH_CONFIDENCE_SPAN,
+    birth_weight,
+    llm_birth_weight,
+)
+from plugins.memory.memory_os.prefetch import (
+    GRAPH_FALLBACK_PHRASE,
+    GRAPH_INJECTION_WEIGHT_FLOOR,
+    GRAPH_RELATION_PHRASES,
+    GRAPH_SHADOW_OUTCOMES,
+)
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3] / "plugins" / "memory" / "memory_os"
+
+# producer relation 全集(llm 的 _AUTO_ACTIVE_TYPES ∪ structural ∪
+# provenance ∪ vector)。新 relation 必须同时登记短语表两方向。
+_PRODUCER_RELATIONS = frozenset(
+    {"co_occurs", "depends_on", "refines", "evidence_for", "contradicts"}
+)
+
+
+def test_birth_weight_table_invariants():
+    values = list(EDGE_BIRTH_WEIGHTS.values())
+    assert values, "birth weight table must not be empty"
+    assert min(values) >= GRAPH_INJECTION_WEIGHT_FLOOR, (
+        "注入下限是不设防安全底线 — 任何出生权重都不得低于它(否则新边"
+        "出生即被静默过滤,「计算了却无人读」的死指标形态)"
+    )
+    assert max(values) < 1.0, (
+        "出生权重必须 < 1.0:weight==1.0 是「未迁移遗留行」的可判定诊断"
+    )
+    # llm 公式上下界同样受两条不变量约束
+    assert llm_birth_weight(0.0) == pytest.approx(LLM_BIRTH_BASE)
+    assert llm_birth_weight(1.0) == pytest.approx(
+        LLM_BIRTH_BASE + LLM_BIRTH_CONFIDENCE_SPAN
+    )
+    assert llm_birth_weight(0.0) >= GRAPH_INJECTION_WEIGHT_FLOOR
+    assert llm_birth_weight(1.0) < 1.0
+    # 越界/非法输入按 0 处理(不抛、不越界)
+    assert llm_birth_weight(2.5) == pytest.approx(LLM_BIRTH_BASE + LLM_BIRTH_CONFIDENCE_SPAN)
+    assert llm_birth_weight(-1) == pytest.approx(LLM_BIRTH_BASE)
+    assert llm_birth_weight("not-a-number") == pytest.approx(LLM_BIRTH_BASE)
+
+
+def test_birth_weight_unknown_key_fails_loud():
+    with pytest.raises(KeyError):
+        birth_weight("structural", "no_such_evidence_kind")
+    with pytest.raises(KeyError):
+        birth_weight("no_such_proposer", "explicit_reference")
+
+
+def test_structural_producer_branches_emit_registered_weights():
+    """真实 producer 逐分支:四个产边位点的权重全部来自表(反事实:任一
+    位点回退硬编码 1.0 即红)。"""
+    from plugins.memory.memory_os.structural_edge_proposer import _detect_relation
+
+    base = {
+        "kind": "note",
+        "tags_json": "[]",
+        "created_at": "2026-08-07T00:00:00+00:00",
+    }
+
+    # ① 共享 source_event → co_occurs 0.55
+    edges = _detect_relation(
+        {**base, "id": "cry_a", "body": "完全不同的内容甲", "source_event_ids_json": '["evt_shared"]'},
+        {**base, "id": "cry_b", "body": "毫无重叠的另一段乙", "source_event_ids_json": '["evt_shared"]'},
+    )
+    shared = [e for e in edges if e["relation_type"] == "co_occurs"]
+    assert shared and shared[0]["weight"] == pytest.approx(
+        birth_weight("structural", "shared_source_event")
+    )
+
+    # ② 显式引用 → depends_on 0.70
+    edges = _detect_relation(
+        {**base, "id": "cry_ref_a", "body": "本记录依赖 cry_ref_b 的结论", "source_event_ids_json": "[]"},
+        {**base, "id": "cry_ref_b", "body": "底层结论内容", "source_event_ids_json": "[]"},
+    )
+    dep = [e for e in edges if e["relation_type"] == "depends_on"]
+    assert dep and dep[0]["weight"] == pytest.approx(
+        birth_weight("structural", "explicit_reference")
+    )
+
+    # ③ 词面相似(dice)→ co_occurs 0.45
+    same_body = "memory os graph layer injection weight ranking exploration slots"
+    edges = _detect_relation(
+        {**base, "id": "cry_sim_a", "body": same_body, "source_event_ids_json": "[]"},
+        {**base, "id": "cry_sim_b", "body": same_body + " extra", "source_event_ids_json": "[]"},
+    )
+    sim = [e for e in edges if e["relation_type"] == "co_occurs"]
+    assert sim and sim[0]["weight"] == pytest.approx(
+        birth_weight("structural", "body_similarity")
+    )
+
+    # ④ 仅时间邻近(无其他信号)→ co_occurs 0.35
+    edges = _detect_relation(
+        {**base, "id": "cry_t_a", "body": "内容完全不同的一段甲",
+         "source_event_ids_json": "[]", "created_at": "2026-08-07T00:00:00+00:00"},
+        {**base, "id": "cry_t_b", "body": "彼此毫无词面重叠乙",
+         "source_event_ids_json": "[]", "created_at": "2026-08-07T00:10:00+00:00"},
+    )
+    temporal = [e for e in edges if e["relation_type"] == "co_occurs"]
+    assert temporal and temporal[0]["weight"] == pytest.approx(
+        birth_weight("structural", "temporal_proximity")
+    )
+
+    # 全部产出权重 ∈ 表值(无任何分支漏改)
+    all_values = set(EDGE_BIRTH_WEIGHTS.values())
+    for e in edges:
+        assert float(e["weight"]) in all_values
+
+
+def test_relation_phrase_vocabulary_matches_producers():
+    """短语词表 relation 全集 == producer relation 全集,且每个 relation
+    两个方向都有短语(方向敏感渲染的完整性)。"""
+    from plugins.memory.memory_os.llm_edge_proposer import _AUTO_ACTIVE_TYPES
+
+    phrase_relations = {rel for rel, _direction in GRAPH_RELATION_PHRASES}
+    assert phrase_relations == _PRODUCER_RELATIONS, (
+        f"phrase table drifted from producer vocabulary: "
+        f"{phrase_relations ^ _PRODUCER_RELATIONS}"
+    )
+    assert set(_AUTO_ACTIVE_TYPES) <= _PRODUCER_RELATIONS
+    for rel in phrase_relations:
+        assert (rel, "anchor_is_from") in GRAPH_RELATION_PHRASES, rel
+        assert (rel, "anchor_is_to") in GRAPH_RELATION_PHRASES, rel
+    assert GRAPH_FALLBACK_PHRASE, "unknown relations need a direction-free fallback"
+
+
+def test_shadow_outcomes_census():
+    """封闭 outcome 集普查:新 outcome 必须在此登记(监控的 outcome 分布
+    与 R4 的 injected 过滤都消费该集合)。"""
+    assert GRAPH_SHADOW_OUTCOMES == frozenset({
+        "emitted_full",
+        "emitted_stub",
+        "below_weight_floor",
+        "target_inactive",
+        "non_crystallized_target",
+        "unresolved",
+        "not_selected",
+        "knob_disabled",
+    })
+
+
+def test_birth_weight_call_sites_bidirectional_source_scan():
+    """源码级双向守卫:每个 birth_weight(a, b) 调用点的键在表内;每个表键
+    在某个 producer 源码里有调用点(镜像方向 — 表里躺着无 producer 的键
+    正是词表漂移的形态)。"""
+    call_re = re.compile(r'birth_weight\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\)')
+    producer_files = [
+        _PLUGIN_ROOT / "structural_edge_proposer.py",
+        _PLUGIN_ROOT / "edge_provenance.py",
+    ]
+    found_keys: set[tuple[str, str]] = set()
+    for path in producer_files:
+        source = path.read_text(encoding="utf-8")
+        for match in call_re.finditer(source):
+            key = (match.group(1), match.group(2))
+            assert key in EDGE_BIRTH_WEIGHTS, (
+                f"{path.name} calls birth_weight{key} but the key is not registered"
+            )
+            found_keys.add(key)
+    missing = set(EDGE_BIRTH_WEIGHTS) - found_keys
+    assert not missing, (
+        f"registered birth-weight keys with NO producer call site: {missing}"
+    )
+
+    # llm 走公式而非表:写入点必须消费 confidence,且不得回退硬编码 1.0
+    llm_source = (_PLUGIN_ROOT / "llm_edge_proposer.py").read_text(encoding="utf-8")
+    assert "llm_birth_weight(confidence)" in llm_source, (
+        "llm proposer must derive birth weight from the captured confidence"
+    )
+    assert "weight=1.0" not in llm_source, (
+        "llm proposer must not fall back to the saturated legacy weight"
+    )

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -478,8 +478,20 @@ def test_t1_4_6_g7_deterministic_recall_independent(tmp_path):
 
 
 def test_t1_5_1_shadow_section_does_not_inject_with_edges(tmp_path):
-    """T1.5.1: Phase 1 — edges are shadow-logged, NOT injected into context."""
+    """T1.5.1(P1 更新):回滚开关关火时 — edges are shadow-logged, NOT
+    injected into context。默认已翻 True(owner 裁定),关火需显式 False
+    override;knob_disabled 的边落账但 injected=False(F2)。"""
     store, index = _store(tmp_path)
+    from plugins.memory.memory_os.knob_overrides import register_override as _reg
+    _reg(
+        "graph_layer_injection_enabled",
+        False,
+        prior=True,
+        proposed_by="test",
+        approved_via="test",
+        expires_at="",
+        roots=store.roots,
+    )
     # Seed an event so FTS5 has content
     event = EventEnvelope.from_dict(build_event(seed=100, profile="graph-layer-test"))
     store.append_event(event)
@@ -2160,7 +2172,79 @@ def test_e8c_dedup_hit_emits_short_preview_line(tmp_path):
     assert decisions[0]["injected"] is True
 
 
-def test_e8_fallback_terms_also_query_crystallized_segment():
+def test_exploration_slots_rotate_daily_and_bound_selection(tmp_path):
+    """P3 反饿死反事实:候选 > 8 时选 top-6 按权重 + 2 个探索位。
+
+    分层出生权重若无探索位,排序固化后弱边永无展示 → 永无命中 → 60 天
+    被判「无命中」处决(自我实现遗忘)。探索位按天确定性轮转(无随机数,
+    热路径可复现):同日两次调用结果完全一致;跨日探索子集变化;落选边
+    以 not_selected 落账(封闭 outcome)。
+    """
+    from plugins.memory.memory_os.prefetch import (
+        GRAPH_EXPLOIT_SLOTS,
+        GRAPH_EXPLORE_SLOTS,
+        _render_graph_layer_lines,
+    )
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="explore-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    rid_anchor = _write_cry_record(
+        store, body="锚点记录:探索位轮转契约", candidate_id="cand-exp-anchor",
+        file_name="exp_anchor.md",
+    )
+    neighbor_ids = []
+    for i in range(12):
+        neighbor_ids.append(_write_cry_record(
+            store,
+            body=f"邻居记录{i}:内容标识 NEIGHBOR-{i} 的独立正文",
+            candidate_id=f"cand-exp-{i}",
+            file_name=f"exp_{i}.md",
+        ))
+    edges = [
+        {
+            "edge_id": f"edge-exp-{i}",
+            "from_record_type": "crystallized_record",
+            "from_record_id": rid_anchor,
+            "to_record_type": "crystallized_record",
+            "to_record_id": neighbor_ids[i],
+            "relation_type": "co_occurs",
+            "weight": round(0.90 - i * 0.02, 2),  # 0.90 .. 0.68, all ≥ floor
+            "state": "active",
+        }
+        for i in range(12)
+    ]
+
+    def _selected_neighbors(day):
+        source_ids: list[str] = []
+        lines, decisions = _render_graph_layer_lines(
+            store, list(edges), anchor_ids=[rid_anchor],
+            seen=set(), source_ids=source_ids, day_ordinal=day,
+        )
+        return lines, decisions, source_ids
+
+    day0 = 738000
+    lines_a, decisions_a, sel_a = _selected_neighbors(day0)
+    lines_b, _decisions_b, sel_b = _selected_neighbors(day0)
+    assert lines_a == lines_b and sel_a == sel_b, "same-day selection must be deterministic"
+
+    cap = GRAPH_EXPLOIT_SLOTS + GRAPH_EXPLORE_SLOTS
+    assert len(lines_a) == cap, f"selection must bound lines to {cap}: {len(lines_a)}"
+    not_selected = [d for d in decisions_a if d["outcome"] == "not_selected"]
+    assert len(not_selected) == 12 - cap, "the rest must be ledgered as not_selected"
+
+    # top-6 按权重恒在(exploit 位)
+    top6 = {f"crystallized_record:{nid}" for nid in neighbor_ids[:GRAPH_EXPLOIT_SLOTS]}
+    assert top6 <= set(sel_a), f"exploit slots must keep the top-{GRAPH_EXPLOIT_SLOTS}"
+
+    # 探索位跨日轮转:一周内至少出现两种探索子集(确定性哈希,非随机)
+    explore_sets = set()
+    for day in range(day0, day0 + 7):
+        _lines, _decisions, sel = _selected_neighbors(day)
+        explore_sets.add(tuple(sorted(set(sel) - top6)))
+    assert len(explore_sets) >= 2, (
+        f"exploration slots must rotate across days: {explore_sets}"
+    )
     """E8b counterfactual(生产复验补钉):逐词回退同样必须带结晶限定段。
 
     生产实测:主查询双段皆 0(AND 失效同样打击结晶限定段)→ 走逐词回退,

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -511,13 +511,20 @@ def test_t1_5_1_shadow_section_does_not_inject_with_edges(tmp_path):
     lines = shadow_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) >= 1, "Expected at least 1 shadow log entry"
 
-    # Verify shadow log structure
+    # Verify shadow log structure (v1: injected/outcome per edge + anchor_ids)
     record = json.loads(lines[-1])
-    assert record.get("schema_version") == "memory-os.graph_layer_shadow.v0"
-    assert record.get("phase") == "1"
+    assert record.get("schema_version") == "memory-os.graph_layer_shadow.v1"
     assert record.get("anchor_count") >= 1
+    assert record.get("anchor_ids"), "v1 must persist anchor ids"
     assert record.get("edge_count") >= 1
+    # knob 关闭:边落账但全部 injected=False/knob_disabled — 权重反馈闭环
+    # 不得把这些当命中(F2)
+    assert record.get("injected_count") == 0
     edges = record.get("edges", [])
+    assert edges and all(
+        e.get("injected") is False and e.get("outcome") == "knob_disabled"
+        for e in edges
+    ), f"knob-off edges must be marked not-injected: {edges}"
     assert any(
         e.get("relation_type") == "co_occurs"
         and e.get("from_record_id") == event.id

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -1591,175 +1591,246 @@ def test_t2_3_6_format_tags_list(tmp_path):
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Phase 1.6 — Edge target resolution helpers (Task 1 of P1a)
+# Phase 1.6 — Edge target resolution helpers(P2 改造后:批量解析 + 预览状态)
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-def test_resolve_edge_target_preview_found(tmp_path):
-    """When crystallized record exists, return body preview."""
-    from plugins.memory.memory_os.prefetch import _resolve_edge_target_preview
-    from plugins.memory.memory_os.roots import MemoryOSRoots
-    from plugins.memory.memory_os.store import MemoryOSStore
-    from plugins.memory.memory_os.crystallized import CrystallizedCandidate, CrystallizedMemoryService
-    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
-
-    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
-    roots.memory_os_root.mkdir(parents=True, exist_ok=True)
-    store = MemoryOSStore(roots)
-    store.initialize()
-
-    # Write a crystallized record
-    svc = CrystallizedMemoryService(store)
-    candidate = CrystallizedCandidate(
-        candidate_id="cand-1",
-        kind="preference",
-        body="用户偏好深色主题界面",
-        source_event_ids=["evt_seed_001"],
-    )
-    decision = ApprovalDecision(
-        candidate_id="cand-1",
-        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
-        reviewer="owner",
-        reviewed_at="2026-06-22T10:00:00Z",
-        note="test",
-        source_state="active",
-    )
-    svc.write_approved_record(candidate, decision, file_name="owner_approved.md")
-
-    # Non-existent record -> None
-    preview = _resolve_edge_target_preview(store, "nonexistent_id")
-    assert preview is None
-
-    # Find the actual record_id from what was written
-    records = svc.read_records("owner_approved.md")
-    assert len(records) == 1
-    record_id = records[0].frontmatter["id"]
-    preview = _resolve_edge_target_preview(store, record_id)
-    assert preview is not None
-    assert "深色主题" in preview
-
-
-def test_resolve_edge_target_preview_excludes_revoked_record(tmp_path):
-    from plugins.memory.memory_os.prefetch import _resolve_edge_target_preview
-    from plugins.memory.memory_os.roots import MemoryOSRoots
-    from plugins.memory.memory_os.store import MemoryOSStore
+def _write_cry_record(store, *, body, candidate_id, file_name, kind="note"):
+    """真实 producer 写入结晶记录并返回 record_id(counterfactual 教训:
+    手写 fixture 会让反事实空转,必须走 CrystallizedMemoryService)。"""
     from plugins.memory.memory_os.crystallized import (
         CrystallizedCandidate,
         CrystallizedMemoryService,
     )
     from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
 
-    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
-    store = MemoryOSStore(roots)
-    store.initialize()
-    service = CrystallizedMemoryService(store)
-    candidate = CrystallizedCandidate(
-        candidate_id="cand-revoked-preview",
-        kind="preference",
-        body="SECRET-NONCE-REVOKED-PREVIEW",
-        source_event_ids=["evt-revoked-preview"],
-    )
-    decision = ApprovalDecision(
-        candidate_id=candidate.candidate_id,
-        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
-        reviewer="owner",
-        reviewed_at="2026-06-22T10:00:00Z",
-    )
-    service.write_approved_record(
-        candidate,
-        decision,
-        file_name="owner_approved.md",
-    )
-    record_id = str(service.read_records("owner_approved.md")[0].frontmatter["id"])
-    service.revoke_record(record_id, revoked_by="owner", reason="test")
-
-    assert _resolve_edge_target_preview(store, record_id) is None
-
-    from plugins.memory.memory_os.prefetch import _graph_layer_injection_lines
-
-    lines = _graph_layer_injection_lines(
-        store,
-        [
-            {
-                "edge_id": "edge-revoked-preview",
-                "to_record_type": "crystallized_record",
-                "to_record_id": record_id,
-                "relation_type": "similar_to",
-                "weight": 0.8,
-                "state": "active",
-            }
-        ],
-    )
-    assert lines == []
-
-
-def test_graph_layer_injection_lines_formats_edges(tmp_path):
-    """Injection line formatting: each edge produces relation_type + body preview."""
-    from plugins.memory.memory_os.prefetch import _graph_layer_injection_lines
-    from plugins.memory.memory_os.roots import MemoryOSRoots
-    from plugins.memory.memory_os.store import MemoryOSStore
-    from plugins.memory.memory_os.crystallized import CrystallizedCandidate, CrystallizedMemoryService
-    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
-
-    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
-    roots.memory_os_root.mkdir(parents=True, exist_ok=True)
-    store = MemoryOSStore(roots)
-    store.initialize()
-
     svc = CrystallizedMemoryService(store)
     candidate = CrystallizedCandidate(
-        candidate_id="cand-graph-1",
-        kind="note",
-        body="图谱测试记忆内容",
-        source_event_ids=["evt_seed_002"],
+        candidate_id=candidate_id,
+        kind=kind,
+        body=body,
+        source_event_ids=[f"evt_seed_{candidate_id}"],
     )
     decision = ApprovalDecision(
-        candidate_id="cand-graph-1",
+        candidate_id=candidate_id,
         purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
         reviewer="owner",
         reviewed_at="2026-06-22T10:00:00Z",
         note="test",
         source_state="active",
     )
-    svc.write_approved_record(candidate, decision, file_name="test_graph.md")
+    svc.write_approved_record(candidate, decision, file_name=file_name)
+    return str(svc.read_records(file_name)[-1].frontmatter["id"])
 
-    records = svc.read_records("test_graph.md")
-    record_id = records[0].frontmatter["id"]
+
+def test_batch_resolve_and_graph_preview(tmp_path):
+    """批量解析一次扫描建映射;_graph_preview 区分 ok/inactive/missing。"""
+    from plugins.memory.memory_os.prefetch import (
+        _batch_resolve_crystallized,
+        _graph_preview,
+    )
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+    from plugins.memory.memory_os.crystallized import CrystallizedMemoryService
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
+    roots.memory_os_root.mkdir(parents=True, exist_ok=True)
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    rid = _write_cry_record(
+        store, body="用户偏好深色主题界面", candidate_id="cand-batch-1",
+        file_name="batch_a.md", kind="preference",
+    )
+    rid_revoked = _write_cry_record(
+        store, body="SECRET-NONCE-REVOKED-PREVIEW", candidate_id="cand-batch-2",
+        file_name="batch_b.md", kind="preference",
+    )
+    CrystallizedMemoryService(store).revoke_record(
+        rid_revoked, revoked_by="owner", reason="test",
+    )
+
+    cry_map = _batch_resolve_crystallized(store, {rid, rid_revoked, "nonexistent_id"})
+    assert rid in cry_map
+    assert rid_revoked in cry_map, "revoked records must resolve (for inactive detection)"
+    assert "nonexistent_id" not in cry_map
+
+    text, status = _graph_preview(rid, "crystallized_record", cry_map, {})
+    assert status == "ok" and text and "深色主题" in text
+    assert _graph_preview(rid_revoked, "crystallized_record", cry_map, {}) == (None, "inactive")
+    assert _graph_preview("nonexistent_id", "crystallized_record", cry_map, {})[1] == "missing"
+
+    # 事件端点走 events 缓存
+    text, status = _graph_preview("evt_9", "event", {}, {"evt_9": "事件摘要内容测试"})
+    assert status == "ok" and text and "事件摘要" in text
+    assert _graph_preview("evt_gone", "event", {}, {})[1] == "missing"
+
+
+def test_render_drops_revoked_and_unresolved_neighbors(tmp_path):
+    """撤销邻居整行抑制(target_inactive);解析失败的结晶邻居整行丢弃
+    (unresolved)— record_id 永不作为兜底行出现(P2:裸 id 阅读方对不上
+    号,只会诱导编造引用;诊断归 shadow outcome)。反事实:旧实现会落
+    [unresolved:cry_...] 行。"""
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+    from plugins.memory.memory_os.crystallized import CrystallizedMemoryService
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    rid_anchor = _write_cry_record(
+        store, body="锚点记录:图谱注入方向归一约定", candidate_id="cand-dir-a",
+        file_name="dir_a.md",
+    )
+    rid_revoked = _write_cry_record(
+        store, body="SECRET-NONCE-REVOKED-PREVIEW", candidate_id="cand-dir-r",
+        file_name="dir_r.md",
+    )
+    CrystallizedMemoryService(store).revoke_record(
+        rid_revoked, revoked_by="owner", reason="test",
+    )
 
     edges = [
         {
-            "edge_id": "edge-1",
-            "to_record_type": "crystallized_record",
-            "to_record_id": record_id,
-            "relation_type": "co_occurs",
-            "weight": 0.85,
+            "edge_id": "edge-revoked",
             "from_record_type": "crystallized_record",
-            "from_record_id": "cry_src",
+            "from_record_id": rid_anchor,
+            "to_record_type": "crystallized_record",
+            "to_record_id": rid_revoked,
+            "relation_type": "co_occurs",
+            "weight": 0.9,
             "state": "active",
         },
         {
-            "edge_id": "edge-2",
-            "to_record_type": "crystallized_record",
-            "to_record_id": "nonexistent_cry_999",
-            "relation_type": "similar_to",
-            "weight": 0.60,
+            "edge_id": "edge-missing",
             "from_record_type": "crystallized_record",
-            "from_record_id": "cry_src",
+            "from_record_id": rid_anchor,
+            "to_record_type": "crystallized_record",
+            "to_record_id": "cry_nonexistent_999",
+            "relation_type": "co_occurs",
+            "weight": 0.8,
             "state": "active",
         },
     ]
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[rid_anchor], seen=set(),
+    )
+    assert lines == [], f"neither neighbor is renderable: {lines}"
+    assert "SECRET-NONCE" not in " ".join(lines)
+    by_target = {str(d["edge"]["to_record_id"]): d for d in decisions}
+    assert by_target[rid_revoked]["outcome"] == "target_inactive"
+    assert by_target["cry_nonexistent_999"]["outcome"] == "unresolved"
+    assert all(d["injected"] is False for d in decisions)
 
+
+def test_render_formats_direction_normalized_chinese_lines(tmp_path):
+    """新行文法 + F1 方向归一反事实。
+
+    B→A 的边(锚点在 to 侧):旧实现无条件取 to_record_id 当展示目标,会把
+    锚点自己当"关联记忆"展示且 depends_on 方向读反;新实现必须展示 B 的
+    正文,短语用 to 侧的「被以下内容依赖」。行内永不出现 record_id。"""
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
+    roots.memory_os_root.mkdir(parents=True, exist_ok=True)
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    rid_a = _write_cry_record(
+        store, body="锚点记录:图谱注入的方向归一约定说明",
+        candidate_id="cand-f1-a", file_name="f1_a.md",
+    )
+    rid_b = _write_cry_record(
+        store, body="邻居记录:被依赖的底层配置基线说明",
+        candidate_id="cand-f1-b", file_name="f1_b.md",
+    )
+
+    edges = [{
+        "edge_id": "edge-f1",
+        "from_record_type": "crystallized_record",
+        "from_record_id": rid_b,
+        "to_record_type": "crystallized_record",
+        "to_record_id": rid_a,
+        "relation_type": "depends_on",
+        "weight": 0.85,
+        "state": "active",
+    }]
     seen: set[tuple[str, str]] = set()
-    lines = _graph_layer_injection_lines(store, edges, seen=seen)
+    source_ids: list[str] = []
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[rid_a], seen=seen, source_ids=source_ids,
+    )
 
-    # At least one line should be resolved successfully
-    assert len(lines) >= 1
-    # First edge should contain relation_type and body preview
-    assert "co_occurs" in lines[0] or "图谱测试" in lines[0]
-    # Second edge resolution failure -> fallback to record_id
-    assert any("nonexistent_cry_999" in line for line in lines)
-    # seen should contain the successfully resolved record
-    assert ("crystallized_record", record_id) in seen
+    assert len(lines) == 1, f"expected one rendered line: {lines}"
+    line = lines[0]
+    assert line.startswith("- 「"), f"line must lead with anchor preview: {line}"
+    assert "锚点记录" in line, f"anchor preview must name the anchor: {line}"
+    assert "被以下内容依赖" in line, f"to-side depends_on phrase expected: {line}"
+    assert "邻居记录" in line, f"neighbor body must be rendered, not the anchor: {line}"
+    assert "关联度 0.85" in line
+    assert rid_a not in line and rid_b not in line, f"record_id must never render: {line}"
+    assert len(line) <= 220
+    assert ("crystallized_record", rid_b) in seen, "dedup registers the NEIGHBOR"
+    assert ("crystallized_record", rid_a) not in seen, "anchor must not be re-registered"
+    assert source_ids == [f"crystallized_record:{rid_b}"], (
+        f"attribution must follow the displayed neighbor: {source_ids}"
+    )
+    assert decisions[0]["injected"] is True
+    assert decisions[0]["outcome"] == "emitted_full"
+
+
+def test_render_from_side_phrase_and_aggregation(tmp_path):
+    """from 侧短语(依赖于/细化了)+ 同 (锚点,邻居) 多边聚合为一行。"""
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    rid_a = _write_cry_record(
+        store, body="锚点记录:注入行文法契约", candidate_id="cand-agg-a",
+        file_name="agg_a.md",
+    )
+    rid_b = _write_cry_record(
+        store, body="邻居记录:字符预算与聚合规则", candidate_id="cand-agg-b",
+        file_name="agg_b.md",
+    )
+
+    edges = [
+        {
+            "edge_id": "edge-agg-1",
+            "from_record_type": "crystallized_record",
+            "from_record_id": rid_a,
+            "to_record_type": "crystallized_record",
+            "to_record_id": rid_b,
+            "relation_type": "co_occurs",
+            "weight": 0.6,
+            "state": "active",
+        },
+        {
+            "edge_id": "edge-agg-2",
+            "from_record_type": "crystallized_record",
+            "from_record_id": rid_a,
+            "to_record_type": "crystallized_record",
+            "to_record_id": rid_b,
+            "relation_type": "refines",
+            "weight": 0.8,
+            "state": "active",
+        },
+    ]
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[rid_a], seen=set(),
+    )
+    assert len(lines) == 1, f"same (anchor,neighbor) pair must aggregate: {lines}"
+    line = lines[0]
+    assert "同源共现于" in line and "细化了" in line and "、" in line, line
+    assert "关联度 0.80" in line, f"aggregated weight takes the max: {line}"
+    assert len(decisions) == 2
+    assert all(d["injected"] is True for d in decisions)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -2025,20 +2096,37 @@ def test_e8_crystallized_hits_prioritized_into_anchor_pool():
     assert len(anchors) <= 5
 
 
-def test_e8c_dedup_hit_emits_relation_stub_line(tmp_path):
-    """E8c counterfactual:目标已被其他段展示时,注入不得静默吞行 —— 产短关系行。
+def test_e8c_dedup_hit_emits_short_preview_line(tmp_path):
+    """E8c 升级版反事实:目标已被其他段展示时不得静默吞行,降级为
+    「已列出·」+ 60 字符正文短预览 — 不再打 ↺ + 裸 record_id。
 
-    生产实锤(2026-08-07 06:30Z):锚点命中、查到 2 条边、shadow 落账,但
-    两个目标恰好已被 Indexed/Crystallized 段展示 → 跨段去重把行全吃掉 →
-    Related Memory 恒空。小图谱阶段检索命中集与一跳邻居集高度重叠,
-    该设计让图谱贡献永远隐形。「已展示的两条记忆彼此相关」是图谱独有
-    信息 — 去重命中降级为短关系行(↺ 标记,不重复正文),而非消失。
+    生产实锤(2026-08-07 06:30Z):小图谱阶段检索命中集与一跳邻居集高度
+    重叠,静默去重让 Related Memory 恒空;而裸 id 短行阅读方对不上号
+    (其它区段不显示 record_id)。短预览是同一正文的精确前缀,即为跨段
+    对齐键。方向归一后本场景锚点=结晶(to 侧),邻居=事件(经 events
+    缓存解析),evidence_for 的 to 侧短语为「其证据为」。
     """
-    from plugins.memory.memory_os.prefetch import _graph_layer_injection_lines
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
+    from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, EventEnvelope
 
     roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="graph-stub-test")
     store = MemoryOSStore(roots)
     store.initialize()
+    rid = _write_cry_record(
+        store, body="结晶正文:图谱与状态层的联动约定,阅读方按正文前缀对齐",
+        candidate_id="cand-e8c", file_name="e8c.md",
+    )
+    ev = EventEnvelope(
+        schema_version=EVENT_SCHEMA_VERSION,
+        id="evt_src_1",
+        ts="2026-08-07T00:00:00Z",
+        profile="graph-stub-test",
+        source="fixture",
+        kind="conversation_turn",
+        summary="事件摘要:昨天讨论了图谱注入的方向归一细节",
+        tags=[],
+        safe_ref={},
+    )
 
     edges = [{
         "relation_type": "evidence_for",
@@ -2046,15 +2134,23 @@ def test_e8c_dedup_hit_emits_relation_stub_line(tmp_path):
         "from_record_type": "event",
         "from_record_id": "evt_src_1",
         "to_record_type": "crystallized_record",
-        "to_record_id": "cry_already_shown",
+        "to_record_id": rid,
         "state": "active",
     }]
-    seen = {("crystallized_record", "cry_already_shown")}
-    lines = _graph_layer_injection_lines(store, edges, seen=seen)
-    assert len(lines) == 1, f"dedup hit must yield a relation stub, not silence: {lines}"
-    assert "evidence_for" in lines[0]
-    assert "↺" in lines[0], f"stub must be marked as already-shown: {lines[0]}"
-    assert len(lines[0]) <= 160, f"stub must stay short: {lines[0]!r}"
+    seen = {("crystallized_record", rid), ("event", "evt_src_1")}
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[rid], seen=seen, events=[ev],
+    )
+    assert len(lines) == 1, f"dedup hit must yield a short-preview line, not silence: {lines}"
+    line = lines[0]
+    assert "已列出·" in line, f"dedup hit must carry the already-listed marker: {line}"
+    assert "其证据为" in line, f"to-side evidence_for phrase expected: {line}"
+    assert "事件摘要" in line, f"neighbor (event) preview must render: {line}"
+    assert "evt_src_1" not in line and rid not in line, f"no record_id in lines: {line}"
+    assert "↺" not in line, f"legacy id-stub marker must be gone: {line}"
+    assert len(line) <= 220, f"stub line must stay bounded: {line!r}"
+    assert decisions[0]["outcome"] == "emitted_stub"
+    assert decisions[0]["injected"] is True
 
 
 def test_e8_fallback_terms_also_query_crystallized_segment():

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -1287,13 +1287,19 @@ def test_graph_layer_injection_disabled_by_default(tmp_path):
 def test_graph_layer_injection_enabled_produces_lines(tmp_path):
     """knob=True with an active edge produces injection lines.
 
-    Uses a non-existent target record_id so the edge is not
-    cross-section deduped by seen entries from Crystallized Memory
-    or Recent Event Summaries (both of which populate seen).
+    P2 契约:边目标必须是真实结晶记录(真 producer 写入 — 旧版用不存在的
+    目标 id 绕过跨段去重,同时依赖已删除的 [unresolved:id] 兜底行)。真实
+    目标可能已被 Crystallized 段展示,去重命中降级为「已列出·」短预览行,
+    Related Memory 无论如何出现;record_id 永不进入上下文。
     """
     import sqlite3
 
     from plugins.memory.memory_os.index import write_governed_edge
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import (
+        CrystallizedCandidate,
+        CrystallizedMemoryService,
+    )
 
     roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
     roots.memory_os_root.mkdir(parents=True, exist_ok=True)
@@ -1308,26 +1314,38 @@ def test_graph_layer_injection_enabled_produces_lines(tmp_path):
     store.append_event(event)
     anchor_id = event.id
 
+    # ── Write a REAL crystallized record as the edge target ──
+    svc = CrystallizedMemoryService(store)
+    candidate = CrystallizedCandidate(
+        candidate_id="cand-graph-knob",
+        kind="note",
+        body="图谱注入目标记录:行文法与去重降级契约",
+        source_event_ids=[anchor_id],
+    )
+    decision = ApprovalDecision(
+        candidate_id="cand-graph-knob",
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="owner",
+        reviewed_at="2026-06-22T10:00:00Z",
+        note="test",
+        source_state="active",
+    )
+    svc.write_approved_record(candidate, decision, file_name="graph_knob.md")
+    target_id = str(svc.read_records("graph_knob.md")[0].frontmatter["id"])
+
     # ── Build index so FTS5 can find the event ──
     index = MemoryOSIndex(roots)
     index.rebuild_from_store(store)
 
-    # ── Write an active edge: event → non-existent target ──
-    # Using a non-existent target avoids cross-section dedup
-    # (Crystallized Memory adds real crystallized_record ids to seen;
-    #  Recent Event Summaries adds selected event ids to seen).
     conn = sqlite3.connect(str(index.roots.index_path))
     conn.row_factory = sqlite3.Row
-    # W4 语义更新:非 crystallized 目标解析失败时不再落 [unresolved:] 兜底
-    # (事件会被 retention 清理,悬挂目标属噪音)。本测试改用 crystallized
-    # 类型的不存在目标 — 兜底行为保留,跨段去重规避意图不变。
     write_governed_edge(
         conn,
         index.roots,
         from_record_type="event",
         from_record_id=anchor_id,
         to_record_type="crystallized_record",
-        to_record_id="cry_nonexistent_target_999",
+        to_record_id=target_id,
         relation_type="co_occurs",
         state="active",
     )
@@ -1356,10 +1374,14 @@ def test_graph_layer_injection_enabled_produces_lines(tmp_path):
     assert "Related Memory" in context, (
         f"Expected 'Related Memory' section when knob enabled. Context:\n{context}"
     )
-    # Should contain the fallback injection line (target doesn't resolve
-    # as a crystallized record, so record_id is shown)
-    assert "co_occurs" in context
-    assert "unresolved" in context
+    # 新行文法短语(同源共现于)仅由 Related Memory 产生
+    assert "同源共现于" in context, (
+        f"graph relation phrase expected in context:\n{context}"
+    )
+    assert target_id not in context, (
+        f"record_id must never enter the agent context:\n{context}"
+    )
+    assert "unresolved" not in context
 
 
 def _append_event(store, *, event_id, ts, session_id, source_class="foreground", kind="conversation_turn", summary="", source="fixture", tags=None):

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -1266,22 +1266,83 @@ def test_deterministic_floor_recall_header_annotation(tmp_path):
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-def test_graph_layer_injection_disabled_by_default(tmp_path):
-    """Default knob=False: Related Memory section is empty (shadow-only)."""
+def test_graph_layer_injection_default_on_and_false_override_rolls_back(tmp_path):
+    """P1 反事实(两个方向):无 override 时注入默认开启(owner 裁定图谱
+    为永久能力 — 旧默认 False 时本场景无 Related Memory);显式 False
+    override 关火(开关保留作回滚)。"""
+    import sqlite3
+
+    from plugins.memory.memory_os.index import write_governed_edge
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import (
+        CrystallizedCandidate,
+        CrystallizedMemoryService,
+    )
+
     roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
     roots.memory_os_root.mkdir(parents=True, exist_ok=True)
+    (roots.memory_os_root / "system").mkdir(parents=True, exist_ok=True)
     store = MemoryOSStore(roots)
     store.initialize()
-    index = MemoryOSIndex(roots)
 
-    context = build_prefetch(
-        "test query",
-        budget_chars=4000,
-        store=store,
-        index=index,
+    event = EventEnvelope.from_dict(build_event(seed=201, profile="test"))
+    store.append_event(event)
+
+    svc = CrystallizedMemoryService(store)
+    candidate = CrystallizedCandidate(
+        candidate_id="cand-default-on",
+        kind="note",
+        body="默认开启验证目标记录:回滚开关契约",
+        source_event_ids=[event.id],
     )
-    # Related Memory should not appear when knob defaults off
-    assert "Related Memory" not in context
+    decision = ApprovalDecision(
+        candidate_id="cand-default-on",
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="owner",
+        reviewed_at="2026-06-22T10:00:00Z",
+        note="test",
+        source_state="active",
+    )
+    svc.write_approved_record(candidate, decision, file_name="default_on.md")
+    target_id = str(svc.read_records("default_on.md")[0].frontmatter["id"])
+
+    index = MemoryOSIndex(roots)
+    index.rebuild_from_store(store)
+    conn = sqlite3.connect(str(index.roots.index_path))
+    conn.row_factory = sqlite3.Row
+    write_governed_edge(
+        conn,
+        index.roots,
+        from_record_type="event",
+        from_record_id=event.id,
+        to_record_type="crystallized_record",
+        to_record_id=target_id,
+        relation_type="co_occurs",
+        state="active",
+    )
+    conn.close()
+
+    # ── 无 override:默认注入 ──
+    context = build_prefetch("event", budget_chars=4000, store=store, index=index)
+    assert "Related Memory" in context, (
+        f"default-on injection expected without any override:\n{context}"
+    )
+
+    # ── 显式 False override:回滚关火 ──
+    from plugins.memory.memory_os.knob_overrides import register_override as _reg
+    _reg(
+        "graph_layer_injection_enabled",
+        False,
+        prior=True,
+        proposed_by="test",
+        approved_via="test",
+        expires_at="",
+        roots=roots,
+    )
+    context_off = build_prefetch("event", budget_chars=4000, store=store, index=index)
+    assert "Related Memory" not in context_off, (
+        f"explicit False override must roll injection back:\n{context_off}"
+    )
 
 
 def test_graph_layer_injection_enabled_produces_lines(tmp_path):

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -8333,52 +8333,59 @@ def test_w6_graph_governance_state_info_entry():
     ), "a report predating edge_step_results must not fabricate a measurement"
 
 
-def test_w6_output_knob_override_expiry_visibility():
-    """E5 counterfactual:输出型 knob 的 enabled override 静默过期必须 WARN。
+def test_p1_output_knob_effective_value_mismatch_visibility():
+    """P1 反事实(W6/E5 判据换轨):生效值 ≠ 期望值必须 WARN。
 
-    生产事故:graph_layer_injection_enabled 的 override 2026-07-01 过期,
-    无任何监控项报告 — 图谱注入静默关闭一个月无人知晓。
+    旧 expired 判据两个方向都错:resolver 只让 state=='active' 的行过期
+    ('confirmed' 过期后仍生效 → 假警);默认翻 True 后真正的危险态是一条
+    active 的 override_value=False — expired 判据结构上看不见它。E5 原
+    事故形状(enabled override 过期 → 生效值跌回默认)在新判据下同样表现
+    为 mismatch=True。
     """
-    expired = monitor.classify_snapshot({
+    mismatched = monitor.classify_snapshot({
         "monitor_profile": "live",
         "output_knob_override_state": {
             "collected": True,
             "knobs": {
                 "graph_layer_injection_enabled": {
                     "present": True,
-                    "override_value": True,
-                    "expires_at": "2026-07-01T07:58:15+00:00",
-                    "expired": True,
+                    "override_value": False,
+                    "expires_at": "",
+                    "expired": False,
                     "state": "active",
+                    "expected_live_value": True,
+                    "effective_value": False,
+                    "effective_source": "resolver",
+                    "mismatch": True,
                 },
             },
         },
     })
     assert any(
-        item["code"] == "v2_output_knob_override_expired" for item in expired["warn"]
-    ), "an enabled-then-expired output knob override must WARN"
+        item["code"] == "v2_output_knob_override_mismatch" for item in mismatched["warn"]
+    ), "an output knob whose effective value differs from expected must WARN"
     assert any(
-        item["code"] == "v2_output_knob_override_state" for item in expired["info"]
+        item["code"] == "v2_output_knob_override_state" for item in mismatched["info"]
     )
 
-    # 未过期(或无 override)→ 仅 INFO,不 WARN
+    # 生效值 == 期望值(default_live,无 override)→ 仅 INFO,不 WARN
     healthy = monitor.classify_snapshot({
         "monitor_profile": "live",
         "output_knob_override_state": {
             "collected": True,
             "knobs": {
                 "graph_layer_injection_enabled": {
-                    "present": True,
-                    "override_value": True,
-                    "expires_at": "2099-01-01T00:00:00+00:00",
-                    "expired": False,
-                    "state": "active",
+                    "present": False,
+                    "expected_live_value": True,
+                    "effective_value": True,
+                    "effective_source": "resolver",
+                    "mismatch": False,
                 },
             },
         },
     })
     assert not any(
-        item["code"] == "v2_output_knob_override_expired" for item in healthy["warn"]
+        item["code"] == "v2_output_knob_override_mismatch" for item in healthy["warn"]
     )
     assert any(
         item["code"] == "v2_output_knob_override_state" for item in healthy["info"]
@@ -8397,7 +8404,119 @@ def test_w6_output_knob_override_expiry_visibility():
         for item in failed["warn"]
     )
 
-    # 词表守卫:两个新 WARN 码必须在 clean-host 分类表注册
+    # 词表守卫:WARN 码必须在 clean-host 分类表注册
     # (BJ 教训:未注册的 WARN 在 clean-host 落 unclassified 即 FAIL)。
-    for code in ("v2_output_knob_override_expired", "v2_output_knob_override_collection_failed"):
+    for code in (
+        "v2_output_knob_override_mismatch",
+        "v2_output_knob_override_collection_failed",
+        "v2_graph_injection_shadow_collection_failed",
+    ):
         assert code in monitor.CLEAN_HOST_WARN_CLASSIFICATIONS, code
+
+
+def _exec_graph_knob_probe_prefix(hermes_home) -> dict[str, Any]:
+    """Exec the verbatim embedded-script source that defines
+    output_knob_override_state()/graph_injection_shadow_state() (both live
+    inside the giant r'''...''' remote-script literal, not as module
+    attributes). Split point `def module_cadence_summary` is the first
+    top-level def after graph_injection_shadow_state."""
+    script = monitor._remote_probe_script(str(hermes_home))
+    prefix = script.split("def module_cadence_summary", 1)[0]
+    namespace: dict[str, Any] = {}
+    exec(prefix, namespace)
+    return namespace
+
+
+def test_p1_output_knob_state_matches_resolver(tmp_path):
+    """守卫:监控的 effective_value 必须与部署 resolver 对同一份账本的结论
+    一致(镜像重实现的词表漂移正是 E5 家族的成因)。fixture 用 confirmed +
+    已过期 expires_at — 历史上两边分歧的实例:resolver 不让 confirmed
+    过期,旧监控按时间戳判过期。"""
+    import json as _json
+
+    system_dir = tmp_path / "memory-os" / "system"
+    system_dir.mkdir(parents=True)
+    (system_dir / "knob_overrides.jsonl").write_text(
+        _json.dumps({
+            "knob": "graph_layer_injection_enabled",
+            "override_value": False,
+            "state": "confirmed",
+            "expires_at": "2020-01-01T00:00:00+00:00",
+            "ts": "2019-12-01T00:00:00+00:00",
+        }) + "\n",
+        encoding="utf-8",
+    )
+
+    from plugins.memory.memory_os.knob_overrides import OVERRIDABLE_KNOBS, resolve_knob
+
+    _default = OVERRIDABLE_KNOBS["graph_layer_injection_enabled"]["default"]
+    expected_effective = resolve_knob(
+        "graph_layer_injection_enabled", _default, _store_root=system_dir,
+    )
+
+    namespace = _exec_graph_knob_probe_prefix(tmp_path)
+    state = namespace["output_knob_override_state"]()
+    row = state["knobs"]["graph_layer_injection_enabled"]
+    assert row["effective_source"] == "resolver"
+    assert row["effective_value"] == expected_effective, (
+        "monitor must report the DEPLOYED resolver's conclusion, not a mirror"
+    )
+    assert row["mismatch"] == (bool(expected_effective) is not True)
+
+
+def test_v2_graph_injection_shadow_state_collection_and_wiring(tmp_path):
+    """shadow v1 生产证据采集:零样本报 healthy_no_sample(不买绿);v1 行
+    按 injected/outcome 聚合;采集失败 WARN。v0 行不计入(纪元边界)。"""
+    import json as _json
+
+    namespace = _exec_graph_knob_probe_prefix(tmp_path)
+    empty = namespace["graph_injection_shadow_state"]()
+    assert empty["collected"] is True
+    assert empty["status"] == "healthy_no_sample"
+    assert empty["v1_rows_7d"] == 0
+
+    system_dir = tmp_path / "memory-os" / "system"
+    system_dir.mkdir(parents=True)
+    now_stamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    rows = [
+        {  # v0 历史行:不计入 v1 统计
+            "schema_version": "memory-os.graph_layer_shadow.v0",
+            "created_at": now_stamp,
+            "edges": [{"relation_type": "co_occurs"}],
+        },
+        {
+            "schema_version": "memory-os.graph_layer_shadow.v1",
+            "created_at": now_stamp,
+            "injected_count": 2,
+            "edges": [
+                {"outcome": "emitted_full", "injected": True},
+                {"outcome": "emitted_full", "injected": True},
+                {"outcome": "not_selected", "injected": False},
+            ],
+        },
+    ]
+    (system_dir / "graph_layer_shadow.jsonl").write_text(
+        "".join(_json.dumps(r) + "\n" for r in rows), encoding="utf-8",
+    )
+    sampled = namespace["graph_injection_shadow_state"]()
+    assert sampled["status"] == "sampled"
+    assert sampled["v1_rows_7d"] == 1
+    assert sampled["injected_count_7d"] == 2
+    assert sampled["outcome_distribution_7d"] == {"emitted_full": 2, "not_selected": 1}
+
+    # 分类接线:collected → INFO;采集失败 → WARN
+    graded = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "graph_injection_shadow": sampled,
+    })
+    assert any(
+        item["code"] == "v2_graph_injection_shadow_state" for item in graded["info"]
+    )
+    failed = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "graph_injection_shadow": {"collected": False, "error_code": "OSError"},
+    })
+    assert any(
+        item["code"] == "v2_graph_injection_shadow_collection_failed"
+        for item in failed["warn"]
+    )

--- a/tests/scripts/test_memory_os_graph_edge_weight_renormalization.py
+++ b/tests/scripts/test_memory_os_graph_edge_weight_renormalization.py
@@ -1,0 +1,175 @@
+"""P3 — 存量饱和权重一次性重归一脚本测试。
+
+重归一输入是分层出生权重之前的历史产物(新写入口已造不出 weight=1.0,
+乘性强化 + 0.005 最小增量也到不了)— 测试直接以生产同形状铺设存量,
+与 W2 压缩测试同理,不是绕过真实生产者。
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from plugins.memory.memory_os.edge_weights import EDGE_BIRTH_WEIGHTS
+from plugins.memory.memory_os.index import MemoryOSIndex
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+
+def _load_script():
+    script = _REPO_ROOT / "scripts" / "memory_os_graph_edge_weight_renormalization.py"
+    spec = importlib.util.spec_from_file_location(
+        "memory_os_graph_edge_weight_renormalization", script
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed(tmp_path):
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="default")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    index = MemoryOSIndex(roots)
+    index.rebuild_from_store(store)
+
+    edges_path = roots.memory_os_root / "graph" / "edges.jsonl"
+    edges_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def edge(i, rel, proposed_by, *, weight=1.0, source_event_id="", state="active"):
+        return {
+            "edge_id": f"edge_renorm_{i}",
+            "from_record_type": "crystallized_record",
+            "from_record_id": f"cry_from_{i}",
+            "to_record_type": "crystallized_record",
+            "to_record_id": f"cry_to_{i}",
+            "relation_type": rel,
+            "weight": weight,
+            "created_at": f"2026-06-0{(i % 8) + 1}T00:00:00+00:00",
+            "source_event_id": source_event_id,
+            "state": state,
+            "invalidated_at": None,
+            "proposed_by": proposed_by,
+        }
+
+    rows = [
+        edge(0, "depends_on", "structural"),                                  # → 0.70
+        edge(1, "co_occurs", "structural", source_event_id="evt_shared_1"),   # → 0.55
+        edge(2, "co_occurs", "structural"),                                   # → 0.45
+        edge(3, "refines", "structural"),                                     # 遗留语义提名 → 0.45
+        edge(4, "refines", "llm"),                                            # → 0.60
+        edge(5, "evidence_for", "provenance"),                                # → 0.70
+        edge(6, "co_occurs", "vector"),                                       # 1.0 vector:不动,计数
+        edge(7, "co_occurs", "structural", weight=0.55),                      # 已分层:不在计划内
+        edge(8, "refines", "structural", state="invalidated"),                # invalidated:不动
+    ]
+    with edges_path.open("a", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    conn = sqlite3.connect(str(roots.index_path))
+    conn.executemany(
+        "insert or replace into memory_edges (edge_id, from_record_type, from_record_id,"
+        " to_record_type, to_record_id, relation_type, weight, created_at,"
+        " source_event_id, state, invalidated_at, proposed_by)"
+        " values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            tuple(r[k] for k in (
+                "edge_id", "from_record_type", "from_record_id", "to_record_type",
+                "to_record_id", "relation_type", "weight", "created_at",
+                "source_event_id", "state", "invalidated_at", "proposed_by"))
+            for r in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return roots, store, index
+
+
+def _weights(index):
+    conn = sqlite3.connect(str(index.roots.index_path))
+    rows = conn.execute("select edge_id, weight from memory_edges").fetchall()
+    conn.close()
+    return {str(r[0]): float(r[1]) for r in rows}
+
+
+def test_renorm_dry_run_plans_without_writing(tmp_path):
+    roots, store, index = _seed(tmp_path)
+    mod = _load_script()
+
+    rc = mod.main(["--hermes-home", str(tmp_path), "--profile", "default"])
+    assert rc == 0
+
+    weights = _weights(index)
+    assert weights["edge_renorm_0"] == pytest.approx(1.0), "dry-run must not write"
+    report_path = roots.memory_os_root / "system" / "graph_edge_weight_renormalization_report.json"
+    assert not report_path.exists(), "dry-run must not persist the epoch report"
+
+
+def test_renorm_apply_maps_buckets_and_persists_report(tmp_path):
+    """反事实:apply 后各证据桶映射到位;vector/已分层/invalidated 不动;
+    纪元报告落盘(迁移全表 + 映射版本)。"""
+    roots, store, index = _seed(tmp_path)
+    mod = _load_script()
+
+    rc = mod.main(["--hermes-home", str(tmp_path), "--profile", "default", "--apply"])
+    assert rc == 0
+
+    weights = _weights(index)
+    assert weights["edge_renorm_0"] == pytest.approx(
+        EDGE_BIRTH_WEIGHTS[("structural", "explicit_reference")]
+    )
+    assert weights["edge_renorm_1"] == pytest.approx(
+        EDGE_BIRTH_WEIGHTS[("structural", "shared_source_event")]
+    )
+    assert weights["edge_renorm_2"] == pytest.approx(
+        EDGE_BIRTH_WEIGHTS[("structural", "body_similarity")]
+    )
+    assert weights["edge_renorm_3"] == pytest.approx(
+        EDGE_BIRTH_WEIGHTS[("structural", "body_similarity")]
+    )
+    assert weights["edge_renorm_4"] == pytest.approx(0.60)
+    assert weights["edge_renorm_5"] == pytest.approx(
+        EDGE_BIRTH_WEIGHTS[("provenance", "source_event_provenance")]
+    )
+    assert weights["edge_renorm_6"] == pytest.approx(1.0), "vector weights are real similarities"
+    assert weights["edge_renorm_7"] == pytest.approx(0.55), "already-tiered edges untouched"
+    assert weights["edge_renorm_8"] == pytest.approx(1.0), "invalidated edges untouched"
+
+    report_path = roots.memory_os_root / "system" / "graph_edge_weight_renormalization_report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["mapping_version"] == "v1"
+    assert report["migrated_count"] == 6
+    assert report["skipped_vector_count"] == 1
+    assert sorted(report["migrated_edge_ids"]) == [f"edge_renorm_{i}" for i in range(6)]
+    assert report["failed_count"] == 0
+    assert report["bucket_counts"]["structural_legacy_semantic"] == 1
+
+
+def test_renorm_survives_index_sync_and_is_idempotent(tmp_path):
+    """反事实(依赖 W0):重归一结果在重投影后保持;第二次 apply 计划为 0
+    (weight==1.0 不可再生 → 幂等)。"""
+    roots, store, index = _seed(tmp_path)
+    mod = _load_script()
+    rc = mod.main(["--hermes-home", str(tmp_path), "--profile", "default", "--apply"])
+    assert rc == 0
+
+    index.sync_from_store(store)
+    weights = _weights(index)
+    assert weights["edge_renorm_0"] == pytest.approx(
+        EDGE_BIRTH_WEIGHTS[("structural", "explicit_reference")]
+    ), "renormalized weight must survive reprojection (W0 canonical append)"
+
+    report2 = mod.renormalize_edge_weights(
+        MemoryOSRoots.from_hermes_home(tmp_path, profile="default"), apply=True,
+    )
+    assert report2["planned_count"] == 0, "second apply must find nothing to migrate"
+    assert report2["migrated_count"] == 0

--- a/tests/system_modularization/test_knob_lane_switch.py
+++ b/tests/system_modularization/test_knob_lane_switch.py
@@ -403,23 +403,25 @@ def test_register_override_rejects_value_not_in_allowed_non_bool(store_root):
 # ── A3.10: graph_layer_injection_enabled knob ──────────────────────────────
 
 def test_graph_layer_injection_enabled_is_registered_lane_switch(store_root):
-    """graph_layer_injection_enabled should be a lane_switch knob, default False."""
+    """graph_layer_injection_enabled: lane_switch, default True(P1 2026-08-07,
+    owner 裁定图谱为永久能力 — 开关保留作回滚,not for graduation;旧默认
+    False 靠无过期 override 撑着,override 丢失即静默变暗且监控不响)。"""
     from plugins.memory.memory_os.knob_overrides import OVERRIDABLE_KNOBS, resolve_knob
 
     spec = OVERRIDABLE_KNOBS.get("graph_layer_injection_enabled")
     assert spec is not None, "graph_layer_injection_enabled must be in OVERRIDABLE_KNOBS"
     assert spec.get("kind") == "lane_switch"
-    assert spec.get("default") is False
+    assert spec.get("default") is True
     assert spec.get("allowed") == [True, False]
     assert spec.get("meta") is False
 
     # Verify resolve_knob returns default when no override exists
     result = resolve_knob(
         "graph_layer_injection_enabled",
-        default=False,
+        default=True,
         _store_root=store_root,
     )
-    assert result is False
+    assert result is True
 
 
 def test_non_bool_allowed_list_would_not_trigger_type_guard():


### PR DESCRIPTION
图谱注入质量三题 + 顾问评审挖出的三个前置缺陷,按 S1→S2→S3 依赖序单批落地。

## S1 — 方向归一 + 中文自然语言渲染(F1/P2)
- **F1 正确性缺陷**:`query_edges` 匹配 `from OR to`,渲染无条件取 `to_record_id` — 「X→锚点」边把锚点自己当"关联记忆"展示,depends_on 方向读反;四处同改(seen 判定/预览目标/seen.add/`source_ids` 披露归属)。
- 行文法:`- 「锚点预览12字」方向短语:邻居正文预览(已列出·关联度 w)`;方向敏感中文短语表(module 级,producer 词表双向守卫);去重命中降级 60 字符正文短预览(结晶段同一正文精确前缀 = 零歧义对齐键),取代 `↺`+裸 ID;`[unresolved:id]` 兜底删除,record_id 永不进入上下文;同对多边聚合一行;批量结晶解析替换最坏 16 次全扫;事件端点经 events 缓存解析。

## S2 — shadow v1 + R4 真实命中口径(F2/F3)
- shadow 移到渲染后,每边 `injected` + 封闭 `outcome`(8 值),anchor_ids 入行;v0 时代「查到边」=「注入命中」,knob 关闭期的边也被当命中强化。
- R4 只认 `injected=True`(缺字段历史行按旧语义);遗忘守卫 `shadow_exists`→`first_injection_at`(v0 state 保守迁移,v1 空值是真实信号);`update_edge_weight` no-op 可判定(F3:生产首轮报的 32 条「强化」全部是 no-op)+0.005 最小增量;新计数 already_saturated / skipped_not_injected / invalidated_never_hit(饿死信号) / forget_eligible_backlog(遗忘潮可见性)。

## S3 — 分层出生权重 + 探索位 + 默认翻转 + 监控 + 重归一(P3/P1)
- 出生权重按证据强度分层:structural 0.35–0.70、llm `0.45+0.30×confidence`(confidence 本已采集、写入时被硬编码 1.0 丢弃)、provenance 0.70、vector=sim;全部 <1.0 且 ≥ 注入下限;R4 强化改乘性 `w+=0.12×(1−w)`,cap 不可达。
- 反饿死探索位(与分层同批,单发分层比现状更糟):候选 32,top-6 按权重 + 2 探索位按天确定性轮转(crc32 无随机数);落选 `not_selected` 落账。
- P1 默认翻 True(注册表+调用点两处;开关留作回滚);监控判据 expired→`effective≠expected`(resolver 本体取值 + 一致性守卫测试),新增 `v2_graph_injection_shadow_state` INFO(7 天 v1 行/outcome 分布,零样本 `healthy_no_sample` 不买绿)。
- 一次性重归一脚本(dry-run 默认/--apply/幂等/W0 持久/纪元报告含迁移全表);部署后在生产 dry-run→apply。

## 验证
- 全量 **3264 passed / 13 skipped / 0 failed**(CH 基线 3233,+31)
- 四静态门全绿:import cycle 0 / write surface unclassified 0 / static hygiene pass / public checkout probe PASS;`git diff --check` 干净
- 反事实测试:F1 方向(B→A 边必须展示 B)、F2 幽灵命中(injected=False 不强化)、F2 守卫(仅 knob_disabled 行不遗忘)、F3 饱和分账、探索位轮转确定性、默认翻转双向(无 override 注入/False override 关火)、出生权重四分支走真实 producer、重归一分桶+幂等+重投影存活
