### PR TITLE
CK: graph_anchor_provenance — router must not re-veto anchor-established graph sections

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -3939,6 +3939,15 @@ first_injection_at=2026-08-07 起算 60 天,过密图谱（refines 为主,重归
 `invalidated_never_hit_count` 持续走高 = 探索位轮转覆盖不足（饿死信号）。
 届时另核 09:55Z 失控 disable 行来源（CJ 节,owner 确认是否本人所写）。
 
+**Indexed Recall 的 router 二审问题（CK 登记 → 当日按历史数据裁定:维持
+现状,不修）**：owner 追问「历史数据能否立刻下结论」— 能。全史 1030 条
+披露行实测:Indexed 非空出现 303 次,选入 160(52.8%);丢弃 143 中
+route_excludes 123(旧版路由规则,已不在现行代码)、风险码击杀 53(防
+泄漏正常工作)、**词表 below_threshold 仅 18(6%)**;近期切片(08-01 起,
+E8b 后)选入 14/词表否决 1/风险 0 — 当前流量下几乎不存在。6% 不构成
+放宽 casual 防线的理由。对照:同账本 Related Memory 全史仅出现 1 次
+(CK 的必要性一个数字说明)。若未来 agent 体验反例出现可凭同一账本重查。
+
 **V3 激活复查日：2026-09-05（不许无日期搁置——owner 决策 2026-08-06）。**
 标准：届时 `v3_seed_evidence_snapshot.activation_evidence_ready=True` 且
 Full Monitor 0 FAIL → 开启 R4（`wandering_enabled=true` 影子观察 14 天再评
@@ -5157,3 +5166,25 @@ first_injection_at=2026-08-07 起算,首波大规模遗忘潮预期落点 **2026
   effective≠expected 判据（首个生产 run 抓到失控 disable 行）、双层白名单
   剥计数修复、归属纪元 v1→v2（完备性宣称被生产证伪）;全量 3267/13,
   终验 102/4/0。
+
+### CK — router 弱谓词二审否决图谱段（2026-08-07 深夜,Hermes agent 亲测反馈）
+
+owner 转达 agent 真实体验:shadow 活跃(23 边/4 关系/带权重)但上下文无
+Related Memory 段。agent 自诊「cry_xxx 触发 mechanism_leak 扣 0.80」——
+**细节不对但结论对**:`_MECHANISM_PATTERNS` 并不匹配 cry_,旧行真正死因
+是纯零分(ASCII 实体不可能与中文 query 相交、固定中文词表匹配不上)
+below_threshold。且 agent 看到的是**旧渲染器**输出:gateway 23:44(CST)
+才重启,其引用的 `_resolve_edge_target_preview` 在 S1 已删除。
+
+**结构性缺陷(新行文法也逃不掉的那部分)**:图谱段相关性由锚点机制在
+上游用真实查询词建立(FTS 命中一跳,含 E8b 中文回退),router 的固定词表
+是更弱的谓词 — 让它重新裁决 = 「FTS 命中、词表盲区、整段否决」,锚点
+机制白干。修复:`_score_section` 给 `source_class=='graph_layer'` 且非空
+文本 +0.35(`graph_anchor_provenance` 独立 reason code)。不豁免三样:
+风险码(-0.80 仍击杀泄漏行,0.35-0.80<0.30 反事实钉住)、路由排除
+(ambiguous_recall/diagnostic 照旧)、预算排序。**刻意不含 indexed**:
+casual 兜底路由下词表不匹配的 Indexed 内容不免票是被
+`test_casual_continuity_report_selects_safe_carryover_without_mechanism_
+working` 钉住的既有强度 — 实现首版含 indexed 被该测试当场拦下,按
+「不放宽既有测试迁就新改动」裁决收窄;indexed 的同族问题(FTS 命中被
+词表二审否决)是否也修,归 owner 单独裁决(待办)。

--- a/plugins/memory/memory_os/context_router.py
+++ b/plugins/memory/memory_os/context_router.py
@@ -19,6 +19,19 @@ SCHEMA_VERSION = "memory-os.context_router.v0"
 INCLUDE_THRESHOLD = 0.30
 RANKING_MODE = "score_then_budget"
 
+# 图谱锚点溯源加分(CK 2026-08-07):Related Memory 的内容由当前 query 的
+# FTS 命中锚点一跳展开(锚点收集含 E8b 中文回退)— 相关性已在上游用真实
+# 查询词建立。本文件的打分词表(ASCII 实体 + 固定中文词表)是更弱的谓词,
+# 让它重新裁决会出现「FTS 命中、词表盲区、整段否决」:生产实测图谱行对
+# 纯中文 query 恒 0 分被 below_threshold 掉,锚点机制白干。加分不豁免
+# 风险码(-0.80 仍可击杀泄漏行)、路由排除与预算排序。
+# 刻意不含 "indexed":casual 兜底路由下词表不匹配的 Indexed Recall 内容
+# 不免票是被测试钉住的既有强度(test_casual_continuity_report_selects_
+# safe_carryover_without_mechanism_working);FTS 命中被词表二审否决的
+# 同族问题对 indexed 是否也该修,留 owner 单独裁决(待办登记)。
+_QUERY_PROVENANCE_SOURCE_CLASSES = frozenset({"graph_layer"})
+GRAPH_ANCHOR_PROVENANCE_SCORE = 0.35
+
 # FIX 3 (P3 audit): `allocated_chars` on each selected-section entry below is
 # an ADVISORY per-section budget projection computed by this dry-run/apply
 # router only -- it has no consumer. The real "apply" path
@@ -459,6 +472,12 @@ def _score_section(section: ContextSection, *, query: str, current_task_anchor: 
     if section.section == "Current Foreground Task" or entity_matches & anchor_terms["entities"]:
         score += 0.50
         reasons.append("foreground_anchor")
+    if (
+        section.source_class in _QUERY_PROVENANCE_SOURCE_CLASSES
+        and section.text.strip()
+    ):
+        score += GRAPH_ANCHOR_PROVENANCE_SCORE
+        reasons.append("graph_anchor_provenance")
     if section.metadata and section.metadata.get("fresh"):
         score += 0.10
         reasons.append("freshness_match")

--- a/tests/plugins/memory/test_memory_os_context_router.py
+++ b/tests/plugins/memory/test_memory_os_context_router.py
@@ -774,3 +774,65 @@ def test_context_router_cli_dry_run_outputs_json_and_does_not_write_store(tmp_pa
     assert output["mode"] == "dry_run"
     assert output["route"] == "active_task"
     assert before_audit == after_audit
+
+
+def test_ck_graph_anchor_provenance_passes_router_for_chinese_lines():
+    """CK 反事实(Hermes agent 真实体验实锤):图谱段相关性由锚点机制在
+    上游用真实查询词建立(FTS 命中一跳),router 的固定词表是更弱谓词 —
+    修复缺席时,与词表零交集的中文图谱行恒 0 分被 below_threshold 否决,
+    锚点机制白干(生产:shadow 活跃 23 边/4 关系,上下文却无 Related
+    Memory 段)。加分后免二审,但不豁免风险码与路由排除。"""
+    graph = ContextSection(
+        section="Related Memory",
+        # 新行文法、纯中文、与 _CHINESE_KEYWORDS 词表和 query 均无交集
+        text="- 「昨晚聊到的晚饭」同源共现于:上次说想试那家新开的粤菜馆,约在周五(关联度 0.55)",
+        source_class="graph_layer",
+    )
+    report = route_context_sections(
+        "那家店后来去了吗?",
+        sections=[graph],
+        current_task_anchor="",
+        budget_chars=1200,
+    )
+    selected = {item["section"] for item in report["selected_sections"]}
+    assert "Related Memory" in selected, (
+        f"anchor-established graph section must not be re-vetoed by the weaker "
+        f"vocabulary predicate: {report['dropped_sections']}"
+    )
+    entry = next(i for i in report["selected_sections"] if i["section"] == "Related Memory")
+    assert "graph_anchor_provenance" in entry["reason_codes"]
+
+
+def test_ck_graph_provenance_does_not_exempt_risk_codes():
+    """风险码仍可击杀:含机制词的图谱行 0.35-0.80 < 0.30 → 依旧丢弃。"""
+    leaky = ContextSection(
+        section="Related Memory",
+        text="- 「注入卡片」同源共现于:system prompt 与 prefetch 的内部反思细节(关联度 0.55)",
+        source_class="graph_layer",
+    )
+    report = route_context_sections(
+        "随便聊聊今天的天气",
+        sections=[leaky],
+        current_task_anchor="",
+        budget_chars=1200,
+    )
+    dropped = {item["section"] for item in report["dropped_sections"]}
+    assert "Related Memory" in dropped, "mechanism-leak graph lines must still die"
+    entry = next(i for i in report["dropped_sections"] if i["section"] == "Related Memory")
+    assert "mechanism_leak_detected" in entry["reason_codes"]
+
+
+def test_ck_graph_provenance_requires_nonempty_text_and_not_indexed():
+    """空文本无加分;indexed 刻意不在溯源集合(casual 路由词表不匹配的
+    Indexed 内容不免票 — 既有测试钉住的强度,是否放宽归 owner 裁决)。"""
+    from plugins.memory.memory_os.context_router import (
+        _QUERY_PROVENANCE_SOURCE_CLASSES,
+        _score_section,
+    )
+
+    assert _QUERY_PROVENANCE_SOURCE_CLASSES == frozenset({"graph_layer"})
+
+    empty = ContextSection(section="Related Memory", text="   ", source_class="graph_layer")
+    score, reasons = _score_section(empty, query="随便聊聊", current_task_anchor="")
+    assert "graph_anchor_provenance" not in reasons
+    assert score < 0.30


### PR DESCRIPTION
Hermes agent 亲测:shadow 活跃但上下文无 Related Memory。结构性缺陷=图谱段相关性已由锚点机制(FTS 命中一跳)在上游建立,router 固定词表是更弱谓词却有否决权(生产账本:全史 1030 行 Related Memory 仅出现 1 次)。修复:graph_layer 非空段 +0.35 graph_anchor_provenance;不豁免风险码/路由排除/预算(反事实钉住)。indexed 刻意不含:被既有 casual 防泄漏测试拦下后按规矩收窄,并按 owner 要求以历史数据裁定维持现状(词表否决率 6%、近期 1/15)。全量 3270/13,静态门全绿。含 checklist CK 节。