### PR TITLE
Deploy-verification fixes: R4 counters through both whitelists + attribution era v1->v2

### DIFF
--- a/plugins/memory/memory_os/cognitive_loop.py
+++ b/plugins/memory/memory_os/cognitive_loop.py
@@ -1153,12 +1153,19 @@ class CognitiveLoopRunner:
         )
         context["edge_weight_feedback_result"] = result
         return {
-            "schema_version": "memory-os.cognitive_loop.edge_weight_feedback.v0",
+            "schema_version": "memory-os.cognitive_loop.edge_weight_feedback.v1",
             "status": result.get("status", "ok"),
             "outcome": result.get("outcome", ""),
             "new_hit_record_count": result.get("new_hit_record_count", 0),
             "reinforced_count": result.get("reinforced_count", 0),
+            # v1(S2/S3 生产验证发现):白名单透传缺了新计数 — 报告工件与
+            # 监控的 edge_step_results 读的都是这里,漏键即对读者不存在
+            # (「计算了却无人读」的镜像:算了却传不出去)。
+            "already_saturated_count": result.get("already_saturated_count", 0),
+            "skipped_not_injected_count": result.get("skipped_not_injected_count", 0),
             "forgotten_count": result.get("forgotten_count", 0),
+            "invalidated_never_hit_count": result.get("invalidated_never_hit_count", 0),
+            "forget_eligible_backlog": result.get("forget_eligible_backlog", 0),
             "unresolved_hit_count": result.get("unresolved_hit_count", 0),
             "failed_count": result.get("failed_count", 0),
             "duration_ms": result.get("duration_ms", 0),

--- a/plugins/memory/memory_os/memory_sources.py
+++ b/plugins/memory/memory_os/memory_sources.py
@@ -26,7 +26,15 @@ SCHEMA_VERSION = "memory-os.memory_sources.v0"
 # handles rollup rows written before `trigger_class` existed. Without this
 # boundary, fixing the producer could never clear the FAIL: on production all 69
 # gapped rows are natural rows, so they sit inside the gated era forever.
-ATTRIBUTION_SCHEMA_VERSION = "memory-os.memory_sources_attribution.v1"
+# v1→v2(2026-08-07):v1 宣称「归属完备 producer」,生产数据证伪 — graph
+# 注入路径(F1 方向归一之前)存在一条 596 字符已展示、source_ids 为空的
+# v1 纪元内自然行(09:51Z),而纪元门按全纪元计 gap,该行会永久 FAIL 且
+# 无法追溯补齐(披露已发生)。按既有纪元边界模式处理:v1 行整体降为已
+# 分类债务(legacy_unattributed_record_count,all_history 计数保留),
+# v2 从今日(S1 归属线程钉死后的首个真正完备 producer)起受门约束;
+# 零 v2 样本走既有 healthy_no_sample + attribution_era_no_sample 冻结
+# 护栏,不买绿。
+ATTRIBUTION_SCHEMA_VERSION = "memory-os.memory_sources_attribution.v2"
 LAST_SCHEMA_VERSION = "memory-os.memory_sources_last.v0"
 HISTORY_SCHEMA_VERSION = "memory-os.memory_sources_history.v0"
 STATS_SCHEMA_VERSION = "memory-os.memory_sources_stats.v0"

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -7196,6 +7196,10 @@ def cognitive_loop_step_evidence():
       "write_failed_count", "candidate_count", "promoted_count",
       "ttl_invalidated_count", "failed_count", "scanned_ref_count",
       "new_hit_record_count", "reinforced_count", "forgotten_count",
+      # R4 v1 counters(S2/S3):饱和分账、非注入过滤、饿死信号、遗忘积压 —
+      # 两层白名单(loop 包装器 + 这里)漏任何一层,计数对读者即不存在。
+      "already_saturated_count", "skipped_not_injected_count",
+      "invalidated_never_hit_count", "forget_eligible_backlog",
       "unresolved_hit_count", "duration_ms", "error",
     )
     edge_step_results = {}

--- a/tests/plugins/memory/test_memory_os_cognitive_loop.py
+++ b/tests/plugins/memory/test_memory_os_cognitive_loop.py
@@ -902,3 +902,40 @@ def test_w5_edge_proposer_step_wrappers_propagate_skip_reason(tmp_path):
     vector = runner._vector_edge_proposer({})
     assert vector["status"] == "skipped"
     assert vector.get("reason") == "knob_disabled"
+
+
+def test_edge_weight_feedback_wrapper_passes_through_r4_counters(tmp_path, monkeypatch):
+    """反事实(S3 生产验证实锤):step 包装器白名单漏键 = 计数对一切读者
+    不存在 — 报告工件与监控 edge_step_results 读的都是包装器返回值。
+    already_saturated / skipped_not_injected / invalidated_never_hit /
+    forget_eligible_backlog 四个 R4 新计数必须透传。"""
+    store = _init_store(tmp_path)
+    runner = CognitiveLoopRunner(store)
+
+    import plugins.memory.memory_os.edge_weight_feedback as ewf
+
+    def _fake_run(index_path, *, index=None, audit_path=None, now=None):
+        return {
+            "status": "ok",
+            "outcome": "reinforced",
+            "new_hit_record_count": 3,
+            "reinforced_count": 1,
+            "already_saturated_count": 2,
+            "skipped_not_injected_count": 4,
+            "forgotten_count": 5,
+            "invalidated_never_hit_count": 5,
+            "forget_eligible_backlog": 7,
+            "unresolved_hit_count": 0,
+            "failed_count": 0,
+            "tracked_edge_count": 9,
+            "duration_ms": 1,
+        }
+
+    monkeypatch.setattr(ewf, "run_edge_weight_feedback", _fake_run)
+    summary = runner._edge_weight_feedback({})
+    assert summary["already_saturated_count"] == 2
+    assert summary["skipped_not_injected_count"] == 4
+    assert summary["invalidated_never_hit_count"] == 5
+    assert summary["forget_eligible_backlog"] == 7
+    assert summary["reinforced_count"] == 1
+    assert summary["outcome"] == "reinforced"

--- a/tests/plugins/memory/test_memory_os_phase1_observability.py
+++ b/tests/plugins/memory/test_memory_os_phase1_observability.py
@@ -122,6 +122,38 @@ def test_exposure_stats_separate_legacy_debt_from_schema_era_health_and_freeze_g
     assert stats["conservation_total_passes"] is True
 
 
+def test_v1_era_gapped_rows_are_debt_not_permanent_gate_fail(tmp_path):
+    """纪元 v1→v2 反事实(2026-08-07):v1 曾宣称归属完备,生产证伪 —
+    E8c 时代 graph 路径留下一条已展示但 source_ids 为空的 v1 纪元内自然行,
+    纪元门按全纪元计 gap → 永久 FAIL 且无法追溯补齐。版本升级后该行必须
+    降为已分类债务:不进 schema_era gap 门(修复缺席=常量仍为 v1 时本测试
+    必红),但 all_history 与 legacy 债务计数保留(分类而非抹除)。"""
+    store = _store(tmp_path)
+    append_memory_source_record(store.roots, {
+        "record_id": "v1-era-graph-gap",
+        "created_at": "2026-08-07T09:51:49Z",
+        "natural_production": True,
+        "traffic_class": "production",
+        # 字面 v1(不是常量):钉住的就是「旧纪元行不再受门约束」这件事
+        "attribution_schema": "memory-os.memory_sources_attribution.v1",
+        "selected": [_section(source_ids=[])],
+        "dropped": [],
+    })
+
+    stats = exposure_monitor_stats(store, now=datetime(2026, 8, 8, 0, tzinfo=timezone.utc))
+
+    assert stats["schema_era_attribution_gap_count"] == 0, (
+        "v1 rows must leave the gated set after the era bump"
+    )
+    assert stats["all_history_attribution_gap_count"] == 1, (
+        "debt is classified, never erased"
+    )
+    assert stats["legacy_unattributed_record_count"] == 1
+    # 零 v2 样本:诚实护栏 — no-sample + 冻结,不买绿
+    assert stats["schema_era_health"] == "healthy_no_sample"
+    assert "attribution_era_no_sample" in stats["freeze_reasons"]
+
+
 def test_budget_pressure_streak_requires_consecutive_calendar_days(tmp_path):
     store = _store(tmp_path)
     append_memory_source_record(store.roots, {

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -8520,3 +8520,61 @@ def test_v2_graph_injection_shadow_state_collection_and_wiring(tmp_path):
         item["code"] == "v2_graph_injection_shadow_collection_failed"
         for item in failed["warn"]
     )
+
+
+def test_r4_counters_survive_both_whitelists_end_to_end(tmp_path, monkeypatch):
+    """双层白名单防漂移守卫(S3 生产验证实锤):R4 v1 计数要抵达监控读者,
+    必须先穿过 loop 包装器的键透传、再穿过采集端 _edge_fields 过滤 —
+    两层漏任何一层,计数对读者即不存在。本测试用真实包装器的输出喂真实
+    采集器,端到端断言四个计数存活。"""
+    import json as _json
+
+    from plugins.memory.memory_os.cognitive_loop import CognitiveLoopRunner
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="default")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    runner = CognitiveLoopRunner(store)
+
+    import plugins.memory.memory_os.edge_weight_feedback as ewf
+
+    def _fake_run(index_path, *, index=None, audit_path=None, now=None):
+        return {
+            "status": "ok", "outcome": "reinforced",
+            "new_hit_record_count": 3, "reinforced_count": 1,
+            "already_saturated_count": 2, "skipped_not_injected_count": 4,
+            "forgotten_count": 5, "invalidated_never_hit_count": 5,
+            "forget_eligible_backlog": 7, "unresolved_hit_count": 0,
+            "failed_count": 0, "duration_ms": 1,
+        }
+
+    monkeypatch.setattr(ewf, "run_edge_weight_feedback", _fake_run)
+    wrapper_summary = runner._edge_weight_feedback({})
+
+    report = {
+        "cycle_id": "cycle-guard-1",
+        "status": "ok",
+        "steps": [{
+            "step": "edge_weight_feedback",
+            "status": "ok",
+            "duration_ms": 1,
+            "result": wrapper_summary,
+        }],
+        "step_summary": {"step_count": 1, "omitted_step_count": 0, "tail_step_statuses": {}},
+    }
+    mod_dir = tmp_path / "system-modules" / "cognitive_loop"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "reports.jsonl").write_text(
+        _json.dumps(report) + "\n", encoding="utf-8",
+    )
+
+    namespace = _exec_graph_knob_probe_prefix(tmp_path)
+    evidence = namespace["cognitive_loop_step_evidence"]()
+    surfaced = evidence["edge_step_results"]["edge_weight_feedback"]
+    assert surfaced["already_saturated_count"] == 2
+    assert surfaced["skipped_not_injected_count"] == 4
+    assert surfaced["invalidated_never_hit_count"] == 5
+    assert surfaced["forget_eligible_backlog"] == 7
+    assert surfaced["reinforced_count"] == 1


### PR DESCRIPTION
PR #46 部署到 hermes-media 后的逐项生产验证挖出两个真问题,当场修复:

## S3.1 — R4 v1 计数被两层白名单静默剥掉
部署后 run-once 实测:cognitive_loop 的 step 包装器按固定键集透传 `edge_weight_feedback` 摘要,四个新计数(already_saturated / skipped_not_injected / invalidated_never_hit / forget_eligible_backlog)被剥掉;监控采集端 `_edge_fields` 是第二层同病白名单。两层漏任何一层,计数对读者即不存在(「计算了却无人读」的镜像:算了却传不出去)。修复:包装器 schema v0→v1 补四键、监控 `_edge_fields` 补四键、端到端双白名单守卫测试(真实包装器输出喂真实采集器)。

## S3.2 — 归属纪元 v1→v2(v1 完备性宣称被生产证伪)
Full Monitor 出现 `v2_exposure_schema_era_unhealthy` FAIL,定位到一条 09:51Z 的 v1 纪元内自然行:Related Memory 已展示 596 字符而 source_ids 为空(F1 之前的 graph 注入路径归属缺口)。纪元门按全纪元计 gap → 该行**永久 FAIL** 且无法追溯补齐。按既有纪元边界模式:常量 v1→v2,v1 行整体降为已分类债务(all_history 计数保留,分类而非抹除),v2 从 S1 归属线程钉死后的首个真正完备 producer 起受门约束,零 v2 样本走既有 healthy_no_sample + 冻结护栏。反事实(字面 v1 行)经 cp 回退实证无 bump 必红。

## 验证
- 静态四门全绿 + git diff --check 干净
- 全量测试(本地)与 CI 均须绿后合并
