### PR TITLE
P0-P2: profile attribution mainlining, lane last-run reason codes, loop health view, version gate, recall eval categories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
           python-version: '3.11'
           cache: pip
 
+      - name: Enforce release tag / pyproject version single source
+        if: github.ref_type == 'tag'
+        run: python scripts/memory_os_version_consistency_check.py --repo-root . --tag "${{ github.ref_name }}"
+
       - name: Install test dependencies
         run: python -m pip install -e '.[dev]'
 

--- a/plugins/memory-os-agent-os/__init__.py
+++ b/plugins/memory-os-agent-os/__init__.py
@@ -183,12 +183,20 @@ def _load_memory_os_audit_api() -> tuple[Any, Any]:
 
 
 def _resolve_profile() -> str:
-    return (
+    explicit = (
         os.environ.get("HERMES_PROFILE")
         or os.environ.get("HERMES_AGENT_IDENTITY")
         or os.environ.get("HERMES_AGENT_NAME")
-        or "default"
     )
+    if explicit:
+        return explicit
+    # Multi-profile hosts often export only HERMES_HOME
+    # (.../profiles/<name>); derive the profile from that shape instead of
+    # collapsing to "default" and mis-attributing the profile's records.
+    home = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes")).expanduser().resolve()
+    if home.name and home.parent.name == "profiles":
+        return home.name
+    return "default"
 
 
 def register_cli(subparser: argparse.ArgumentParser) -> None:

--- a/plugins/memory/memory_os/cron_registry.py
+++ b/plugins/memory/memory_os/cron_registry.py
@@ -561,6 +561,51 @@ MEMORY_OS_CRON_LANES: tuple[MemoryOSCronLaneDef, ...] = (
 )
 
 
+# ── Per-lane last-run evidence census ("Completion Is Not Output") ──────────
+#
+# Every lane must declare HOW a reader separates "no eligible input" from
+# "processing failed" without re-running it:
+#
+#   "lane_last_run"      — writes the standard system/lane_last_run/<lane_id>.json
+#                          record (plugins.memory.memory_os.lane_last_run).
+#   "dedicated_artifact" — carries its own richer per-run artifact with a
+#                          closed reason/status set (e.g. exposure_rollup's
+#                          snapshot last_run block, v3_wandering_runs.jsonl,
+#                          session_fact_extraction runs.jsonl).
+#
+# A census test pins this table to MEMORY_OS_CRON_LANES in both directions,
+# so a new lane cannot be registered without triaging its evidence surface
+# at birth — the pattern that closed the exposure_monitor_stats orphan-key
+# class of drift.
+LANE_LAST_RUN_EVIDENCE: dict[str, str] = {
+    "event_stats_refresh": "lane_last_run",
+    "index_sync": "lane_last_run",
+    "state_overlay_refresh": "dedicated_artifact",  # system/state_overlay/runs.jsonl
+    "entity_index_refresh": "dedicated_artifact",  # system/entity_index_runs.jsonl
+    "proposal_followups_opsgate": "lane_last_run",
+    "clearance_cycle": "lane_last_run",
+    "hindsight_health_probe": "lane_last_run",
+    "fact_judge": "lane_last_run",
+    "candidate_aggregation": "lane_last_run",
+    "l3_probe_verification": "lane_last_run",
+    "v3_wandering": "dedicated_artifact",  # system/v3_wandering_runs.jsonl
+    "session_fact_extraction": "dedicated_artifact",  # system-modules/session_fact_extraction/runs.jsonl
+    "exposure_rollup": "dedicated_artifact",  # exposure_rollup_snapshot.json last_run block
+    "v3_seed_evidence": "dedicated_artifact",  # v3_seed_edges_daily.jsonl + snapshot
+    "v3_journal_sweep": "lane_last_run",
+    "working_cleanup": "lane_last_run",
+    "state_source_mirror": "lane_last_run",
+    "hindsight_advisory_digest": "lane_last_run",
+    "owner_review_digest_render": "lane_last_run",
+    "memory_sources_feedback_request": "lane_last_run",
+    "expression_feedback_request": "lane_last_run",
+    "full_monitor_refresh": "lane_last_run",
+    "module_cadence_report": "dedicated_artifact",  # system-modules/module_cadence/reports.jsonl
+}
+
+LANE_LAST_RUN_EVIDENCE_KINDS = frozenset({"lane_last_run", "dedicated_artifact"})
+
+
 def _build_specs() -> tuple[MemoryOSCronSpec, ...]:
     groups = {group.key: group for group in MEMORY_OS_CRON_GROUPS}
     missing = sorted({lane.group_key for lane in MEMORY_OS_CRON_LANES} - set(groups))

--- a/plugins/memory/memory_os/lane_last_run.py
+++ b/plugins/memory/memory_os/lane_last_run.py
@@ -1,0 +1,119 @@
+"""Standard per-lane last-run evidence ("Completion Is Not Output").
+
+An ExecutionGate envelope records that a lane *ran*, never that it
+*produced* anything — a lane with nothing to do and a broken lane both
+close a clean envelope.  Every lane that can legitimately produce nothing
+must therefore leave a durable per-run record of WHY, using a closed
+per-lane reason set, so a reader can separate "no eligible input" from
+"input existed but processing failed" without re-running anything or
+reading source.
+
+This module is the standard writer for that record:
+``<hermes_home>/memory-os/system/lane_last_run/<lane_id>.json``.
+
+Semantics:
+* ``status`` describes the lane RUN itself: ``ok`` (ran to its decision
+  point), ``skipped`` (declined to run: disabled / not eligible), or
+  ``error`` (the run failed).
+* ``reason`` is the lane's closed-set outcome code (e.g. ``produced``,
+  ``no_new_records``, ``sessions_dir_absent``, ``llm_empty_content``).
+* ``counters`` are small bounded ints (inputs scanned / eligible /
+  produced, failures by reason).
+
+Lanes that already carry richer artifacts (exposure_rollup's snapshot
+``last_run`` block, session_mirror's auto-apply file, v3_wandering's runs
+ledger) keep them; this file is the uniform surface new wiring targets and
+the Loop Health projection reads first.
+
+Writes are single-file atomic replaces (state file, not a ledger), matching
+the ``session_mirror_auto_apply_last_run.json`` precedent, and fail-open:
+evidence about a lane must never break the lane.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+LANE_LAST_RUN_SCHEMA_VERSION = "memory-os.lane_last_run.v0"
+
+_ALLOWED_STATUSES = ("ok", "skipped", "error")
+_MAX_ERROR_CHARS = 300
+_MAX_COUNTERS = 24
+
+
+def lane_last_run_path(hermes_home: str | Path, lane_id: str) -> Path:
+    return Path(hermes_home) / "memory-os" / "system" / "lane_last_run" / f"{lane_id}.json"
+
+
+def record_lane_last_run(
+    hermes_home: str | Path,
+    lane_id: str,
+    *,
+    status: str,
+    reason: str,
+    counters: dict[str, int] | None = None,
+    error: str = "",
+) -> bool:
+    """Atomically write the lane's last-run record. Fail-open, returns success."""
+    try:
+        if status not in _ALLOWED_STATUSES:
+            status = "error"
+        record: dict[str, Any] = {
+            "schema_version": LANE_LAST_RUN_SCHEMA_VERSION,
+            "lane_id": str(lane_id),
+            "recorded_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "status": status,
+            "reason": str(reason)[:120],
+        }
+        if counters:
+            bounded: dict[str, int] = {}
+            for index, (key, value) in enumerate(sorted(counters.items())):
+                if index >= _MAX_COUNTERS:
+                    break
+                try:
+                    bounded[str(key)[:64]] = int(value)
+                except (TypeError, ValueError):
+                    continue
+            record["counters"] = bounded
+        if error:
+            record["error"] = str(error)[:_MAX_ERROR_CHARS]
+        path = lane_last_run_path(hermes_home, lane_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{lane_id}.", suffix=".tmp", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(record, handle, ensure_ascii=False, sort_keys=True)
+            os.replace(tmp_name, path)
+        except BaseException:
+            with_suppressed_unlink(tmp_name)
+            raise
+        return True
+    except Exception as exc:  # noqa: BLE001 - evidence must never break the lane
+        try:
+            sys.stderr.write(f"lane_last_run: write failed for {lane_id}: {exc}\n")
+        except Exception:  # noqa: BLE001
+            pass
+        return False
+
+
+def with_suppressed_unlink(tmp_name: str) -> None:
+    try:
+        os.unlink(tmp_name)
+    except OSError:
+        pass
+
+
+def read_lane_last_run(hermes_home: str | Path, lane_id: str) -> dict[str, Any] | None:
+    """Read the lane's last-run record; None when absent or malformed."""
+    path = lane_last_run_path(hermes_home, lane_id)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None

--- a/plugins/memory/memory_os/loop_health_view.py
+++ b/plugins/memory/memory_os/loop_health_view.py
@@ -1,0 +1,176 @@
+"""Loop Health View — a read-only projection over existing lane evidence.
+
+Groups the registered cron lanes into the production loops the owner
+reasons about (memory, cognition, graph, self-evolution, expression, …) and
+rolls up each loop's state from the per-lane last-run evidence
+(``system/lane_last_run/<lane_id>.json``, see lane_last_run.py).
+
+Deliberate constraints:
+
+* **Projection only.** This module writes nothing, owns no ledger, and adds
+  no authority — it reads artifacts other lanes already produce.  Deleting
+  it loses nothing but a view.
+* **Standard evidence only (phase 1).** Lanes whose evidence lives in a
+  dedicated richer artifact (exposure_rollup's snapshot, v3_wandering's runs
+  ledger, …, per cron_registry.LANE_LAST_RUN_EVIDENCE) are listed with
+  ``evidence: "dedicated_artifact"`` and do not influence the loop state —
+  the row tells the reader where to look instead of pretending to know.
+* **Freshness comes from the lane's own cadence** (due_interval_minutes),
+  never from a group's cron expression — deriving it from the schedule
+  collapses a weekly lane sharing a daily tick into a permanently-stale one.
+
+Loop states (closed set):
+
+* ``attention``   — some member's last run reported status=error
+* ``active``      — no errors, and at least one fresh ok run
+* ``idle``        — evidence exists but only skips / stale runs
+* ``no_evidence`` — no member has standard evidence on disk yet
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .cron_registry import LANE_LAST_RUN_EVIDENCE, MEMORY_OS_CRON_LANES
+from .lane_last_run import read_lane_last_run
+
+LOOP_HEALTH_VIEW_SCHEMA_VERSION = "memory-os.loop_health_view.v0"
+
+# Every registered lane appears in exactly one loop; a guard test pins this
+# partition against MEMORY_OS_CRON_LANES in both directions so a new lane
+# must be placed (or the table consciously extended) at birth.
+LOOP_MEMBERS: dict[str, tuple[str, ...]] = {
+    "memory": (
+        "event_stats_refresh",
+        "index_sync",
+        "candidate_aggregation",
+        "fact_judge",
+        "session_fact_extraction",
+        "working_cleanup",
+        "state_source_mirror",
+        "exposure_rollup",
+    ),
+    "cognition": (
+        "clearance_cycle",
+        "l3_probe_verification",
+        "state_overlay_refresh",
+        "entity_index_refresh",
+    ),
+    "graph": (
+        "v3_wandering",
+        "v3_seed_evidence",
+        "v3_journal_sweep",
+    ),
+    "self_evolution": (
+        "proposal_followups_opsgate",
+        "module_cadence_report",
+    ),
+    "expression": (
+        "expression_feedback_request",
+    ),
+    "owner_review": (
+        "owner_review_digest_render",
+        "memory_sources_feedback_request",
+    ),
+    "substrate": (
+        "hindsight_health_probe",
+        "hindsight_advisory_digest",
+    ),
+    "observability": (
+        "full_monitor_refresh",
+    ),
+}
+
+# A lane is "fresh" while its evidence is younger than N times its cadence:
+# one missed tick should not flip a loop to idle, three should.
+_FRESHNESS_CADENCE_MULTIPLIER = 3
+
+
+def _parse_recorded_at(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def build_loop_health_view(
+    hermes_home: str | Path,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Compute the projection. Read-only; safe to call from any surface."""
+    moment = now or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    cadence_by_lane = {lane.lane_id: int(lane.due_interval_minutes or 0) for lane in MEMORY_OS_CRON_LANES}
+
+    loops: list[dict[str, Any]] = []
+    for loop_name, member_ids in LOOP_MEMBERS.items():
+        members: list[dict[str, Any]] = []
+        has_error = False
+        has_fresh_ok = False
+        has_any_standard_evidence = False
+        for lane_id in member_ids:
+            evidence_kind = LANE_LAST_RUN_EVIDENCE.get(lane_id, "lane_last_run")
+            row: dict[str, Any] = {"lane_id": lane_id, "evidence": evidence_kind}
+            if evidence_kind != "lane_last_run":
+                row["status"] = "see_dedicated_artifact"
+                members.append(row)
+                continue
+            record = read_lane_last_run(hermes_home, lane_id)
+            if record is None:
+                row["status"] = "no_evidence"
+                members.append(row)
+                continue
+            has_any_standard_evidence = True
+            status = str(record.get("status") or "")
+            row["status"] = status
+            row["reason"] = str(record.get("reason") or "")
+            row["recorded_at"] = str(record.get("recorded_at") or "")
+            recorded_at = _parse_recorded_at(row["recorded_at"])
+            cadence_minutes = cadence_by_lane.get(lane_id) or 0
+            if recorded_at is not None:
+                age_minutes = max(0, int((moment - recorded_at).total_seconds() // 60))
+                row["age_minutes"] = age_minutes
+                if cadence_minutes > 0:
+                    row["stale"] = age_minutes > cadence_minutes * _FRESHNESS_CADENCE_MULTIPLIER
+            if status == "error":
+                has_error = True
+            elif status == "ok" and row.get("stale") is not True:
+                has_fresh_ok = True
+            members.append(row)
+        if has_error:
+            state = "attention"
+        elif has_fresh_ok:
+            state = "active"
+        elif has_any_standard_evidence:
+            state = "idle"
+        else:
+            state = "no_evidence"
+        loops.append({"loop": loop_name, "state": state, "members": members})
+
+    return {
+        "schema_version": LOOP_HEALTH_VIEW_SCHEMA_VERSION,
+        "generated_at": moment.isoformat().replace("+00:00", "Z"),
+        "loops": loops,
+        "raw_body_included": False,
+    }
+
+
+def render_loop_health_summary(view: dict[str, Any]) -> str:
+    """Compact human-readable rendering for CLI / owner surfaces."""
+    lines = [f"Loop Health View ({view.get('generated_at', '')})"]
+    for loop in view.get("loops", []):
+        members = loop.get("members", [])
+        annotated = []
+        for member in members:
+            status = str(member.get("status") or "")
+            reason = str(member.get("reason") or "")
+            label = f"{member.get('lane_id')}={status}"
+            if reason:
+                label += f"({reason})"
+            annotated.append(label)
+        lines.append(f"[{loop.get('state', ''):>11}] {loop.get('loop', '')}: " + ", ".join(annotated))
+    return "\n".join(lines)

--- a/plugins/memory/memory_os/recall_golden.py
+++ b/plugins/memory/memory_os/recall_golden.py
@@ -14,6 +14,33 @@ each query and scores the results.
 
 Golden set files live under ``<memory_os_root>/recall_golden/`` and are
 named ``<profile>.golden.json``.
+
+Case categories and production-case collection
+==============================================
+Complex retrieval's biggest risk is that a fix for one query class quietly
+hurts three others (the CJK production incident is the canonical example),
+so every golden query should carry a ``category`` from
+``RECOMMENDED_CASE_CATEGORIES`` and the report breaks results down
+per-category.  The metric semantics ride on category conventions rather
+than new mechanics:
+
+* wrong-memory injection — ``must_hit=False`` expectations; any match is an
+  injection (``false_positive``), reported as
+  ``metrics.wrong_memory_injection_*``.
+* stale-memory injection — a ``superseded``-category query whose OLD fact
+  is a ``must_hit=False`` expectation.
+* authority violation — ``authority_class``/``source_ref`` expectations;
+  verified mismatches classify ``source_authority_issue``.
+* no-answer honesty — a ``no_answer``-category query whose expectations are
+  all ``must_hit=False``: the pipeline must not fabricate a recall.
+
+Collection procedure (target: ~50 real production cases, then 100–200):
+take real owner queries from production sessions — misses the owner
+reported (待办 8 instances), plus sampled routine queries — and write one
+``GoldenQuery`` each, with the expected fact's canonical ``source_ref``
+where known.  Never hand-write the memory fixtures the case recalls
+against: build them through the real producers, or the counterfactual is
+vacuous.
 """
 
 from __future__ import annotations
@@ -29,6 +56,26 @@ from .recall_types import RecallType
 from .store import MemoryOSStore
 
 GOLDEN_SET_SCHEMA_VERSION = "memory-os.recall_golden_set.v1"
+
+# Category vocabulary for golden queries (advisory, not enforced: a category
+# outside this tuple still evaluates, it just fragments the per-category
+# report).  Mirrors the query classes production has actually hurt on.
+RECOMMENDED_CASE_CATEGORIES: tuple[str, ...] = (
+    "chinese_natural",       # 中文自然句
+    "mixed_language",        # 中英混合
+    "entity",                # 实体/专名
+    "paraphrase",            # 同义改写
+    "task_continuation",     # 任务延续
+    "old_vs_current_fact",   # 新旧事实并存
+    "superseded",            # 已被取代的事实（旧值为负例 → 陈旧注入）
+    "contested",             # 有争议/矛盾中
+    "revoked",               # 已撤销（必须不出现）
+    "graph_needed",          # 需要图谱扩展才能命中
+    "graph_not_needed",      # 图谱不应插手
+    "no_answer",             # 诚实无答案（全负例）
+    "weak_clue",             # 低线索
+    "adversarial",           # 污染/对抗输入
+)
 
 
 @dataclass(frozen=True)
@@ -60,6 +107,8 @@ class GoldenQuery:
     query: str
     expected: list[GoldenResult] = field(default_factory=list)
     description: str = ""
+    # See RECOMMENDED_CASE_CATEGORIES; empty reports as "uncategorized".
+    category: str = ""
 
 
 @dataclass(frozen=True)
@@ -89,6 +138,7 @@ class RecallEvaluationItem:
     matched_authority: str = ""
     score: float = 0.0
     error: str = ""
+    category: str = ""
 
 
 @dataclass(frozen=True)
@@ -131,6 +181,7 @@ def load_golden_set(path: Path) -> GoldenSet:
                 query=q_raw.get("query", ""),
                 expected=expected,
                 description=q_raw.get("description", ""),
+                category=str(q_raw.get("category", "") or ""),
             )
         )
     return GoldenSet(
@@ -153,6 +204,7 @@ def save_golden_set(path: Path, gs: GoldenSet) -> None:
                 "query": q.query,
                 "expected": [asdict(e) for e in q.expected],
                 "description": q.description,
+                "category": q.category,
             }
             for q in gs.queries
         ],
@@ -218,6 +270,7 @@ def evaluate_recall(
                 must_hit=True,
                 matched=False,
                 error=str(exc),
+                category=gq.category,
             ))
             continue
 
@@ -277,6 +330,7 @@ def evaluate_recall(
                 matched_source_ref=matched_source_ref,
                 matched_authority=matched_authority,
                 score=1.0 if matched else 0.0,
+                category=gq.category,
             )
             items.append(item)
 
@@ -354,28 +408,54 @@ def run_golden_set_report(
     golden_set = load_golden_set(path)
     evaluation = evaluate_recall(store, golden_set, profile=profile)
     score = score_from_evaluation(evaluation)
+    item_rows = [
+        {
+            "query": item.query,
+            "recall_type": item.recall_type,
+            "content_pattern": item.content_pattern,
+            "expected_source_ref": item.expected_source_ref,
+            "expected_authority": item.expected_authority,
+            "must_hit": item.must_hit,
+            "matched": item.matched,
+            "matched_source_ref": item.matched_source_ref,
+            "matched_authority": item.matched_authority,
+            "classification": classify_evaluation_item(item),
+            "error": item.error,
+            "category": item.category or "uncategorized",
+        }
+        for item in evaluation.items
+    ]
+    # Per-category breakdown: a fix that helps one query class while quietly
+    # hurting three others is exactly what the flat recall_rate hides.
+    by_category: dict[str, dict[str, int]] = {}
+    classification_counts: dict[str, int] = {}
+    for row in item_rows:
+        classification = str(row["classification"])
+        classification_counts[classification] = classification_counts.get(classification, 0) + 1
+        bucket = by_category.setdefault(str(row["category"]), {})
+        bucket[classification] = bucket.get(classification, 0) + 1
+    negative_checks = sum(1 for row in item_rows if not row["must_hit"])
+    wrong_injections = classification_counts.get("false_positive", 0)
+    metrics = {
+        # Every must_hit=False expectation is an injection tripwire; a match
+        # means the pipeline surfaced memory it must not (wrong / stale /
+        # revoked — the category tells which).
+        "negative_checks": negative_checks,
+        "wrong_memory_injection_count": wrong_injections,
+        "wrong_memory_injection_rate": (wrong_injections / negative_checks) if negative_checks else 0.0,
+        "authority_violation_count": classification_counts.get("source_authority_issue", 0),
+        "context_insufficient_count": classification_counts.get("context_insufficient", 0),
+    }
     return {
         "schema_version": GOLDEN_SET_SCHEMA_VERSION,
         "golden_path": str(path),
         "profile": profile,
         "query_count": len(golden_set.queries),
         "score": score,
-        "items": [
-            {
-                "query": item.query,
-                "recall_type": item.recall_type,
-                "content_pattern": item.content_pattern,
-                "expected_source_ref": item.expected_source_ref,
-                "expected_authority": item.expected_authority,
-                "must_hit": item.must_hit,
-                "matched": item.matched,
-                "matched_source_ref": item.matched_source_ref,
-                "matched_authority": item.matched_authority,
-                "classification": classify_evaluation_item(item),
-                "error": item.error,
-            }
-            for item in evaluation.items
-        ],
+        "metrics": metrics,
+        "by_category": by_category,
+        "by_classification": classification_counts,
+        "items": item_rows,
         "executed_at": evaluation.executed_at,
     }
 

--- a/plugins/memory/memory_os/roots.py
+++ b/plugins/memory/memory_os/roots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -29,6 +30,48 @@ def _validate_profile(profile: str | None) -> str:
     if _contains_traversal(profile) or "/" in profile or "\\" in profile:
         raise RootValidationError(f"profile contains path traversal: {profile}")
     return profile
+
+
+def _derive_profile_from_home(home: Path) -> str:
+    """Return the profile name a profiles/<name>-shaped home implies, else ''."""
+    if home.name and home.parent.name == "profiles":
+        return home.name
+    return ""
+
+
+def resolve_profile_name(
+    hermes_home: str | Path,
+    explicit: str | None = None,
+    *,
+    environ: dict[str, str] | None = None,
+) -> str:
+    """Resolve the profile attribution for records written against hermes_home.
+
+    Priority: ``explicit`` (a --profile flag) > ``HERMES_PROFILE`` >
+    profiles/<name>-shaped hermes_home > ``"default"``.
+
+    Multi-profile hosts routinely export only HERMES_HOME
+    (e.g. ``/root/.hermes/profiles/sannai``) without HERMES_PROFILE; the old
+    ``HERMES_PROFILE or "default"`` fallback then stamped that profile's
+    records as ``default`` and profile-filtered readers silently dropped
+    them.  Raises RootValidationError when an explicitly requested profile
+    contradicts a profile-shaped home: running would mis-attribute this
+    home's records to another profile, so fail closed instead of guessing.
+
+    The stdlib-only cron wrapper (scripts/memory_os_execution_gate_runner.py
+    ``_resolve_profile``) is a deliberate local twin of this logic; a guard
+    test pins both to the same behavior table.
+    """
+    env = environ if environ is not None else os.environ
+    home = Path(hermes_home).expanduser().resolve()
+    derived = _derive_profile_from_home(home)
+    requested = _validate_profile((explicit or "").strip() or str(env.get("HERMES_PROFILE") or "").strip())
+    if requested and derived and requested != derived:
+        raise RootValidationError(
+            f"requested profile {requested!r} contradicts profile-shaped hermes_home {home} "
+            f"(implies {derived!r}); refusing to mis-attribute records"
+        )
+    return requested or derived or "default"
 
 
 def _validate_external_root(path: str | Path) -> Path:
@@ -86,8 +129,12 @@ class MemoryOSRoots:
         profile: str | None = None,
         external_state_roots: list[str | Path] | tuple[str | Path, ...] | None = None,
     ) -> "MemoryOSRoots":
-        resolved_profile = _validate_profile(profile)
         home = Path(hermes_home).expanduser().resolve()
+        # An explicitly passed profile always wins (Hermes' agent identity may
+        # legitimately differ from the home directory name).  Only when the
+        # caller passed nothing do we read the profiles/<name> home shape, so
+        # a sannai-style profile home no longer collapses to "" / "default".
+        resolved_profile = _validate_profile(profile) or _derive_profile_from_home(home)
         memory_os_root = home / "memory-os"
         external_roots = tuple(_validate_external_root(root) for root in (external_state_roots or ()))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-memory-os"
-version = "0.1.0"
+version = "0.2.1"
 description = "A file-first memory and governance runtime for long-running Hermes agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/cleanup_expired_working.py
+++ b/scripts/cleanup_expired_working.py
@@ -1,58 +1,125 @@
 #!/usr/bin/env python3
+"""Cleanup expired working memory items older than RETENTION_DAYS.
+
+Designed for no_agent=True cron. stdout reports removals; every run —
+including "nothing to clean" — records a durable last-run reason under
+system/lane_last_run/ ("Completion Is Not Output": this lane's old
+docstring promised to be *silent* when idle, which made a broken lane and
+an idle lane indistinguishable on disk).
 """
-Cleanup expired working memory items older than RETENTION_DAYS.
-Designed for no_agent=True cron (stdout-only watchdog pattern).
-Silent when nothing to clean; reports count + chars when items removed.
-"""
+
+from __future__ import annotations
 
 import json
-from pathlib import Path
+import os
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
-WORKING_PATH = Path("/root/.hermes/memory-os/working/lingering.json")
+_HERMES_HOME = os.environ.get("HERMES_HOME", "") or str(Path.home() / ".hermes")
+_repo_root = Path(__file__).absolute().parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(_HERMES_HOME) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+try:
+    from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
+    def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
+        sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
+        return False
+
 RETENTION_DAYS = 7
+_LANE_ID = "working_cleanup"
 
-if not WORKING_PATH.exists():
-    raise SystemExit(0)
 
-doc = json.loads(WORKING_PATH.read_text(encoding="utf-8"))
-items = doc.get("items", [])
-now = datetime.now(timezone.utc)
+def main(hermes_home: str | None = None) -> int:
+    home = hermes_home or _HERMES_HOME
+    working_path = Path(home) / "memory-os" / "working" / "lingering.json"
 
-before = len(items)
-surviving = []
-removed_count = 0
-removed_chars = 0
+    if not working_path.exists():
+        record_lane_last_run(home, _LANE_ID, status="skipped", reason="working_file_absent")
+        return 0
 
-for item in items:
-    if item.get("status") != "expired":
-        surviving.append(item)
-        continue
-    ts_str = item.get("updated_at") or item.get("created_at")
-    if not ts_str:
-        surviving.append(item)
-        continue
     try:
-        ts = datetime.fromisoformat(ts_str)
-    except (ValueError, TypeError):
+        doc = json.loads(working_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        record_lane_last_run(
+            home, _LANE_ID, status="error", reason="working_file_unreadable", error=str(exc)
+        )
+        sys.stderr.write(f"working_cleanup: cannot read {working_path}: {exc}\n")
+        return 1
+
+    items = doc.get("items", []) if isinstance(doc, dict) else []
+    now = datetime.now(timezone.utc)
+
+    before = len(items)
+    surviving = []
+    removed_count = 0
+    removed_chars = 0
+
+    for item in items:
+        if not isinstance(item, dict) or item.get("status") != "expired":
+            surviving.append(item)
+            continue
+        ts_str = item.get("updated_at") or item.get("created_at")
+        if not ts_str:
+            surviving.append(item)
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except (ValueError, TypeError):
+            surviving.append(item)
+            continue
+        age_days = (now - ts).total_seconds() / 86400
+        if age_days > RETENTION_DAYS:
+            removed_count += 1
+            removed_chars += len(str(item.get("text", "")))
+            continue
         surviving.append(item)
-        continue
-    age_days = (now - ts).total_seconds() / 86400
-    if age_days > RETENTION_DAYS:
-        removed_count += 1
-        removed_chars += len(str(item.get("text", "")))
-        continue
-    surviving.append(item)
 
-if removed_count == 0:
-    raise SystemExit(0)
+    if removed_count == 0:
+        record_lane_last_run(
+            home,
+            _LANE_ID,
+            status="ok",
+            reason="no_expired_items",
+            counters={"items_scanned": before, "items_removed": 0},
+        )
+        return 0
 
-doc["items"] = surviving
-WORKING_PATH.write_text(json.dumps(doc, indent=2, ensure_ascii=False), encoding="utf-8")
+    doc["items"] = surviving
+    try:
+        working_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        record_lane_last_run(
+            home, _LANE_ID, status="error", reason="working_file_write_failed", error=str(exc)
+        )
+        sys.stderr.write(f"working_cleanup: cannot write {working_path}: {exc}\n")
+        return 1
 
-msg = (
-    f"🧹 Working Memory Cleanup: removed {removed_count} expired items "
-    f"(> {RETENTION_DAYS}d old), freed ~{removed_chars} chars. "
-    f"Before: {before} items → After: {len(surviving)} items"
-)
-print(msg)
+    record_lane_last_run(
+        home,
+        _LANE_ID,
+        status="ok",
+        reason="removed_expired_items",
+        counters={
+            "items_scanned": before,
+            "items_removed": removed_count,
+            "chars_freed": removed_chars,
+        },
+    )
+    print(
+        f"🧹 Working Memory Cleanup: removed {removed_count} expired items "
+        f"(> {RETENTION_DAYS}d old), freed ~{removed_chars} chars. "
+        f"Before: {before} items → After: {len(surviving)} items"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -53,6 +53,7 @@ SOURCE_L3_PROBE_HELPER = REPO_ROOT / "scripts" / "memory_os_l3_probe_helper.py"
 SOURCE_EVENT_STATS_REFRESH = REPO_ROOT / "scripts" / "memory_os_event_stats_refresh.py"
 SOURCE_EXPOSURE_ROLLUP = REPO_ROOT / "scripts" / "memory_os_exposure_rollup.py"
 SOURCE_MONITOR_DASHBOARD_SNAPSHOT = REPO_ROOT / "scripts" / "memory_os_monitor_dashboard_snapshot.py"
+SOURCE_LOOP_HEALTH_VIEW = REPO_ROOT / "scripts" / "memory_os_loop_health_view.py"
 SOURCE_FULL_MONITOR_REFRESH = REPO_ROOT / "scripts" / "memory_os_full_monitor_refresh.py"
 SOURCE_FULL_MONITOR = REPO_ROOT / "scripts" / "memory_os_3_200_monitor.py"
 SOURCE_CLOSURE_RUNTIME_EVIDENCE = REPO_ROOT / "scripts" / "memory_os_closure_runtime_evidence.py"
@@ -1168,6 +1169,7 @@ def _write_operational_helper_scripts(hermes_home: Path, *, dry_run: bool) -> di
         "event_stats_refresh": SOURCE_EVENT_STATS_REFRESH,
         "exposure_rollup": SOURCE_EXPOSURE_ROLLUP,
         "monitor_dashboard_snapshot": SOURCE_MONITOR_DASHBOARD_SNAPSHOT,
+        "loop_health_view": SOURCE_LOOP_HEALTH_VIEW,
         "full_monitor_refresh": SOURCE_FULL_MONITOR_REFRESH,
         "full_monitor": SOURCE_FULL_MONITOR,
         "closure_runtime_evidence": SOURCE_CLOSURE_RUNTIME_EVIDENCE,

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -1414,6 +1414,30 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
                 },
             })
 
+    raw_lane_last_run = snapshot.get("lane_last_run")
+    lane_last_run: dict[str, Any] = raw_lane_last_run if isinstance(raw_lane_last_run, dict) else {}
+    if lane_last_run:
+        # Deliberately ungraded (INFO): a failed run already fails
+        # helper-completion grading, so grading here would double-alarm.
+        # This entry carries the WHY behind lanes that produced nothing
+        # ("Completion Is Not Output"); error_lanes names any lane whose
+        # last recorded run failed so an operator can jump straight to
+        # system/lane_last_run/<lane_id>.json. Directory absence is normal
+        # until the reason-code deployment reaches the host.
+        lanes_map = lane_last_run.get("lanes") if isinstance(lane_last_run.get("lanes"), dict) else {}
+        info.append({
+            "code": "lane_last_run_state",
+            "value": {
+                "lane_count": int(lane_last_run.get("lane_count") or 0),
+                "status_counts": lane_last_run.get("status_counts") or {},
+                "error_lanes": sorted(
+                    lane_id
+                    for lane_id, entry in lanes_map.items()
+                    if isinstance(entry, dict) and entry.get("status") == "error"
+                ),
+            },
+        })
+
     hermes_status = snapshot.get("hermes_status") if isinstance(snapshot.get("hermes_status"), dict) else {}
     hermes_gateway_running = hermes_status.get("gateway_running") is True
 
@@ -6174,6 +6198,45 @@ def continuity_freshness_summary():
         "raw_body_included": False,
     }
 
+def lane_last_run_summary():
+    # Standard per-lane last-run evidence (lane_last_run.py). Report-only:
+    # a failed run already fails helper-completion grading, so this section
+    # exists to explain WHY lanes produced nothing ("Completion Is Not
+    # Output"), not to re-alarm. Directory absence is normal until the
+    # reason-code deployment reaches this host.
+    directory = os.path.join(_hermes_home, "memory-os/system/lane_last_run")
+    lanes = {}
+    status_counts = {"ok": 0, "skipped": 0, "error": 0, "malformed": 0}
+    if os.path.isdir(directory):
+        for name in sorted(os.listdir(directory)):
+            if not name.endswith(".json"):
+                continue
+            lane_key = name[:-5]
+            try:
+                with open(os.path.join(directory, name), "r", encoding="utf-8") as handle:
+                    record = json.load(handle)
+            except (OSError, ValueError):
+                record = None
+            if not isinstance(record, dict):
+                status_counts["malformed"] += 1
+                lanes[lane_key] = {"status": "malformed", "reason": "", "recorded_at": ""}
+                continue
+            status = str(record.get("status") or "")
+            lanes[str(record.get("lane_id") or lane_key)] = {
+                "status": status,
+                "reason": str(record.get("reason") or ""),
+                "recorded_at": str(record.get("recorded_at") or ""),
+            }
+            status_counts[status if status in status_counts else "malformed"] += 1
+    return {
+        "schema_version": "memory-os.lane_last_run_monitor.v0",
+        "directory_exists": os.path.isdir(directory),
+        "lane_count": len(lanes),
+        "status_counts": status_counts,
+        "lanes": lanes,
+        "raw_body_included": False,
+    }
+
 def rh26_probe():
     code = r"""
 import json, re
@@ -9114,6 +9177,7 @@ print(json.dumps({
   "session_activity": session_activity_stats(),
   "compaction": compaction_stats(),
   "continuity_freshness": continuity_freshness_summary(),
+  "lane_last_run": lane_last_run_summary(),
   "disk_df": df,
   "disk_du": du,
 }, ensure_ascii=False, sort_keys=True))

--- a/scripts/memory_os_candidate_aggregation_lane.py
+++ b/scripts/memory_os_candidate_aggregation_lane.py
@@ -44,7 +44,8 @@ REPO_ROOT = Path(_HERMES_HOME) / "memory-os" / "runtime" / "python"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.modules.governance.candidate_aggregation import run_candidate_aggregation_lane
 
@@ -55,10 +56,7 @@ def main() -> int:
         or os.environ.get("HERMES_HOME", "")
         or str(Path.home() / ".hermes")
     )
-    profile = (
-        _preparse_cli_arg(sys.argv, "--profile")
-        or os.environ.get("HERMES_PROFILE", "default")
-    )
+    profile = resolve_profile_name(hermes_home, _preparse_cli_arg(sys.argv, "--profile"))
     envelope_id = (
         _preparse_cli_arg(sys.argv, "--envelope-id")
         or os.environ.get("MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID", "")
@@ -121,6 +119,39 @@ def main() -> int:
         "actual_crystallized_approval": result["actual_crystallized_approval"],
         "status": "ok" if not result.get("error") else "error",
     }
+    # Both existing artifacts (status ledger + helper report) are counters
+    # only; persist a closed outcome code so "nothing pending" and "triage
+    # produced nothing" are distinguishable from a failed run.
+    triage_actions = sum(
+        int(result.get(key) or 0)
+        for key in ("promoted_count", "demoted_count", "fleeting_count", "compacted_count")
+    )
+    if result.get("error"):
+        run_status, reason = "error", "lane_failed"
+    elif int(result.get("candidates_read") or 0) == 0:
+        run_status, reason = "ok", "no_candidates"
+    elif int(result.get("pending") or 0) == 0:
+        run_status, reason = "ok", "nothing_pending"
+    elif triage_actions == 0:
+        run_status, reason = "ok", "no_triage_actions"
+    else:
+        run_status, reason = "ok", "triaged"
+    record_lane_last_run(
+        hermes_home,
+        "candidate_aggregation",
+        status=run_status,
+        reason=reason,
+        counters={
+            "candidates_read": int(result.get("candidates_read") or 0),
+            "pending": int(result.get("pending") or 0),
+            "already_triaged": int(result.get("already_triaged") or 0),
+            "promoted_count": int(result.get("promoted_count") or 0),
+            "demoted_count": int(result.get("demoted_count") or 0),
+            "fleeting_count": int(result.get("fleeting_count") or 0),
+            "compacted_count": int(result.get("compacted_count") or 0),
+        },
+        error=str(result.get("error") or ""),
+    )
     print(json.dumps(summary, ensure_ascii=False, indent=2))
     return 0
 

--- a/scripts/memory_os_candidate_backfill_409.py
+++ b/scripts/memory_os_candidate_backfill_409.py
@@ -52,7 +52,7 @@ from plugins.memory.memory_os.crystallized import (
     read_candidate_queue,
     read_candidate_triage,
 )
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.modules.governance.candidate_aggregation import (
     _is_fleeting_candidate,
@@ -106,7 +106,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--hermes-home", default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"),
     )
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE") or "default")
+    parser.add_argument("--profile", default="")
     parser.add_argument(
         "--execution-gate-envelope-id",
         default=os.environ.get("MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID", ""),
@@ -119,7 +119,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     hermes_home = str(args.hermes_home)
-    profile = str(args.profile)
+    profile = resolve_profile_name(hermes_home, str(args.profile))
 
     roots = MemoryOSRoots.from_hermes_home(hermes_home, profile=profile)
     store = MemoryOSStore(roots)

--- a/scripts/memory_os_clearance_cycle_helper.py
+++ b/scripts/memory_os_clearance_cycle_helper.py
@@ -50,7 +50,8 @@ else:
         sys.path.insert(0, str(_runtime_root))
 
 from plugins.memory.memory_os.clearance_cycle import run_clearance_cycle
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 
 
@@ -60,10 +61,7 @@ def main() -> int:
         or os.environ.get("HERMES_HOME", "")
         or str(Path.home() / ".hermes")
     )
-    profile = (
-        _preparse_cli_arg(sys.argv, "--profile")
-        or os.environ.get("HERMES_PROFILE", "default")
-    )
+    profile = resolve_profile_name(hermes_home, _preparse_cli_arg(sys.argv, "--profile"))
 
     roots = MemoryOSRoots.from_hermes_home(hermes_home, profile=profile)
     store = MemoryOSStore(roots)
@@ -90,6 +88,31 @@ def main() -> int:
             "actual_unapproved_crystallized_approval": False,
         },
     }
+    # Persist a closed outcome so an empty queue is distinguishable from a
+    # cycle whose judge produced nothing (or was unavailable).
+    judged = int(report.get("judged") or 0)
+    queue_depth = int(report.get("queue_depth") or 0)
+    if report.get("status") != "ok":
+        run_status = "error"
+        reason = str(report.get("failure_reason") or "cycle_failed")
+    elif queue_depth == 0 and judged == 0:
+        run_status, reason = "ok", "queue_empty"
+    elif judged == 0:
+        run_status, reason = "ok", "nothing_judged"
+    else:
+        run_status, reason = "ok", "judged"
+    record_lane_last_run(
+        hermes_home,
+        "clearance_cycle",
+        status=run_status,
+        reason=reason,
+        counters={
+            "judged": judged,
+            "invalidated": int(report.get("invalidated") or 0),
+            "queue_depth": queue_depth,
+            "budget_used": int(report.get("budget_used") or 0),
+        },
+    )
     print(json.dumps(helper_report, ensure_ascii=False, indent=2))
     return 0 if report.get("status") == "ok" else 1
 

--- a/scripts/memory_os_clearance_snapshot_rebuild.py
+++ b/scripts/memory_os_clearance_snapshot_rebuild.py
@@ -65,7 +65,7 @@ from plugins.memory.memory_os.clearance_receipts import (
     clearance_snapshot_freshness,
     rebuild_clearance_receipt_snapshot,
 )
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 
 
@@ -80,7 +80,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--profile",
-        default=os.environ.get("HERMES_PROFILE", "default"),
+        default="",
         help="Memory-OS profile name",
     )
     parser.add_argument(
@@ -89,6 +89,7 @@ def main(argv: list[str] | None = None) -> int:
         default="json",
     )
     args = parser.parse_args(argv)
+    profile = resolve_profile_name(args.hermes_home, args.profile)
 
     t0 = time.monotonic()
     run_status = "ok"
@@ -96,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
     freshness: dict = {}
 
     try:
-        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=profile)
         store = MemoryOSStore(roots)
         store.initialize()
 
@@ -117,7 +118,7 @@ def main(argv: list[str] | None = None) -> int:
             "error": error_msg,
             "freshness": freshness,
             "duration_ms": duration_ms,
-            "profile": args.profile,
+            "profile": profile,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         }, ensure_ascii=False))
 

--- a/scripts/memory_os_entity_index_refresh.py
+++ b/scripts/memory_os_entity_index_refresh.py
@@ -49,7 +49,7 @@ else:
     if _runtime_root.exists() and str(_runtime_root) not in sys.path:
         sys.path.insert(0, str(_runtime_root))
 
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.entity_index import refresh_entity_index, entity_index_stats
 from plugins.memory.memory_os.knob_overrides import resolve_knob
 
@@ -62,9 +62,10 @@ def main(argv: list[str] | None = None) -> int:
         "--hermes-home", default=_HERMES_HOME,
         help="Path to HERMES_HOME",
     )
-    parser.add_argument("--profile", default="default")
+    parser.add_argument("--profile", default="")
     parser.add_argument("--output", choices=("json",), default="json")
     args = parser.parse_args(argv)
+    profile = resolve_profile_name(args.hermes_home, args.profile)
 
     t0 = time.monotonic()
     run_status = "ok"
@@ -73,7 +74,7 @@ def main(argv: list[str] | None = None) -> int:
     record_count = 0
 
     try:
-        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=profile)
         enabled = bool(resolve_knob(
             "entity_index_enabled", default=False, roots=roots,
         ))
@@ -120,7 +121,7 @@ def main(argv: list[str] | None = None) -> int:
             "entity_count": entity_count,
             "record_count": record_count,
             "duration_ms": duration_ms,
-            "profile": args.profile,
+            "profile": profile,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         }))
 

--- a/scripts/memory_os_event_stats_refresh.py
+++ b/scripts/memory_os_event_stats_refresh.py
@@ -54,7 +54,8 @@ else:
         sys.path.insert(0, str(_runtime_root))
 
 from plugins.memory.memory_os.event_stats import build_event_stats, write_event_stats
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 
 
@@ -64,10 +65,7 @@ def main() -> int:
         or os.environ.get("HERMES_HOME", "")
         or str(Path.home() / ".hermes")
     )
-    profile = (
-        _preparse_cli_arg(sys.argv, "--profile")
-        or os.environ.get("HERMES_PROFILE", "default")
-    )
+    profile = resolve_profile_name(hermes_home, _preparse_cli_arg(sys.argv, "--profile"))
 
     roots = MemoryOSRoots.from_hermes_home(hermes_home, profile=profile)
     store = MemoryOSStore(roots)
@@ -88,6 +86,16 @@ def main() -> int:
         "has_continuity_selector": bool(stats.continuity_selector),
         "updated_at": stats.updated_at,
     }
+    record_lane_last_run(
+        hermes_home,
+        "event_stats_refresh",
+        status="ok",
+        reason="stats_refreshed" if event_dicts else "no_events",
+        counters={
+            "total_event_count": int(stats.total_event_count or 0),
+            "recent_event_summaries_count": len(stats.recent_event_summaries),
+        },
+    )
     print(json.dumps(summary, ensure_ascii=False, indent=2))
 
     # Helper report for ExecutionGate postcheck (INV-5: no LLM / no network).

--- a/scripts/memory_os_execution_gate_runner.py
+++ b/scripts/memory_os_execution_gate_runner.py
@@ -59,6 +59,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--registry-key", required=True)
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
     parser.add_argument("--smoke-mode", choices=("normal", "safe", "render-only", "natural"), default="normal")
+    parser.add_argument(
+        "--profile",
+        default="",
+        help="Profile attribution for permit/completion records. Falls back to HERMES_PROFILE, then a profiles/<name>-shaped --hermes-home, then 'default'.",
+    )
     return parser
 
 
@@ -68,16 +73,48 @@ def main(argv: list[str] | None = None) -> int:
         str(args.registry_key),
         hermes_home=Path(args.hermes_home).expanduser(),
         smoke_mode=str(args.smoke_mode),
+        profile=str(args.profile),
     )
 
 
-def run_registry_key(registry_key: str, *, hermes_home: Path, smoke_mode: str = "normal") -> int:
+def _resolve_profile(hermes_home: Path, explicit: str = "") -> tuple[str, dict[str, str] | None]:
+    """Resolve the profile attribution for gate records against hermes_home.
+
+    Priority: explicit --profile > HERMES_PROFILE > profile-shaped
+    hermes_home (``.../profiles/<name>``) > ``"default"``.
+
+    Returns ``(profile, conflict)``.  ``conflict`` is None when the sources
+    agree; when an explicitly requested profile contradicts a profile-shaped
+    home it carries {"requested", "derived_from_home"} and the caller must
+    fail closed — stamping records with the wrong profile is exactly the
+    mis-attribution this resolver exists to prevent.
+
+    NOTE: this runner is deliberately stdlib-only, so this is a local twin of
+    plugins.memory.memory_os.roots.resolve_profile_name.  A guard test pins
+    both implementations to the same behavior table.
+    """
+    home = Path(hermes_home).expanduser().resolve()
+    derived = home.name if home.name and home.parent.name == "profiles" else ""
+    requested = (explicit or "").strip() or str(os.environ.get("HERMES_PROFILE") or "").strip()
+    if requested and derived and requested != derived:
+        return derived, {"requested": requested, "derived_from_home": derived}
+    if requested:
+        return requested, None
+    if derived:
+        return derived, None
+    return "default", None
+
+
+def run_registry_key(
+    registry_key: str, *, hermes_home: Path, smoke_mode: str = "normal", profile: str = ""
+) -> int:
     """Run one lane behind an ExecutionGate permit. Returns its exit code."""
     return int(
         run_registry_key_detailed(
             registry_key,
             hermes_home=hermes_home,
             smoke_mode=smoke_mode,
+            profile=profile,
         ).get("returncode")
         or 0
     )
@@ -89,6 +126,7 @@ def run_registry_key_detailed(
     hermes_home: Path,
     smoke_mode: str = "normal",
     timeout_seconds: int | None = None,
+    profile: str = "",
 ) -> dict[str, Any]:
     """Run one lane and report the outcome structurally.
 
@@ -102,6 +140,7 @@ def run_registry_key_detailed(
     if not spec:
         sys.stderr.write(f"unknown Memory-OS cron registry key: {registry_key}\n")
         return {"status": "unknown_registry_key", "error_code": "unknown_registry_key", "returncode": 2}
+    resolved_profile, profile_conflict = _resolve_profile(hermes_home, profile)
     effective_timeout = int(timeout_seconds or 0) or int(spec.get("timeout_seconds") or 0) or DEFAULT_HELPER_TIMEOUT_SECONDS
     scripts_dir = Path(__file__).resolve().parent
     helper = scripts_dir / spec["raw_script"]
@@ -121,6 +160,8 @@ def run_registry_key_detailed(
             helper_present=helper.is_file(),
             smoke_mode=smoke_mode,
             boundary=boundary,
+            profile=resolved_profile,
+            profile_conflict=profile_conflict,
         )
     except ExecutionGateInfrastructureError as exc:
         sys.stderr.write(f"Memory-OS execution gate infrastructure error: {exc.code}\n")
@@ -144,6 +185,7 @@ def run_registry_key_detailed(
                 smoke_mode=smoke_mode,
                 boundary=boundary,
                 helper_report={},
+                profile=resolved_profile,
                 requires_boundary_report=spec.get("requires_boundary_report", True),
             )
         except ExecutionGateInfrastructureError as exc:
@@ -165,6 +207,11 @@ def run_registry_key_detailed(
     env = {
         **os.environ,
         "HERMES_HOME": str(hermes_home),
+        # Hand the helper the profile this run resolved to, so every lane
+        # script stamps its own records with the same attribution as the
+        # permit/completion envelope instead of re-deriving (and possibly
+        # mis-deriving) it from an incomplete environment.
+        "HERMES_PROFILE": resolved_profile,
         "MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID": envelope_id,
         "MEMORY_OS_EXECUTION_REPORT_PATH": str(report_path),
         "MEMORY_OS_EXECUTION_SMOKE_MODE": smoke_mode,
@@ -204,6 +251,7 @@ def run_registry_key_detailed(
             smoke_mode=smoke_mode,
             boundary=observed_boundary,
             helper_report=helper_report,
+            profile=resolved_profile,
             # A timed-out helper never got to write its boundary report, so
             # requiring one would mislabel the timeout as a boundary gap.
             requires_boundary_report=False if timed_out else spec.get("requires_boundary_report", True),
@@ -295,18 +343,31 @@ def _append_permit(
     helper_present: bool,
     smoke_mode: str,
     boundary: dict[str, Any],
+    profile: str,
+    profile_conflict: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     now = datetime.now(timezone.utc)
     material = f"{registry_key}|{lane_id}|{now.isoformat()}"
     envelope_id = f"xgate_{now.strftime('%Y%m%dT%H%M%S%fZ')}_{hashlib.sha256(material.encode('utf-8')).hexdigest()[:10]}"
     boundary_true = _any_boundary_true(boundary)
+    if boundary_true:
+        permit_decision, permit_reason = "blocked", "boundary_true"
+    elif profile_conflict:
+        # A profile explicitly requested via --profile/HERMES_PROFILE
+        # contradicts the profiles/<name>-shaped hermes_home.  Running would
+        # stamp this home's records with another profile's identity, so fail
+        # closed — but leave this blocked permit as durable evidence rather
+        # than exiting silently.
+        permit_decision, permit_reason = "blocked", "profile_home_conflict"
+    else:
+        permit_decision, permit_reason = "allowed", "boundary_false"
     record = {
         "schema_version": SCHEMA_VERSION,
         "stage": "permit",
         "execution_gate_envelope_id": envelope_id,
         "created_at": now.isoformat().replace("+00:00", "Z"),
         "expires_at": (now + timedelta(seconds=_expiry_seconds(lane_id, risk_class))).isoformat().replace("+00:00", "Z"),
-        "profile": os.environ.get("HERMES_PROFILE") or "default",
+        "profile": profile,
         "lane_id": lane_id,
         "trigger_surface": "hermes_cron",
         "risk_class": risk_class,
@@ -321,9 +382,11 @@ def _append_permit(
         "boundary": boundary,
         "boundary_true": boundary_true,
         "precheck": {"helper_present": helper_present},
-        "permit_decision": "blocked" if boundary_true else "allowed",
-        "permit_reason": "boundary_true" if boundary_true else "boundary_false",
+        "permit_decision": permit_decision,
+        "permit_reason": permit_reason,
     }
+    if profile_conflict:
+        record["profile_conflict"] = dict(profile_conflict)
     _append_jsonl(_records_path(hermes_home), record)
     _update_sidecar_index(hermes_home, envelope_id, "permit", record)
     return record
@@ -339,6 +402,7 @@ def _append_completion(
     smoke_mode: str,
     boundary: dict[str, Any],
     helper_report: dict[str, Any],
+    profile: str,
     requires_boundary_report: bool = True,
 ) -> None:
     now = datetime.now(timezone.utc)
@@ -357,7 +421,7 @@ def _append_completion(
         "stage": "completion",
         "execution_gate_envelope_id": envelope_id,
         "created_at": now.isoformat().replace("+00:00", "Z"),
-        "profile": os.environ.get("HERMES_PROFILE") or "default",
+        "profile": profile,
         "lane_id": lane_id,
         "execution_status": execution_status,
         "postcheck": {

--- a/scripts/memory_os_exposure_rollup.py
+++ b/scripts/memory_os_exposure_rollup.py
@@ -29,20 +29,20 @@ else:
         sys.path.insert(0, str(runtime_root))
 
 from plugins.memory.memory_os.exposure_rollup import run_exposure_rollup_cycle
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=_HERMES_HOME)
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "default"))
+    parser.add_argument("--profile", default="")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=resolve_profile_name(args.hermes_home, args.profile))
     store = MemoryOSStore(roots)
     store.initialize()
     result = run_exposure_rollup_cycle(

--- a/scripts/memory_os_expression_feedback_prompt.py
+++ b/scripts/memory_os_expression_feedback_prompt.py
@@ -1,50 +1,90 @@
 #!/usr/bin/env python3
 """Render a bounded right-brain expression feedback prompt for Hermes agent.
 
-This script does not send messages and does not write Memory-OS state. Hermes
-cron owns delivery and the Hermes agent owns the owner interaction.
+This script does not send messages and does not write owner-facing Memory-OS
+state. Hermes cron owns delivery and the Hermes agent owns the owner interaction.
+Its only write is the per-lane last-run evidence file (system/lane_last_run/),
+which records WHY a run produced no prompt.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 try:
     from memory_os_execution_report import write_helper_execution_report
 except ModuleNotFoundError:
     from scripts.memory_os_execution_report import write_helper_execution_report
 
+_HERMES_HOME_DEFAULT = str(Path.home() / ".hermes")
+_repo_root = Path(__file__).absolute().parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+try:
+    from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
+    def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
+        sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
+        return False
+
+_LANE_ID = "expression_feedback_request"
+
+
+def _record_last_run(status: str, reason: str) -> None:
+    hermes_home = os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT
+    record_lane_last_run(hermes_home, _LANE_ID, status=status, reason=reason)
+
 
 def main() -> int:
-    report = _run_json(
-        [
-            "hermes",
-            "memory-os-agent-os",
-            "review",
-            "surface",
-            "--operation",
-            "expression_feedback_context",
-            "--limit",
-            "1",
-        ]
-    )
+    # Empty stdout is a designed outcome here (Hermes cron stays silent), so
+    # every no-prompt exit must record WHY it produced nothing — otherwise a
+    # broken surface and a quiet week are indistinguishable on disk.
+    try:
+        report = _run_json(
+            [
+                "hermes",
+                "memory-os-agent-os",
+                "review",
+                "surface",
+                "--operation",
+                "expression_feedback_context",
+                "--limit",
+                "1",
+            ]
+        )
+    except SystemExit:
+        _record_last_run("error", "hermes_cli_failed")
+        raise
     if report.get("status") != "ok":
+        _record_last_run("skipped", "surface_not_ok")
         return 0
     item = report.get("latest_expression_outcome")
     if not isinstance(item, dict):
         item = report.get("latest_outcome")
     if not isinstance(item, dict):
+        _record_last_run("skipped", "no_expression_outcome")
         return 0
     if bool(item.get("outcome_silent")):
+        _record_last_run("skipped", "outcome_silent")
         return 0
     existing_feedback = report.get("existing_feedback") if isinstance(report.get("existing_feedback"), dict) else {}
     if int(existing_feedback.get("count") or 0) > 0:
+        _record_last_run("skipped", "already_feedback_for_latest_outcome")
         return 0
     preview = str(item.get("expression_preview") or item.get("outcome_preview") or "").strip()
     tokens = item.get("action_tokens") if isinstance(item.get("action_tokens"), dict) else {}
     if not tokens:
+        _record_last_run("skipped", "action_tokens_missing")
         return 0
 
     print("Memory-OS right-brain expression feedback request")
@@ -84,6 +124,7 @@ def main() -> int:
             'memory_os_review_reply({ "action": "feedback", '
             f'"action_token": "{token}", "rating": "{rating}" }})'
         )
+    _record_last_run("ok", "prompt_rendered")
     return 0
 
 

--- a/scripts/memory_os_fact_judge_lane.py
+++ b/scripts/memory_os_fact_judge_lane.py
@@ -51,7 +51,8 @@ REPO_ROOT = Path(_HERMES_HOME) / "memory-os" / "runtime" / "python"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.modules.governance.fact_judge import run_fact_judge_lane
 
@@ -63,10 +64,7 @@ def _resolve_config() -> tuple[str, str, str]:
         or os.environ.get("HERMES_HOME", "")
         or str(Path.home() / ".hermes")
     )
-    profile = (
-        _preparse_cli_arg(sys.argv, "--profile")
-        or os.environ.get("HERMES_PROFILE", "default")
-    )
+    profile = resolve_profile_name(hermes_home, _preparse_cli_arg(sys.argv, "--profile"))
     envelope_id = (
         _preparse_cli_arg(sys.argv, "--envelope-id")
         or os.environ.get("MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID", "")
@@ -103,6 +101,33 @@ def main() -> int:
         "error_count": result["error_count"],
         "status": "ok" if not result.get("error") else "error",
     }
+    # A tick with error_count > 0 used to journal exactly like an empty one.
+    # Persist a closed outcome so a quietly-failing judge is visible on disk.
+    if result.get("error"):
+        run_status, reason = "error", "lane_failed"
+    elif int(result.get("candidates_read") or 0) == 0:
+        run_status, reason = "ok", "no_candidates"
+    elif int(result.get("error_count") or 0) > 0:
+        run_status, reason = "ok", "judged_with_errors"
+    elif int(result.get("judged_count") or 0) == 0:
+        run_status, reason = "ok", "no_candidates_judged"
+    else:
+        run_status, reason = "ok", "judged"
+    record_lane_last_run(
+        hermes_home,
+        "fact_judge",
+        status=run_status,
+        reason=reason,
+        counters={
+            "candidates_read": int(result.get("candidates_read") or 0),
+            "judged_count": int(result.get("judged_count") or 0),
+            "durable_count": int(result.get("durable_count") or 0),
+            "moment_count": int(result.get("moment_count") or 0),
+            "skipped_count": int(result.get("skipped_count") or 0),
+            "error_count": int(result.get("error_count") or 0),
+        },
+        error=str(result.get("error") or ""),
+    )
     print(json.dumps(summary, ensure_ascii=False, indent=2))
     return 0
 

--- a/scripts/memory_os_full_monitor_refresh.py
+++ b/scripts/memory_os_full_monitor_refresh.py
@@ -31,6 +31,7 @@ _IMPORT_ROOT = (
 if _IMPORT_ROOT.exists() and str(_IMPORT_ROOT) not in sys.path:
     sys.path.insert(0, str(_IMPORT_ROOT))
 
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
 from plugins.memory.memory_os.operational_truth import build_full_monitor_envelope
 
 
@@ -234,8 +235,24 @@ def main(argv: list[str] | None = None) -> int:
             monitor_profile=args.monitor_profile,
         )
     except Exception as exc:
+        # The finally-block deletes the temp artifact on failure, so without
+        # this record a crashed refresh leaves the previous snapshot silently
+        # going stale with no on-disk explanation.
+        record_lane_last_run(
+            hermes_home,
+            "full_monitor_refresh",
+            status="error",
+            reason="refresh_failed",
+            error=str(exc),
+        )
         print(f"Full monitor refresh failed: {exc}", file=sys.stderr)
         return 2
+    record_lane_last_run(
+        hermes_home,
+        "full_monitor_refresh",
+        status="ok",
+        reason="artifact_published",
+    )
     return 0
 
 

--- a/scripts/memory_os_graph_edge_weight_renormalization.py
+++ b/scripts/memory_os_graph_edge_weight_renormalization.py
@@ -76,7 +76,7 @@ from plugins.memory.memory_os.index import (  # noqa: E402
     _initialize_schema,
     update_edge_weight,
 )
-from plugins.memory.memory_os.roots import MemoryOSRoots  # noqa: E402
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name  # noqa: E402
 
 MAPPING_VERSION = "v1"
 # weight==1.0 判定阈值:乘性强化 + update_edge_weight 的 0.005 最小增量
@@ -226,11 +226,11 @@ def renormalize_edge_weights(roots: MemoryOSRoots, *, apply: bool) -> dict:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=_HERMES_HOME)
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "default"))
+    parser.add_argument("--profile", default="")
     parser.add_argument("--apply", action="store_true", help="execute (default: dry-run)")
     args = parser.parse_args(argv)
 
-    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=resolve_profile_name(args.hermes_home, args.profile))
     if not roots.index_path.exists():
         # No index yet — build the projection so weight updates can resolve.
         from plugins.memory.memory_os.store import MemoryOSStore

--- a/scripts/memory_os_graph_edges_compaction.py
+++ b/scripts/memory_os_graph_edges_compaction.py
@@ -64,7 +64,7 @@ from plugins.memory.memory_os.index import (  # noqa: E402
     _initialize_schema,
     transition_edge_state,
 )
-from plugins.memory.memory_os.roots import MemoryOSRoots  # noqa: E402
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name  # noqa: E402
 
 
 def _effective_edges(edges_path: Path) -> dict[str, dict]:
@@ -153,11 +153,11 @@ def compact_duplicate_edges(roots: MemoryOSRoots, *, apply: bool) -> dict:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=_HERMES_HOME)
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "default"))
+    parser.add_argument("--profile", default="")
     parser.add_argument("--apply", action="store_true", help="execute (default: dry-run)")
     args = parser.parse_args(argv)
 
-    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=resolve_profile_name(args.hermes_home, args.profile))
     if not roots.index_path.exists():
         # No index yet — build the projection so transitions can validate.
         from plugins.memory.memory_os.store import MemoryOSStore

--- a/scripts/memory_os_hindsight_advisory_digest.py
+++ b/scripts/memory_os_hindsight_advisory_digest.py
@@ -59,6 +59,7 @@ else:
     if _runtime_root.exists() and str(_runtime_root) not in sys.path:
         sys.path.insert(0, str(_runtime_root))
 
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
 from plugins.memory.memory_os.substrates.hindsight import GovernedHindsightConfig
 
 # Reuse shared config reader from health probe (code-review fix: dedup)
@@ -272,6 +273,27 @@ def main(argv: list[str] | None = None) -> int:
         timeout=args.timeout,
         query=args.query,
         budget=args.budget,
+    )
+    # The full "why nothing happened" taxonomy used to be stdout-only and the
+    # advisory file was written only on success, so every skip/failure case
+    # was invisible on disk.  Persist the outcome for every path.
+    status_code = str(report.get("status") or "unknown")
+    if status_code == "ok":
+        run_status, reason = "ok", "advisory_emitted"
+    elif status_code in ("disabled", "unconfigured"):
+        run_status, reason = "skipped", str(report.get("reason") or status_code)
+    else:
+        run_status, reason = "error", status_code
+    record_lane_last_run(
+        args.hermes_home,
+        "hindsight_advisory_digest",
+        status=run_status,
+        reason=reason,
+        counters={
+            "latency_ms": int(report.get("latency_ms") or 0),
+            "advisory_emitted": int(bool(report.get("advisory_emitted"))),
+        },
+        error=str(report.get("reason") or "") if run_status == "error" else "",
     )
     print(json.dumps(report, ensure_ascii=False, indent=2))
     # Advisory digest is optional/fail-open.  Non-ok statuses are reported in

--- a/scripts/memory_os_hindsight_health_probe.py
+++ b/scripts/memory_os_hindsight_health_probe.py
@@ -53,6 +53,7 @@ else:
     if _runtime_root.exists() and str(_runtime_root) not in sys.path:
         sys.path.insert(0, str(_runtime_root))
 
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
 from plugins.memory.memory_os.substrates.hindsight import GovernedHindsightConfig
 
 
@@ -177,6 +178,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     report = probe_hindsight_health(args.hermes_home, timeout_seconds=args.timeout)
+    # The probe's taxonomy used to be stdout-only, leaving a broken substrate
+    # indistinguishable from an idle one on disk.  Persist the closed outcome
+    # set so readers never have to re-run the probe.
+    outcome = str(report.get("status") or "unknown")
+    record_lane_last_run(
+        args.hermes_home,
+        "hindsight_health_probe",
+        status="ok",
+        reason=outcome,
+        counters={"latency_ms": int(report.get("latency_ms") or 0)},
+        error=str(report.get("reason") or "") if outcome in ("timeout", "unreachable", "unhealthy") else "",
+    )
     print(json.dumps(report, ensure_ascii=False, indent=2))
     return 0
 

--- a/scripts/memory_os_index_sync.py
+++ b/scripts/memory_os_index_sync.py
@@ -51,7 +51,8 @@ else:
 
 from plugins.memory.memory_os.audit import read_audit_records
 from plugins.memory.memory_os.index import MemoryOSIndex, _markdown_records
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.crystallized import is_active_crystallized_frontmatter, read_candidate_queue
 
@@ -136,10 +137,7 @@ def main() -> int:
         or os.environ.get("HERMES_HOME", "")
         or str(Path.home() / ".hermes")
     )
-    profile = (
-        _preparse_cli_arg(sys.argv, "--profile")
-        or os.environ.get("HERMES_PROFILE", "default")
-    )
+    profile = resolve_profile_name(hermes_home, _preparse_cli_arg(sys.argv, "--profile"))
 
     roots = MemoryOSRoots.from_hermes_home(hermes_home, profile=profile)
     store = MemoryOSStore(roots)
@@ -189,6 +187,19 @@ def main() -> int:
         "drift": drifts,
         "drift_ok": drift_ok,
     }
+    # stdout used to be this lane's only evidence; persist the outcome so a
+    # failed or drifting sync is visible from disk without re-running.
+    if status == "ok":
+        reason = "synced" if drift_ok else "synced_with_drift"
+    else:
+        reason = "sync_failed"
+    record_lane_last_run(
+        hermes_home,
+        "index_sync",
+        status="ok" if status == "ok" else "error",
+        reason=reason,
+        counters={"drift_count": len(drifts), **(counts if isinstance(counts, dict) else {})},
+    )
     print(json.dumps(summary, ensure_ascii=False, indent=2))
     return 0 if status == "ok" else 1
 

--- a/scripts/memory_os_l3_probe_helper.py
+++ b/scripts/memory_os_l3_probe_helper.py
@@ -18,7 +18,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -137,13 +136,27 @@ def _has_all_markers(path: Path, markers: list[str]) -> bool:
 
 REPO_ROOT = _resolve_repo_root()
 PROBE_SCRIPT = REPO_ROOT / "scripts" / "probe_l3_prefetch_behavior.py"
-LAST_RUN_FILE = Path(tempfile.gettempdir()) / "l3_probe_last_result.json"
+_HERMES_HOME = os.environ.get("HERMES_HOME", "") or str(Path.home() / ".hermes")
+# Diagnostics used to land in the OS temp dir, which reboots clear and the
+# monitor never reads; keep them durable under the profile home instead.
+LAST_RUN_FILE = Path(_HERMES_HOME) / "memory-os" / "system" / "l3_probe_last_result.json"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+try:
+    from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
+    def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
+        sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
+        return False
 
 SCHEMA_VERSION = "memory-os.l3_probe_result.v0"
+_LANE_ID = "l3_probe_verification"
 
 
 def main(smoke: bool = False) -> int:
     if not PROBE_SCRIPT.exists():
+        record_lane_last_run(_HERMES_HOME, _LANE_ID, status="error", reason="probe_script_missing")
         print(json.dumps({
             "schema_version": SCHEMA_VERSION,
             "status": "error",
@@ -186,6 +199,21 @@ def main(smoke: bool = False) -> int:
         result.returncode == 0
         and "GOVERNANCE PATH" in stdout
         and "PARTIAL FAILURE" not in stdout
+    )
+    if "NONCE NOT FOUND" in stdout:
+        failure_reason = "nonce_not_found"
+    elif "NEGATIVE NONCE FOUND" in stdout:
+        failure_reason = "negative_nonce_found"
+    elif result.returncode != 0:
+        failure_reason = "probe_crashed"
+    else:
+        failure_reason = "partial_failure"
+    record_lane_last_run(
+        _HERMES_HOME,
+        _LANE_ID,
+        status="ok" if all_pass else "error",
+        reason="probe_pass" if all_pass else failure_reason,
+        counters={"returncode": int(result.returncode)},
     )
     if all_pass:
         return 0  # silent — nothing delivered to user

--- a/scripts/memory_os_loop_health_view.py
+++ b/scripts/memory_os_loop_health_view.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Print the Loop Health View — a read-only projection over lane evidence.
+
+On-demand owner tool (not a cron lane): groups registered lanes into
+production loops and rolls up each loop's state from the standard
+system/lane_last_run/ evidence. Writes nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERMES_HOME = os.environ.get("HERMES_HOME", "") or str(Path.home() / ".hermes")
+_repo_root = Path(__file__).absolute().parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(_HERMES_HOME) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+from plugins.memory.memory_os.loop_health_view import (
+    build_loop_health_view,
+    render_loop_health_summary,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hermes-home", default=_HERMES_HOME)
+    parser.add_argument("--output", choices=("json", "summary"), default="summary")
+    args = parser.parse_args(argv)
+
+    view = build_loop_health_view(args.hermes_home)
+    if args.output == "json":
+        print(json.dumps(view, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_loop_health_summary(view))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory_os_memory_sources_feedback_prompt.py
+++ b/scripts/memory_os_memory_sources_feedback_prompt.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """Render a bounded MemorySources feedback prompt for Hermes agent delivery.
 
-This script does not send messages and does not write Memory-OS state. Hermes
-cron owns delivery and the Hermes agent owns the owner interaction. Empty
-stdout means there is no suitable feedback context to ask about.
+This script does not send messages and does not write owner-facing Memory-OS
+state. Hermes cron owns delivery and the Hermes agent owns the owner interaction.
+Empty stdout means there is no suitable feedback context to ask about — and
+the per-lane last-run evidence file (system/lane_last_run/) records WHY,
+using the same skip_reason set --status-json reports.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,8 +22,31 @@ try:
 except ModuleNotFoundError:
     from scripts.memory_os_execution_report import write_helper_execution_report
 
+_HERMES_HOME_DEFAULT = str(Path.home() / ".hermes")
+_repo_root = Path(__file__).absolute().parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+try:
+    from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
+    def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
+        sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
+        return False
+
 CANARY_TARGET = 20
 STATUS_SCHEMA_VERSION = "memory-os.memory_sources_feedback_prompt_status.v0"
+_LANE_ID = "memory_sources_feedback_request"
+
+
+def _record_last_run(status: str, reason: str) -> None:
+    hermes_home = os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT
+    record_lane_last_run(hermes_home, _LANE_ID, status=status, reason=reason)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -36,32 +62,43 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 0
     args = parser.parse_args(argv)
-    report = _run_json(
-        [
-            "hermes",
-            "memory-os-agent-os",
-            "review",
-            "surface",
-            "--operation",
-            "memory_sources_feedback_context",
-            "--limit",
-            "3",
-        ]
-    )
+    try:
+        report = _run_json(
+            [
+                "hermes",
+                "memory-os-agent-os",
+                "review",
+                "surface",
+                "--operation",
+                "memory_sources_feedback_context",
+                "--limit",
+                "3",
+            ]
+        )
+    except SystemExit:
+        _record_last_run("error", "hermes_cli_failed")
+        raise
     if args.status_json:
         stats = _try_run_json(["hermes", "memory-os-agent-os", "memory-sources", "stats", "--hours", "24"])
         print(json.dumps(_status_report(report, stats), ensure_ascii=False, sort_keys=True))
         return 0
+    # The skip_reason taxonomy below used to exist only behind --status-json,
+    # which cron never passes — persist it on the cron path too so a silent
+    # run is explainable from disk.
     if report.get("status") != "ok":
+        _record_last_run("skipped", "surface_not_ok")
         return 0
     item = report.get("latest_memory_source")
     if not isinstance(item, dict):
+        _record_last_run("skipped", "no_memory_source_context")
         return 0
     existing_feedback = report.get("existing_feedback") if isinstance(report.get("existing_feedback"), dict) else {}
     if int(existing_feedback.get("count") or 0) > 0:
+        _record_last_run("skipped", "already_feedback_for_latest_source")
         return 0
     token = str((item.get("action_tokens") or {}).get("mark_feedback") or "").strip()
     if not token:
+        _record_last_run("skipped", "feedback_token_missing")
         return 0
 
     source_classes = ", ".join(str(value) for value in item.get("source_classes") or []) or "unknown"
@@ -83,6 +120,7 @@ def main(argv: list[str] | None = None) -> int:
     print("4. 需要更具体的召回")
     print("你可以直接回：有帮助、缺上下文、太机制化、要更具体。")
     print("OWNER_MESSAGE_END")
+    _record_last_run("ok", "prompt_rendered")
     return 0
 
 

--- a/scripts/memory_os_module_cadence_report.py
+++ b/scripts/memory_os_module_cadence_report.py
@@ -149,6 +149,10 @@ MODULE_TARGETS: tuple[dict[str, Any], ...] = (
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    # Stdlib-only script: no access to roots.resolve_profile_name.  Under the
+    # ExecutionGate runner HERMES_PROFILE is injected with the resolved
+    # profile, so cron runs attribute correctly; manual runs keep the
+    # host-calibrated default.
     parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", DEFAULT_PROFILE))
     parser.add_argument("--apply", action="store_true", help="Append the report to system-modules/module_cadence/reports.jsonl.")
     parser.add_argument("--format", choices=["json", "summary"], default="json")

--- a/scripts/memory_os_monitor_dashboard_snapshot.py
+++ b/scripts/memory_os_monitor_dashboard_snapshot.py
@@ -48,7 +48,7 @@ from plugins.memory.memory_os.clearance_receipts import clearance_snapshot_fresh
 from plugins.memory.memory_os.exposure_rollup import exposure_monitor_stats
 from plugins.memory.memory_os.owner_actions import owner_review_queue_report
 from plugins.memory.memory_os.operational_truth import read_operational_truth_snapshot
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.legacy_right_brain_retirement import (
     LEGACY_CRON_NAMES,
@@ -121,7 +121,7 @@ BOUNDARY_ROWS = (
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", DEFAULT_PROFILE))
+    parser.add_argument("--profile", default="")
     parser.add_argument("--output", type=Path, help="Write snapshot to this path. Defaults to stdout.")
     parser.add_argument("--format", choices=("js", "json"), default="js")
     parser.add_argument(
@@ -137,7 +137,7 @@ def main(argv: list[str] | None = None) -> int:
     hermes_home = Path("__memory_os_dashboard_sample__") if args.sample else Path(args.hermes_home)
     snapshot = build_dashboard_snapshot(
         hermes_home=hermes_home.expanduser().resolve(),
-        profile=str(args.profile or DEFAULT_PROFILE),
+        profile=resolve_profile_name(hermes_home, args.profile),
     )
     output_text = render_snapshot(snapshot, output_format=args.format)
     if args.output:

--- a/scripts/memory_os_owner_review_digest.py
+++ b/scripts/memory_os_owner_review_digest.py
@@ -21,6 +21,30 @@ try:
 except ModuleNotFoundError:
     from scripts.memory_os_execution_report import write_helper_execution_report
 
+_HERMES_HOME_DEFAULT = str(Path.home() / ".hermes")
+_repo_root = Path(__file__).absolute().parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+try:
+    from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
+    def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
+        sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
+        return False
+
+_LANE_ID = "owner_review_digest_render"
+
+
+def _record_last_run(status: str, reason: str) -> None:
+    hermes_home = os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT
+    record_lane_last_run(hermes_home, _LANE_ID, status=status, reason=reason)
+
 
 def main() -> int:
     owner = os.environ.get("MEMORY_OS_OWNER_REVIEW_OWNER", "owner")
@@ -28,35 +52,46 @@ def main() -> int:
     digest_mode = os.environ.get("MEMORY_OS_OWNER_REVIEW_DIGEST_MODE", "agenda").strip() or "agenda"
     limits = _limit_args()
 
-    if not channel:
-        channel = _resolve_channel()
+    # Empty stdout is a designed outcome (no agenda today), so each exit
+    # records WHY on disk — a crashed render and a quiet day must not leave
+    # identical evidence.
+    try:
+        if not channel:
+            channel = _resolve_channel()
 
-    delivery_ref = "cron_" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-    render = _run_json(
-        [
-            "hermes",
-            "memory-os-agent-os",
-            "review",
-            "render-delivery-digest",
-            "--owner",
-            owner,
-            "--channel",
-            channel,
-            "--delivery-ref",
-            delivery_ref,
-            "--format",
-            "json",
-            "--mode",
-            digest_mode,
-            *limits,
-        ]
-    )
+        delivery_ref = "cron_" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        render = _run_json(
+            [
+                "hermes",
+                "memory-os-agent-os",
+                "review",
+                "render-delivery-digest",
+                "--owner",
+                owner,
+                "--channel",
+                channel,
+                "--delivery-ref",
+                delivery_ref,
+                "--format",
+                "json",
+                "--mode",
+                digest_mode,
+                *limits,
+            ]
+        )
+    except SystemExit:
+        _record_last_run("error", "hermes_cli_failed")
+        raise
     if not _has_meaningful_content(render, digest_mode=digest_mode):
+        _record_last_run("skipped", "no_meaningful_content")
         return 0
     text = str(render.get("text") or "").strip()
     if text:
         print(text)
         sys.stdout.flush()
+        _record_last_run("ok", "digest_rendered")
+    else:
+        _record_last_run("skipped", "digest_text_empty")
     return 0
 
 

--- a/scripts/memory_os_proposal_followups_ops_gate.py
+++ b/scripts/memory_os_proposal_followups_ops_gate.py
@@ -10,32 +10,62 @@ work.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 try:
     from memory_os_execution_report import write_helper_execution_report
 except ModuleNotFoundError:
     from scripts.memory_os_execution_report import write_helper_execution_report
 
+_HERMES_HOME_DEFAULT = str(Path.home() / ".hermes")
+_repo_root = Path(__file__).absolute().parents[1]
+if (_repo_root / "plugins" / "memory" / "memory_os").exists():
+    if str(_repo_root) not in sys.path:
+        sys.path.insert(0, str(_repo_root))
+else:
+    _runtime_root = Path(os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT) / "memory-os" / "runtime" / "python"
+    if _runtime_root.exists() and str(_runtime_root) not in sys.path:
+        sys.path.insert(0, str(_runtime_root))
+
+try:
+    from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
+    def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
+        sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
+        return False
+
+_LANE_ID = "proposal_followups_opsgate"
+
+
+def _record_last_run(status: str, reason: str, counters: dict[str, int] | None = None) -> None:
+    hermes_home = os.environ.get("HERMES_HOME", "") or _HERMES_HOME_DEFAULT
+    record_lane_last_run(hermes_home, _LANE_ID, status=status, reason=reason, counters=counters)
+
 
 def main() -> int:
-    result = _run_json(
-        [
-            "hermes",
-            "memory-os-agent-os",
-            "review",
-            "proposal-followups",
-            "--auto-route",
-            "--apply",
-            "--limit",
-            "1",
-            "--owner",
-            "memory_os_auto",
-            "--channel",
-            "hermes_cron",
-        ]
-    )
+    try:
+        result = _run_json(
+            [
+                "hermes",
+                "memory-os-agent-os",
+                "review",
+                "proposal-followups",
+                "--auto-route",
+                "--apply",
+                "--limit",
+                "1",
+                "--owner",
+                "memory_os_auto",
+                "--channel",
+                "hermes_cron",
+            ]
+        )
+    except SystemExit:
+        _record_last_run("error", "hermes_cli_failed")
+        raise
     print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
     boundary = {
         "actual_execute": result.get("actual_execute") is True or result.get("execution_ticket_created") is True,
@@ -54,10 +84,23 @@ def main() -> int:
             "wilson_95_lower_bound": result.get("wilson_95_lower_bound"),
         },
     )
+    # "0 routed" used to be indistinguishable between an empty queue, a
+    # boundary rejection, and a failed surface — persist the closed outcome.
+    routed = int(result.get("auto_followup_routed_count") or 0)
+    eligible = int(result.get("eligible_count") or 0)
+    counters = {"routed_count": routed, "eligible_count": eligible}
     if result.get("actual_execute") is True or result.get("execution_ticket_created") is True:
+        _record_last_run("error", "boundary_violation", counters)
         return 2
     if result.get("status") not in {"ok", "warning"}:
+        _record_last_run("error", "surface_not_ok", counters)
         return 1
+    if eligible == 0:
+        _record_last_run("ok", "no_eligible_proposals", counters)
+    elif routed == 0:
+        _record_last_run("ok", "nothing_routed", counters)
+    else:
+        _record_last_run("ok", "routed", counters)
     return 0
 
 

--- a/scripts/memory_os_queue_consolidated_candidate.py
+++ b/scripts/memory_os_queue_consolidated_candidate.py
@@ -61,14 +61,14 @@ from plugins.memory.memory_os.crystallized import (  # noqa: E402
     append_candidate_queue,
     read_candidate_queue,
 )
-from plugins.memory.memory_os.roots import MemoryOSRoots  # noqa: E402
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name  # noqa: E402
 from plugins.memory.memory_os.store import MemoryOSStore  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"))
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE") or "default")
+    parser.add_argument("--profile", default="")
     parser.add_argument("--source-event-id", required=True)
     parser.add_argument("--body", required=True)
     parser.add_argument("--kind", default="preference")
@@ -78,7 +78,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--apply", action="store_true")
     args = parser.parse_args(argv)
 
-    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=resolve_profile_name(args.hermes_home, args.profile))
     store = MemoryOSStore(roots)
     store.initialize()
 

--- a/scripts/memory_os_recall_probe.py
+++ b/scripts/memory_os_recall_probe.py
@@ -52,7 +52,7 @@ else:
 
 from plugins.memory.memory_os.recall_types import RecallType
 from plugins.memory.memory_os.recall_facade import RetrieverFacade
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 
 # ── Retriever imports — each lane is independently importable ─────────
@@ -102,7 +102,7 @@ def main(argv: list[str] | None = None) -> int:
         "--hermes-home", default=_HERMES_HOME,
         help="Path to HERMES_HOME",
     )
-    parser.add_argument("--profile", default="default")
+    parser.add_argument("--profile", default="")
     parser.add_argument("--output", choices=("json",), default="json")
     args = parser.parse_args(argv)
 
@@ -112,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
         else [args.recall_type]
     )
 
-    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+    roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=resolve_profile_name(args.hermes_home, args.profile))
     store = MemoryOSStore(roots)
     store.initialize()
 

--- a/scripts/memory_os_right_brain_expression.py
+++ b/scripts/memory_os_right_brain_expression.py
@@ -28,6 +28,10 @@ SCHEMA_VERSION = "memory-os.right_brain_expression_adapter_request.v0"
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    # Legacy paused per-lane surface: keeps its host-calibrated "main" default
+    # on purpose — its historical score/feedback ledgers are stamped "main",
+    # and rewiring the fallback would split their attribution. Active lanes
+    # resolve via roots.resolve_profile_name instead.
     parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "main"))
     parser.add_argument("--channel", default=os.environ.get("MEMORY_OS_RIGHT_BRAIN_CHANNEL", "origin"))
     parser.add_argument("--max-refs", type=int, default=int(os.environ.get("MEMORY_OS_RIGHT_BRAIN_MAX_REFS", "6")))

--- a/scripts/memory_os_right_brain_expression_outcome.py
+++ b/scripts/memory_os_right_brain_expression_outcome.py
@@ -36,6 +36,8 @@ INTERNAL_MARKERS = (
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    # Legacy paused per-lane surface: keeps its host-calibrated "main" default
+    # on purpose (see memory_os_right_brain_expression.py).
     parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "main"))
     parser.add_argument("--job-name", default=os.environ.get("MEMORY_OS_RIGHT_BRAIN_JOB_NAME", DEFAULT_JOB_NAME))
     parser.add_argument("--max-preview-chars", type=int, default=int(os.environ.get("MEMORY_OS_RIGHT_BRAIN_OUTCOME_MAX_CHARS", "360")))

--- a/scripts/memory_os_session_fact_extraction_lane.py
+++ b/scripts/memory_os_session_fact_extraction_lane.py
@@ -52,7 +52,7 @@ REPO_ROOT = Path(_HERMES_HOME) / "memory-os" / "runtime" / "python"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.modules.cognition.session_fact_extraction import run_session_fact_extraction_lane
 
@@ -64,10 +64,7 @@ def _resolve_config() -> tuple[str, str, str]:
         or os.environ.get("HERMES_HOME", "")
         or str(Path.home() / ".hermes")
     )
-    profile = (
-        _preparse_cli_arg(sys.argv, "--profile")
-        or os.environ.get("HERMES_PROFILE", "default")
-    )
+    profile = resolve_profile_name(hermes_home, _preparse_cli_arg(sys.argv, "--profile"))
     envelope_id = (
         _preparse_cli_arg(sys.argv, "--envelope-id")
         or os.environ.get("MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID", "")

--- a/scripts/memory_os_state_overlay_refresh.py
+++ b/scripts/memory_os_state_overlay_refresh.py
@@ -50,7 +50,7 @@ else:
     if _runtime_root.exists() and str(_runtime_root) not in sys.path:
         sys.path.insert(0, str(_runtime_root))
 
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.state_overlay import (
     build_state_overlay,
@@ -73,7 +73,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--profile",
-        default="default",
+        default="",
         help="Memory-OS profile name",
     )
     parser.add_argument(
@@ -82,6 +82,7 @@ def main(argv: list[str] | None = None) -> int:
         default="json",
     )
     args = parser.parse_args(argv)
+    profile = resolve_profile_name(args.hermes_home, args.profile)
 
     t0 = time.monotonic()
     run_status = "ok"
@@ -89,11 +90,11 @@ def main(argv: list[str] | None = None) -> int:
     section_count = 0
 
     try:
-        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=profile)
         store = MemoryOSStore(roots)
         store.initialize()
 
-        effective_task = read_effective_current_task(roots, profile=args.profile)
+        effective_task = read_effective_current_task(roots, profile=profile)
         current_task_anchor = str((effective_task or {}).get("anchor") or "")
 
         overlay = build_state_overlay(
@@ -161,7 +162,7 @@ def main(argv: list[str] | None = None) -> int:
             "error": error_msg,
             "sections": section_count,
             "duration_ms": duration_ms,
-            "profile": args.profile,
+            "profile": profile,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         }))
 

--- a/scripts/memory_os_state_source_mirror_helper.py
+++ b/scripts/memory_os_state_source_mirror_helper.py
@@ -29,7 +29,8 @@ if not (_repo_root / "plugins" / "memory" / "memory_os").exists():
         sys.path.insert(0, str(_runtime_root))
 
 from plugins.memory.memory_os.config import load_config
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.state_source_mirror import StateSourceMirror
 from plugins.memory.memory_os.store import MemoryOSStore
 
@@ -39,7 +40,7 @@ def main() -> int:
     external_roots = [
         str(root) for root in (config.get("external_state_roots") or []) if str(root or "").strip()
     ]
-    profile = os.environ.get("HERMES_PROFILE", "default")
+    profile = resolve_profile_name(_HERMES_HOME)
     roots = MemoryOSRoots.from_hermes_home(
         _HERMES_HOME,
         profile=profile,
@@ -49,6 +50,21 @@ def main() -> int:
     store.initialize()
     report = StateSourceMirror(store).scan(dry_run=False)
     report["external_state_root_count"] = len(external_roots)
+    # The scan's findings/status used to be stdout-only while the durable
+    # state file only bumped a timestamp — persist the outcome per run.
+    findings = report.get("findings") if isinstance(report.get("findings"), list) else []
+    findings_by_code: dict[str, int] = {}
+    for finding in findings:
+        code = str(finding.get("code") or "unknown") if isinstance(finding, dict) else "unknown"
+        findings_by_code[code] = findings_by_code.get(code, 0) + 1
+    scan_status = str(report.get("status") or "")
+    record_lane_last_run(
+        _HERMES_HOME,
+        "state_source_mirror",
+        status="ok" if scan_status in {"ok", "warning"} else "error",
+        reason=f"scan_{scan_status or 'failed'}",
+        counters={"findings": len(findings), **findings_by_code},
+    )
     print(json.dumps(report, ensure_ascii=False, sort_keys=True))
     return 0 if report.get("status") in {"ok", "warning"} else 1
 

--- a/scripts/memory_os_v3_journal_sweep.py
+++ b/scripts/memory_os_v3_journal_sweep.py
@@ -29,7 +29,8 @@ else:
         sys.path.insert(0, str(_RUNTIME_ROOT))
 
 from plugins.memory.memory_os.config import load_config
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.v3_retention import sweep_pending_expired
 
@@ -37,27 +38,42 @@ from plugins.memory.memory_os.v3_retention import sweep_pending_expired
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "default"))
+    parser.add_argument("--profile", default="")
     parser.add_argument("--execution-gate-envelope-id", default=os.environ.get("MEMORY_OS_EXECUTION_GATE_ENVELOPE_ID", ""))
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    roots = MemoryOSRoots.from_hermes_home(Path(args.hermes_home), profile=str(args.profile))
+    roots = MemoryOSRoots.from_hermes_home(Path(args.hermes_home), profile=resolve_profile_name(args.hermes_home, str(args.profile)))
     store = MemoryOSStore(roots)
     store.initialize()
     config = load_config(Path(args.hermes_home)).get("v3_inner_life", {})
     ttl_days = config.get("journal_ttl_days") if isinstance(config, dict) else None
     if type(ttl_days) is not int or ttl_days <= 0:
+        # This config-disabled skip used to be stdout-only, invisible on disk.
+        record_lane_last_run(args.hermes_home, "v3_journal_sweep", status="skipped", reason="journal_ttl_unset")
         print('{"cycle_status":"skipped"}')
         return 0
     envelope_id = str(args.execution_gate_envelope_id or "").strip()
     try:
         report = sweep_pending_expired(store, execution_gate_envelope_id=envelope_id)
-    except Exception:
+    except Exception as exc:
+        record_lane_last_run(
+            args.hermes_home, "v3_journal_sweep", status="error", reason="sweep_failed", error=str(exc)
+        )
         print('{"cycle_status":"error"}')
         return 2
+    record_lane_last_run(
+        args.hermes_home,
+        "v3_journal_sweep",
+        status="ok",
+        reason="swept",
+        counters={
+            key: value for key, value in (report.items() if isinstance(report, dict) else ())
+            if isinstance(value, int)
+        },
+    )
     print(json.dumps(report, ensure_ascii=False, separators=(",", ":")))
     return 0
 

--- a/scripts/memory_os_v3_seed_evidence.py
+++ b/scripts/memory_os_v3_seed_evidence.py
@@ -29,7 +29,7 @@ else:
         sys.path.insert(0, str(runtime_root))
 
 from plugins.memory.memory_os.config import load_config
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.v3_seed_evidence import run_v3_seed_evidence_cycle
 
@@ -37,7 +37,7 @@ from plugins.memory.memory_os.v3_seed_evidence import run_v3_seed_evidence_cycle
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-home", default=_HERMES_HOME)
-    parser.add_argument("--profile", default=os.environ.get("HERMES_PROFILE", "default"))
+    parser.add_argument("--profile", default="")
     parser.add_argument("--target-date", default="")
     return parser
 
@@ -49,7 +49,7 @@ def main(argv: list[str] | None = None) -> int:
     if not isinstance(seed_config, dict) or seed_config.get("enabled") is not True:
         result = {"status": "ok", "skipped": True, "reason": "v3_seed_evidence_disabled"}
     else:
-        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=args.profile)
+        roots = MemoryOSRoots.from_hermes_home(args.hermes_home, profile=resolve_profile_name(args.hermes_home, args.profile))
         store = MemoryOSStore(roots)
         store.initialize()
         result = run_v3_seed_evidence_cycle(

--- a/scripts/memory_os_v3_wandering.py
+++ b/scripts/memory_os_v3_wandering.py
@@ -29,7 +29,7 @@ else:
         sys.path.insert(0, str(_RUNTIME_ROOT))
 
 from plugins.memory.memory_os.config import load_config
-from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.roots import MemoryOSRoots, resolve_profile_name
 from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.v3_ephemeral_adapter import HermesEphemeralAdapter, resolve_host_route_snapshot
 from plugins.memory.memory_os.v3_wandering import (
@@ -45,7 +45,7 @@ def main(argv=None) -> int:
     parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
     args = parser.parse_args(argv)
     home = Path(args.hermes_home).expanduser().resolve()
-    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(home, profile="default"))
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(home, profile=resolve_profile_name(home)))
     store.initialize()
     cfg = load_config(home).get("v3_inner_life", {})
     cfg = cfg if isinstance(cfg, dict) else {}

--- a/scripts/memory_os_version_consistency_check.py
+++ b/scripts/memory_os_version_consistency_check.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Memory-OS version single-source gate.
+
+pyproject.toml `[project].version` is the single authoritative version.
+A release tag `vX.Y.Z` may only be cut from a commit whose pyproject
+version matches, so the wheel metadata, the GitHub release, and the
+checked-out source can never disagree again (they did: release v0.2.0
+was cut while pyproject still said 0.1.0).
+
+Usage:
+  --print           print the pyproject version and exit 0
+  --tag vX.Y.Z      exit 1 unless tag == f"v{{pyproject version}}"
+
+CI wires --tag on tag pushes; run it locally before `git tag`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+
+def read_pyproject_version(repo_root: Path) -> str:
+    pyproject_path = repo_root / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        data = tomllib.load(handle)
+    version = str(data.get("project", {}).get("version") or "").strip()
+    if not version:
+        raise ValueError(f"no [project].version in {pyproject_path}")
+    return version
+
+
+def check_tag(tag: str, version: str) -> str | None:
+    """Return an error message when tag and version disagree, else None."""
+    expected = f"v{version}"
+    if tag != expected:
+        return (
+            f"release tag {tag!r} does not match pyproject version {version!r} "
+            f"(expected tag {expected!r}); bump [project].version before tagging"
+        )
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Memory-OS version single-source gate.")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--tag", default="", help="release tag to validate against pyproject version")
+    parser.add_argument("--print", dest="print_version", action="store_true", help="print the pyproject version")
+    args = parser.parse_args(argv)
+
+    try:
+        version = read_pyproject_version(Path(args.repo_root).resolve())
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+        print(f"version_consistency_check: {exc}", file=sys.stderr)
+        return 1
+
+    if args.print_version:
+        print(version)
+
+    if args.tag:
+        error = check_tag(args.tag.strip(), version)
+        if error:
+            print(f"version_consistency_check: {error}", file=sys.stderr)
+            return 1
+        print(f"version_consistency_check: tag {args.tag.strip()} matches pyproject version {version}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugins/memory/test_memory_os_cron_registry.py
+++ b/tests/plugins/memory/test_memory_os_cron_registry.py
@@ -368,3 +368,57 @@ def test_build_lane_disable_state_round_trips(tmp_path):
     records = read_lane_disable_records(home)
     assert records["expression_feedback_request"]["reason"] == "retired with右脑表达 lanes"
     assert read_disabled_lane_keys(home) == frozenset({"expression_feedback_request"})
+
+
+# ── Lane last-run evidence census ("Completion Is Not Output") ──────────────
+#
+# Both directions are pinned, like the exposure vocabulary guard: every
+# registered lane must be triaged, and no census entry may name a lane that
+# does not exist.  A new lane therefore cannot ship without declaring how a
+# reader distinguishes "no eligible input" from "processing failed".
+
+
+def test_every_cron_lane_declares_last_run_evidence():
+    from plugins.memory.memory_os.cron_registry import (
+        LANE_LAST_RUN_EVIDENCE,
+        LANE_LAST_RUN_EVIDENCE_KINDS,
+        MEMORY_OS_CRON_LANES,
+    )
+
+    lane_ids = {lane.lane_id for lane in MEMORY_OS_CRON_LANES}
+
+    missing = sorted(lane_ids - set(LANE_LAST_RUN_EVIDENCE))
+    assert not missing, f"lanes registered without last-run evidence triage: {missing}"
+
+    orphaned = sorted(set(LANE_LAST_RUN_EVIDENCE) - lane_ids)
+    assert not orphaned, f"census names lanes that are not registered: {orphaned}"
+
+    unknown_kinds = {
+        lane_id: kind
+        for lane_id, kind in LANE_LAST_RUN_EVIDENCE.items()
+        if kind not in LANE_LAST_RUN_EVIDENCE_KINDS
+    }
+    assert not unknown_kinds, f"census uses undefined evidence kinds: {unknown_kinds}"
+
+
+def test_lane_last_run_declarations_are_actually_wired():
+    """Source-scan guard: a lane declared 'lane_last_run' must really call
+    record_lane_last_run with its own lane_id — a census that nothing
+    satisfies would be green-by-vocabulary, the exact drift this table
+    exists to prevent."""
+    from pathlib import Path
+
+    from plugins.memory.memory_os.cron_registry import (
+        LANE_LAST_RUN_EVIDENCE,
+        MEMORY_OS_CRON_LANES,
+    )
+
+    scripts_dir = Path(__file__).resolve().parents[3] / "scripts"
+    unwired: list[str] = []
+    for lane in MEMORY_OS_CRON_LANES:
+        if LANE_LAST_RUN_EVIDENCE.get(lane.lane_id) != "lane_last_run":
+            continue
+        source = (scripts_dir / lane.raw_script).read_text(encoding="utf-8")
+        if "record_lane_last_run" not in source or f'"{lane.lane_id}"' not in source:
+            unwired.append(lane.lane_id)
+    assert not unwired, f"lanes declared lane_last_run but not wired: {unwired}"

--- a/tests/plugins/memory/test_memory_os_lane_last_run.py
+++ b/tests/plugins/memory/test_memory_os_lane_last_run.py
@@ -1,0 +1,89 @@
+import json
+
+from plugins.memory.memory_os.lane_last_run import (
+    LANE_LAST_RUN_SCHEMA_VERSION,
+    lane_last_run_path,
+    read_lane_last_run,
+    record_lane_last_run,
+)
+
+
+def test_record_and_read_round_trip(tmp_path):
+    assert record_lane_last_run(
+        tmp_path,
+        "index_sync",
+        status="ok",
+        reason="synced",
+        counters={"events": 3, "drift_count": 0},
+    )
+
+    record = read_lane_last_run(tmp_path, "index_sync")
+
+    assert record is not None
+    assert record["schema_version"] == LANE_LAST_RUN_SCHEMA_VERSION
+    assert record["lane_id"] == "index_sync"
+    assert record["status"] == "ok"
+    assert record["reason"] == "synced"
+    assert record["counters"] == {"events": 3, "drift_count": 0}
+    assert record["recorded_at"].endswith("Z")
+
+
+def test_record_overwrites_previous_run(tmp_path):
+    record_lane_last_run(tmp_path, "lane_x", status="ok", reason="produced")
+    record_lane_last_run(tmp_path, "lane_x", status="skipped", reason="no_eligible_input")
+
+    record = read_lane_last_run(tmp_path, "lane_x")
+
+    assert record["status"] == "skipped"
+    assert record["reason"] == "no_eligible_input"
+
+
+def test_unknown_status_is_coerced_to_error_and_error_text_bounded(tmp_path):
+    record_lane_last_run(
+        tmp_path,
+        "lane_y",
+        status="mystery",
+        reason="boom",
+        error="x" * 1000,
+    )
+
+    record = read_lane_last_run(tmp_path, "lane_y")
+
+    assert record["status"] == "error"
+    assert len(record["error"]) <= 300
+
+
+def test_non_int_counters_are_dropped_not_fatal(tmp_path):
+    record_lane_last_run(
+        tmp_path,
+        "lane_z",
+        status="ok",
+        reason="produced",
+        counters={"good": 1, "bad": "not-an-int"},
+    )
+
+    record = read_lane_last_run(tmp_path, "lane_z")
+
+    assert record["counters"] == {"good": 1}
+
+
+def test_write_failure_is_fail_open(tmp_path, capsys):
+    # Occupy the lane_last_run *path segment* with a file so mkdir fails.
+    blocker = tmp_path / "memory-os" / "system"
+    blocker.parent.mkdir(parents=True)
+    blocker.write_text("not a directory", encoding="utf-8")
+
+    assert record_lane_last_run(tmp_path, "lane_w", status="ok", reason="produced") is False
+    assert "lane_last_run: write failed" in capsys.readouterr().err
+
+
+def test_read_returns_none_for_absent_or_malformed(tmp_path):
+    assert read_lane_last_run(tmp_path, "missing_lane") is None
+
+    path = lane_last_run_path(tmp_path, "broken_lane")
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert read_lane_last_run(tmp_path, "broken_lane") is None
+
+    path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+    assert read_lane_last_run(tmp_path, "broken_lane") is None

--- a/tests/plugins/memory/test_memory_os_loop_health_view.py
+++ b/tests/plugins/memory/test_memory_os_loop_health_view.py
@@ -1,0 +1,113 @@
+import json
+from datetime import datetime, timezone
+
+from plugins.memory.memory_os.cron_registry import (
+    LANE_LAST_RUN_EVIDENCE,
+    MEMORY_OS_CRON_LANES,
+)
+from plugins.memory.memory_os.lane_last_run import lane_last_run_path, record_lane_last_run
+from plugins.memory.memory_os.loop_health_view import (
+    LOOP_MEMBERS,
+    build_loop_health_view,
+    render_loop_health_summary,
+)
+
+_NOW = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _loop(view, name):
+    return next(loop for loop in view["loops"] if loop["loop"] == name)
+
+
+def test_loop_members_partition_every_registered_lane_exactly_once():
+    # Census in both directions, like the lane-evidence table: a new lane
+    # cannot ship without being placed in a loop, and the view can never
+    # name a lane that does not exist.
+    registered = {lane.lane_id for lane in MEMORY_OS_CRON_LANES}
+    placed: list[str] = [lane_id for members in LOOP_MEMBERS.values() for lane_id in members]
+
+    assert sorted(placed) == sorted(set(placed)), "a lane appears in two loops"
+    assert set(placed) == registered, (
+        f"unplaced: {sorted(registered - set(placed))}; unknown: {sorted(set(placed) - registered)}"
+    )
+
+
+def test_view_reports_no_evidence_on_empty_home(tmp_path):
+    view = build_loop_health_view(tmp_path, now=_NOW)
+
+    assert view["schema_version"] == "memory-os.loop_health_view.v0"
+    observability = _loop(view, "observability")
+    assert observability["state"] == "no_evidence"
+    assert observability["members"][0]["status"] == "no_evidence"
+
+
+def test_fresh_ok_run_marks_loop_active(tmp_path):
+    record_lane_last_run(tmp_path, "full_monitor_refresh", status="ok", reason="artifact_published")
+
+    view = build_loop_health_view(tmp_path, now=datetime.now(timezone.utc))
+
+    assert _loop(view, "observability")["state"] == "active"
+
+
+def test_error_run_marks_loop_attention_even_with_fresh_ok_sibling(tmp_path):
+    record_lane_last_run(tmp_path, "index_sync", status="ok", reason="synced")
+    record_lane_last_run(tmp_path, "fact_judge", status="error", reason="lane_failed")
+
+    view = build_loop_health_view(tmp_path, now=datetime.now(timezone.utc))
+
+    memory_loop = _loop(view, "memory")
+    assert memory_loop["state"] == "attention"
+    fact_judge_row = next(m for m in memory_loop["members"] if m["lane_id"] == "fact_judge")
+    assert fact_judge_row["reason"] == "lane_failed"
+
+
+def test_only_skips_mark_loop_idle(tmp_path):
+    record_lane_last_run(tmp_path, "expression_feedback_request", status="skipped", reason="outcome_silent")
+
+    view = build_loop_health_view(tmp_path, now=datetime.now(timezone.utc))
+
+    assert _loop(view, "expression")["state"] == "idle"
+
+
+def test_stale_ok_run_does_not_count_as_active(tmp_path):
+    # A weekly lane's ok from months ago must not keep its loop "active";
+    # freshness derives from the lane's own due_interval_minutes.
+    path = lane_last_run_path(tmp_path, "expression_feedback_request")
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "memory-os.lane_last_run.v0",
+                "lane_id": "expression_feedback_request",
+                "recorded_at": "2026-01-01T00:00:00Z",
+                "status": "ok",
+                "reason": "prompt_rendered",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    view = build_loop_health_view(tmp_path, now=_NOW)
+
+    expression = _loop(view, "expression")
+    assert expression["members"][0]["stale"] is True
+    assert expression["state"] == "idle"
+
+
+def test_dedicated_artifact_lanes_point_to_their_own_evidence(tmp_path):
+    view = build_loop_health_view(tmp_path, now=_NOW)
+
+    graph = _loop(view, "graph")
+    wandering = next(m for m in graph["members"] if m["lane_id"] == "v3_wandering")
+    assert wandering["evidence"] == "dedicated_artifact"
+    assert wandering["status"] == "see_dedicated_artifact"
+    assert LANE_LAST_RUN_EVIDENCE["v3_wandering"] == "dedicated_artifact"
+
+
+def test_render_summary_names_loops_and_reasons(tmp_path):
+    record_lane_last_run(tmp_path, "index_sync", status="ok", reason="synced")
+
+    text = render_loop_health_summary(build_loop_health_view(tmp_path, now=datetime.now(timezone.utc)))
+
+    assert "memory" in text
+    assert "index_sync=ok(synced)" in text

--- a/tests/plugins/memory/test_memory_os_recall_golden.py
+++ b/tests/plugins/memory/test_memory_os_recall_golden.py
@@ -350,6 +350,124 @@ class TestEvaluateRecallCounterfactual:
         assert after_score["recall_rate"] == 0.0
         assert after_score["recall_rate"] < before_score["recall_rate"]
 
+def test_golden_query_category_round_trips(tmp_path: Path):
+    gs = GoldenSet(
+        profile="cat",
+        queries=[
+            GoldenQuery(
+                query="今天的部署状态如何",
+                expected=[GoldenResult(recall_type="crystallized", content_pattern="deploy")],
+                category="chinese_natural",
+            ),
+        ],
+    )
+    path = tmp_path / "cat.golden.json"
+    save_golden_set(path, gs)
+
+    loaded = load_golden_set(path)
+
+    assert loaded.queries[0].category == "chinese_natural"
+
+
+def test_legacy_golden_file_without_category_reports_uncategorized(tmp_path: Path):
+    import json
+
+    path = tmp_path / "legacy_cat.golden.json"
+    path.write_text(json.dumps({
+        "schema_version": "memory-os.recall_golden_set.v1",
+        "profile": "legacy",
+        "queries": [
+            {
+                "query": "some fact",
+                "expected": [{"recall_type": "crystallized", "content_pattern": "ABSENT"}],
+            }
+        ],
+    }), encoding="utf-8")
+    store = _init_store(tmp_path)
+
+    report = run_golden_set_report(store, path, profile="legacy")
+
+    assert report["items"][0]["category"] == "uncategorized"
+    assert "uncategorized" in report["by_category"]
+
+
+class TestReportCategoryBreakdownAndInjectionMetrics:
+    def test_no_answer_honesty_counts_negative_check_without_injection(self, tmp_path):
+        # Honest no-answer: all-negative expectations on an empty store must
+        # register as a checked negative with zero injections.
+        store = _init_store(tmp_path)
+        gs = GoldenSet(
+            profile="metrics",
+            queries=[
+                GoldenQuery(
+                    query="谁是从未提过的人物",
+                    expected=[GoldenResult(
+                        recall_type="crystallized",
+                        content_pattern="NEVER_STORED_TOKEN_777",
+                        must_hit=False,
+                    )],
+                    category="no_answer",
+                ),
+                GoldenQuery(
+                    query="an entity that was never captured",
+                    expected=[GoldenResult(
+                        recall_type="crystallized",
+                        content_pattern="ALSO_ABSENT_TOKEN_888",
+                    )],
+                    category="entity",
+                ),
+            ],
+        )
+        path = tmp_path / "metrics.golden.json"
+        save_golden_set(path, gs)
+
+        report = run_golden_set_report(store, path, profile="metrics")
+
+        assert report["metrics"]["negative_checks"] == 1
+        assert report["metrics"]["wrong_memory_injection_count"] == 0
+        assert report["metrics"]["wrong_memory_injection_rate"] == 0.0
+        assert report["by_category"]["no_answer"] == {"hit": 1}
+        assert report["by_category"]["entity"] == {"miss_missing": 1}
+        assert report["by_classification"]["miss_missing"] == 1
+
+    @pytest.mark.usefixtures("crystallized_test_write_authority")
+    def test_superseded_fact_matching_negative_check_counts_as_injection(self, tmp_path):
+        # Stale-injection semantics: the OLD (superseded) fact is written via
+        # the real production path and listed as must_hit=False; the pipeline
+        # surfacing it is a wrong-memory injection. Counterfactual: before
+        # the metrics rollup the report had no "metrics" key at all.
+        store = _init_store(tmp_path)
+        frontmatter = build_crystallized_frontmatter(seed=17, kind="moment")
+        store.append_crystallized_record(
+            "superseded.md",
+            frontmatter,
+            "Old address marker STALE_FACT_4242 was replaced last month.",
+        )
+        gs = GoldenSet(
+            profile="metrics2",
+            queries=[
+                GoldenQuery(
+                    query="old address marker",
+                    expected=[GoldenResult(
+                        recall_type="crystallized",
+                        content_pattern="STALE_FACT_4242",
+                        must_hit=False,
+                    )],
+                    category="superseded",
+                ),
+            ],
+        )
+        path = tmp_path / "metrics2.golden.json"
+        save_golden_set(path, gs)
+
+        report = run_golden_set_report(store, path, profile="metrics2")
+
+        assert report["metrics"]["negative_checks"] == 1
+        assert report["metrics"]["wrong_memory_injection_count"] == 1
+        assert report["metrics"]["wrong_memory_injection_rate"] == 1.0
+        assert report["by_category"]["superseded"] == {"false_positive": 1}
+
+
 def test_loader_ignores_min_score_and_unknown_keys(tmp_path: Path):
     """Backlog 10: min_score was removed as unimplementable dead schema (no
     per-section score exists at the disclosure surface). Golden files already

--- a/tests/plugins/memory/test_memory_os_roots.py
+++ b/tests/plugins/memory/test_memory_os_roots.py
@@ -58,3 +58,54 @@ def test_roots_reject_external_state_root_path_traversal(tmp_path):
 
     with pytest.raises(RootValidationError, match="external_state_roots"):
         MemoryOSRoots.from_hermes_home(tmp_path, external_state_roots=[traversal])
+
+
+def test_from_hermes_home_derives_profile_from_profile_shaped_home(tmp_path):
+    # Counterfactual for the sannai mis-attribution: without derivation this
+    # returned "" and every `roots.profile or "default"` consumer stamped the
+    # sannai home's records as "default".
+    hermes_home = tmp_path / ".hermes" / "profiles" / "sannai"
+    hermes_home.mkdir(parents=True)
+
+    roots = MemoryOSRoots.from_hermes_home(hermes_home)
+
+    assert roots.profile == "sannai"
+
+
+def test_from_hermes_home_keeps_empty_profile_for_plain_home(tmp_path):
+    roots = MemoryOSRoots.from_hermes_home(tmp_path / ".hermes")
+
+    assert roots.profile == ""
+
+
+def test_from_hermes_home_explicit_profile_outranks_home_shape(tmp_path):
+    # Hermes' agent identity may legitimately differ from the home directory
+    # name, so an explicitly passed profile wins without raising here; the
+    # fail-closed conflict semantics live in resolve_profile_name (the
+    # script/cron surface, where "explicit" is env contamination instead).
+    hermes_home = tmp_path / ".hermes" / "profiles" / "sannai"
+    hermes_home.mkdir(parents=True)
+
+    roots = MemoryOSRoots.from_hermes_home(hermes_home, profile="identity-name")
+
+    assert roots.profile == "identity-name"
+
+
+def test_resolve_profile_name_priority_and_conflict(tmp_path):
+    from plugins.memory.memory_os.roots import resolve_profile_name
+
+    plain_home = tmp_path / "home"
+    sannai_home = tmp_path / "profiles" / "sannai"
+
+    assert resolve_profile_name(plain_home, environ={}) == "default"
+    assert resolve_profile_name(sannai_home, environ={}) == "sannai"
+    assert resolve_profile_name(plain_home, environ={"HERMES_PROFILE": "sannai"}) == "sannai"
+    assert resolve_profile_name(sannai_home, environ={"HERMES_PROFILE": "sannai"}) == "sannai"
+    assert resolve_profile_name(plain_home, "explicit-x", environ={"HERMES_PROFILE": "env-y"}) == "explicit-x"
+
+    with pytest.raises(RootValidationError, match="contradicts"):
+        resolve_profile_name(sannai_home, environ={"HERMES_PROFILE": "default"})
+    with pytest.raises(RootValidationError, match="contradicts"):
+        resolve_profile_name(sannai_home, "other", environ={})
+    with pytest.raises(RootValidationError, match="traversal"):
+        resolve_profile_name(plain_home, "../escape", environ={})

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -827,6 +827,45 @@ def test_classify_snapshot_continuity_freshness_unknown_grade_count_surfaces_as_
     assert not any("continuity_freshness" in item.get("code", "") for item in classification["fail"])
 
 
+def test_classify_snapshot_lane_last_run_state_surfaces_as_info_only():
+    """The lane_last_run section explains WHY lanes produced nothing
+    ("Completion Is Not Output"). It is deliberately INFO-only: a failed run
+    already fails helper-completion grading, so grading here would
+    double-alarm. Counterfactual: before the wiring classify_snapshot never
+    read snapshot["lane_last_run"], so the info entry below did not exist."""
+    snapshot = _healthy_snapshot()
+    snapshot["lane_last_run"] = {
+        "schema_version": "memory-os.lane_last_run_monitor.v0",
+        "directory_exists": True,
+        "lane_count": 3,
+        "status_counts": {"ok": 1, "skipped": 1, "error": 1, "malformed": 0},
+        "lanes": {
+            "index_sync": {"status": "ok", "reason": "synced", "recorded_at": "2026-08-13T00:00:00Z"},
+            "working_cleanup": {"status": "skipped", "reason": "working_file_absent", "recorded_at": "2026-08-13T00:00:00Z"},
+            "fact_judge": {"status": "error", "reason": "lane_failed", "recorded_at": "2026-08-13T00:00:00Z"},
+        },
+        "raw_body_included": False,
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    entries = [item for item in classification["info"] if item["code"] == "lane_last_run_state"]
+    assert entries, classification["info"]
+    assert entries[0]["value"]["error_lanes"] == ["fact_judge"]
+    assert entries[0]["value"]["status_counts"]["error"] == 1
+    assert not any("lane_last_run" in item.get("code", "") for item in classification["warn"])
+    assert not any("lane_last_run" in item.get("code", "") for item in classification["fail"])
+
+
+def test_classify_snapshot_without_lane_last_run_section_adds_no_entry():
+    snapshot = _healthy_snapshot()
+    snapshot.pop("lane_last_run", None)
+
+    classification = classify_snapshot(snapshot)
+
+    assert not any("lane_last_run" in item.get("code", "") for item in classification["info"])
+
+
 def test_continuity_freshness_summary_reads_real_ledger_and_counts_correctly(tmp_path):
     """Exercises the real embedded-script collector (continuity_freshness_summary(),
     added alongside the classify_snapshot wiring tested above) against an

--- a/tests/scripts/test_memory_os_execution_gate_runner.py
+++ b/tests/scripts/test_memory_os_execution_gate_runner.py
@@ -1,5 +1,6 @@
 import json
 import importlib.util
+import os
 import shutil
 import subprocess
 import sys
@@ -513,6 +514,7 @@ def _runner_permit_and_completion(module, hermes_home):
         helper_present=True,
         smoke_mode="off",
         boundary=dict(_FALSE_BOUNDARY),
+        profile="default",
     )
     module._append_completion(
         hermes_home=hermes_home,
@@ -523,6 +525,7 @@ def _runner_permit_and_completion(module, hermes_home):
         smoke_mode="off",
         boundary=dict(_FALSE_BOUNDARY),
         helper_report={},
+        profile="default",
         requires_boundary_report=False,
     )
     records = [
@@ -620,3 +623,183 @@ def test_dual_writer_sidecar_entries_have_identical_shape(tmp_path):
     assert set(runner_entry) == set(core_entry), (
         "sidecar index entries from the two writers diverged in shape"
     )
+
+
+# ── Profile attribution resolution (multi-profile hosts) ────────────────────
+#
+# Multi-profile hosts export only HERMES_HOME=/root/.hermes/profiles/<name>
+# without HERMES_PROFILE.  The old `HERMES_PROFILE or "default"` fallback then
+# stamped that profile's permit/completion records as "default", and
+# profile-filtered readers silently dropped them.
+
+
+def _profile_registry_snapshot(hermes_home, raw_script):
+    registry_path = hermes_home / "memory-os" / "system" / "memory_os_cron_registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "memory-os.cron_registry.v0",
+                "specs": [
+                    {
+                        "key": "index_sync",
+                        "name": "memory-os-index-sync",
+                        "raw_script": raw_script,
+                        "wrapper_script": "memory_os_cron_index_sync_gate.py",
+                        "lane_id": "index_sync",
+                        "helper_kind": "local_helper",
+                        "no_agent": True,
+                        "requires_boundary_report": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_resolve_profile_behavior_table(tmp_path, monkeypatch):
+    module = _load_runner_module()
+    plain_home = tmp_path / "home"
+    sannai_home = tmp_path / "profiles" / "sannai"
+
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    assert module._resolve_profile(plain_home) == ("default", None)
+    assert module._resolve_profile(sannai_home) == ("sannai", None)
+    assert module._resolve_profile(plain_home, "explicit-x") == ("explicit-x", None)
+    assert module._resolve_profile(sannai_home, "sannai") == ("sannai", None)
+    profile, conflict = module._resolve_profile(sannai_home, "other")
+    assert profile == "sannai"
+    assert conflict == {"requested": "other", "derived_from_home": "sannai"}
+
+    monkeypatch.setenv("HERMES_PROFILE", "sannai")
+    assert module._resolve_profile(plain_home) == ("sannai", None)
+    assert module._resolve_profile(sannai_home) == ("sannai", None)
+
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    profile, conflict = module._resolve_profile(sannai_home)
+    assert profile == "sannai"
+    assert conflict == {"requested": "default", "derived_from_home": "sannai"}
+
+    # Explicit --profile outranks the environment.
+    monkeypatch.setenv("HERMES_PROFILE", "main")
+    assert module._resolve_profile(plain_home, "sannai") == ("sannai", None)
+
+
+def test_resolve_profile_matches_roots_resolver_behavior_table(tmp_path, monkeypatch):
+    # The runner is stdlib-only, so it carries a local twin of
+    # roots.resolve_profile_name.  This table pins the two implementations
+    # together: any drift between them re-opens split attribution.
+    from plugins.memory.memory_os.roots import RootValidationError, resolve_profile_name
+
+    module = _load_runner_module()
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    plain_home = tmp_path / "home"
+    sannai_home = tmp_path / "profiles" / "sannai"
+
+    for home, explicit in [
+        (plain_home, ""),
+        (plain_home, "explicit-x"),
+        (sannai_home, ""),
+        (sannai_home, "sannai"),
+    ]:
+        runner_profile, runner_conflict = module._resolve_profile(home, explicit)
+        assert runner_conflict is None
+        assert resolve_profile_name(home, explicit) == runner_profile
+
+    # Conflict: the runner reports it structurally, roots fails closed.
+    runner_profile, runner_conflict = module._resolve_profile(sannai_home, "other")
+    assert runner_conflict is not None
+    try:
+        resolve_profile_name(sannai_home, "other")
+    except RootValidationError:
+        pass
+    else:
+        raise AssertionError("roots resolver accepted a conflicting profile")
+
+
+def test_profile_shaped_home_stamps_permit_and_completion_with_derived_profile(tmp_path, monkeypatch):
+    # Counterfactual for the sannai mis-attribution: before the resolver these
+    # records said "default" whenever HERMES_PROFILE was not exported.
+    module = _load_runner_module()
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    hermes_home = tmp_path / "profiles" / "sannai"
+    _profile_registry_snapshot(hermes_home, "memory_os_missing_helper_for_profile_test.py")
+
+    outcome = module.run_registry_key_detailed("index_sync", hermes_home=hermes_home)
+
+    # Helper is intentionally missing: permit + helper_missing completion both
+    # get written, which is exactly the pair whose attribution matters.
+    assert outcome["status"] == "helper_missing"
+    records_path = hermes_home / "memory-os" / "system" / "execution_gate_envelopes.jsonl"
+    records = [json.loads(line) for line in records_path.read_text(encoding="utf-8").splitlines()]
+    assert [record["stage"] for record in records] == ["permit", "completion"]
+    assert records[0]["profile"] == "sannai"
+    assert records[1]["profile"] == "sannai"
+    assert records[0]["permit_decision"] == "allowed"
+
+
+def test_profile_home_conflict_blocks_lane_with_durable_permit(tmp_path, monkeypatch):
+    # HERMES_PROFILE=default + a sannai-shaped home must not run the helper —
+    # but it must leave a blocked permit as evidence, never exit silently.
+    module = _load_runner_module()
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    hermes_home = tmp_path / "profiles" / "sannai"
+    _profile_registry_snapshot(hermes_home, "memory_os_module_cadence_report_cron.py")
+
+    outcome = module.run_registry_key_detailed("index_sync", hermes_home=hermes_home)
+
+    assert outcome["status"] == "permit_blocked"
+    assert outcome["error_code"] == "profile_home_conflict"
+    assert outcome["returncode"] == 2
+    records_path = hermes_home / "memory-os" / "system" / "execution_gate_envelopes.jsonl"
+    records = [json.loads(line) for line in records_path.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 1
+    assert records[0]["stage"] == "permit"
+    assert records[0]["permit_decision"] == "blocked"
+    assert records[0]["permit_reason"] == "profile_home_conflict"
+    assert records[0]["profile"] == "sannai"
+    assert records[0]["profile_conflict"] == {"requested": "default", "derived_from_home": "sannai"}
+
+
+def test_runner_injects_resolved_profile_into_helper_environment(tmp_path):
+    # The helper subprocess must see the same profile the envelope was stamped
+    # with, so lane scripts stop re-deriving (and mis-deriving) it themselves.
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    runner = Path(__file__).resolve().parents[2] / "scripts" / "memory_os_execution_gate_runner.py"
+    shutil.copy2(runner, scripts_dir / "memory_os_execution_gate_runner.py")
+    (scripts_dir / "memory_os_profile_probe_helper.py").write_text(
+        "\n".join(
+            [
+                "import os",
+                "from pathlib import Path",
+                "out = Path(os.environ['HERMES_HOME']) / 'seen_profile.txt'",
+                "out.write_text(os.environ.get('HERMES_PROFILE', '<unset>'), encoding='utf-8')",
+                "print('PROBE_OK')",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    hermes_home = tmp_path / "profiles" / "sannai"
+    _profile_registry_snapshot(hermes_home, "memory_os_profile_probe_helper.py")
+    env = {key: value for key, value in os.environ.items() if key != "HERMES_PROFILE"}
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(scripts_dir / "memory_os_execution_gate_runner.py"),
+            "--registry-key",
+            "index_sync",
+            "--hermes-home",
+            str(hermes_home),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (hermes_home / "seen_profile.txt").read_text(encoding="utf-8") == "sannai"

--- a/tests/scripts/test_memory_os_feedback_prompt_helpers.py
+++ b/tests/scripts/test_memory_os_feedback_prompt_helpers.py
@@ -4,9 +4,20 @@ from contextlib import redirect_stdout
 from io import StringIO
 import json
 
+import pytest
+
+from plugins.memory.memory_os.lane_last_run import read_lane_last_run
 from scripts import memory_os_expression_feedback_prompt as expression_prompt
 from scripts import memory_os_memory_sources_feedback_prompt as memory_sources_prompt
 from scripts import memory_os_proposal_followups_ops_gate as proposal_followups
+
+
+@pytest.fixture(autouse=True)
+def hermes_home(tmp_path, monkeypatch):
+    # The prompt helpers now persist lane_last_run evidence under
+    # HERMES_HOME; isolate it so tests never touch the real home.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
 
 
 def _capture(func) -> str:
@@ -32,6 +43,53 @@ def test_expression_feedback_prompt_skips_silent_outcome(monkeypatch):
     )
 
     assert _capture(expression_prompt.main) == ""
+
+
+def test_expression_feedback_prompt_persists_skip_reason(monkeypatch, hermes_home):
+    # Weekly cron renders nothing for a silent outcome; the WHY must land on
+    # disk (this file did not exist before the lane_last_run wiring).
+    monkeypatch.setattr(
+        expression_prompt,
+        "_run_json",
+        lambda _command: {
+            "status": "ok",
+            "existing_feedback": {"count": 0},
+            "latest_outcome": {
+                "outcome_silent": True,
+                "expression_preview": "[SILENT]",
+                "action_tokens": {"like_expression": "oa_like"},
+            },
+        },
+    )
+
+    assert _capture(expression_prompt.main) == ""
+
+    record = read_lane_last_run(hermes_home, "expression_feedback_request")
+    assert record is not None
+    assert record["status"] == "skipped"
+    assert record["reason"] == "outcome_silent"
+
+
+def test_expression_feedback_prompt_persists_rendered_outcome(monkeypatch, hermes_home):
+    monkeypatch.setattr(
+        expression_prompt,
+        "_run_json",
+        lambda _command: {
+            "status": "ok",
+            "existing_feedback": {"count": 0},
+            "latest_outcome": {
+                "outcome_silent": False,
+                "expression_preview": "quiet presence",
+                "action_tokens": {"like_expression": "oa_like"},
+            },
+        },
+    )
+
+    assert "memory feedback oa_like like_expression" in _capture(expression_prompt.main)
+
+    record = read_lane_last_run(hermes_home, "expression_feedback_request")
+    assert record["status"] == "ok"
+    assert record["reason"] == "prompt_rendered"
 
 
 def test_expression_feedback_prompt_skips_already_rated_outcome(monkeypatch):
@@ -86,6 +144,53 @@ def test_memory_sources_feedback_prompt_skips_already_rated_source(monkeypatch):
     )
 
     assert _capture(memory_sources_prompt.main) == ""
+
+
+def test_memory_sources_feedback_prompt_persists_skip_reason_on_cron_path(monkeypatch, hermes_home):
+    # The skip_reason enum used to exist only behind --status-json, which
+    # cron never passes; the cron path must persist the same code.
+    monkeypatch.setattr(
+        memory_sources_prompt,
+        "_run_json",
+        lambda _command: {
+            "status": "ok",
+            "existing_feedback": {"count": 1},
+            "latest_memory_source": {
+                "action_tokens": {"mark_feedback": "oa_feedback"},
+            },
+        },
+    )
+
+    assert _capture(memory_sources_prompt.main) == ""
+
+    record = read_lane_last_run(hermes_home, "memory_sources_feedback_request")
+    assert record is not None
+    assert record["status"] == "skipped"
+    assert record["reason"] == "already_feedback_for_latest_source"
+
+
+def test_memory_sources_feedback_prompt_persists_rendered_prompt(monkeypatch, hermes_home):
+    monkeypatch.setattr(
+        memory_sources_prompt,
+        "_run_json",
+        lambda _command: {
+            "status": "ok",
+            "existing_feedback": {"count": 0},
+            "latest_memory_source": {
+                "action_tokens": {"mark_feedback": "oa_feedback"},
+                "source_classes": ["event"],
+                "route": "casual_continuity",
+                "selected_count": 1,
+                "selected_chars_total": 100,
+            },
+        },
+    )
+
+    assert _capture(memory_sources_prompt.main).startswith("OWNER_MESSAGE_BEGIN")
+
+    record = read_lane_last_run(hermes_home, "memory_sources_feedback_request")
+    assert record["status"] == "ok"
+    assert record["reason"] == "prompt_rendered"
 
 
 def test_memory_sources_feedback_prompt_help_does_not_require_hermes(monkeypatch):

--- a/tests/scripts/test_memory_os_lane_last_run_wiring.py
+++ b/tests/scripts/test_memory_os_lane_last_run_wiring.py
@@ -1,0 +1,135 @@
+"""Wiring tests: lanes whose reason taxonomies used to be stdout-only must
+now persist a durable last-run record ("Completion Is Not Output").
+
+Counterfactual: before this wiring, every one of these runs left NO
+lane_last_run file, so the assertions on its existence fail on the old code.
+"""
+
+from __future__ import annotations
+
+from plugins.memory.memory_os.lane_last_run import read_lane_last_run
+
+from scripts import cleanup_expired_working as working_cleanup
+from scripts import memory_os_hindsight_advisory_digest as advisory_digest
+from scripts import memory_os_hindsight_health_probe as health_probe
+import json
+
+
+def test_hindsight_health_probe_persists_disabled_outcome(tmp_path, capsys):
+    assert health_probe.main(["--hermes-home", str(tmp_path)]) == 0
+
+    record = read_lane_last_run(tmp_path, "hindsight_health_probe")
+
+    assert record is not None
+    assert record["status"] == "ok"
+    assert record["reason"] == "disabled"
+    capsys.readouterr()  # drain probe stdout
+
+
+def test_hindsight_advisory_digest_persists_skip_reason(tmp_path, capsys):
+    assert advisory_digest.main(["--hermes-home", str(tmp_path)]) == 0
+
+    record = read_lane_last_run(tmp_path, "hindsight_advisory_digest")
+
+    assert record is not None
+    assert record["status"] == "skipped"
+    assert record["reason"] == "hindsight_not_enabled"
+    assert record["counters"]["advisory_emitted"] == 0
+    capsys.readouterr()
+
+
+def test_working_cleanup_records_absent_file(tmp_path):
+    assert working_cleanup.main(str(tmp_path)) == 0
+
+    record = read_lane_last_run(tmp_path, "working_cleanup")
+
+    assert record["status"] == "skipped"
+    assert record["reason"] == "working_file_absent"
+
+
+def test_working_cleanup_records_no_expired_items(tmp_path):
+    working = tmp_path / "memory-os" / "working" / "lingering.json"
+    working.parent.mkdir(parents=True)
+    working.write_text(
+        json.dumps({"items": [{"status": "active", "text": "keep me"}]}),
+        encoding="utf-8",
+    )
+
+    assert working_cleanup.main(str(tmp_path)) == 0
+
+    record = read_lane_last_run(tmp_path, "working_cleanup")
+    assert record["status"] == "ok"
+    assert record["reason"] == "no_expired_items"
+    assert record["counters"] == {"items_scanned": 1, "items_removed": 0}
+
+
+def test_working_cleanup_records_removal_and_prunes_file(tmp_path, capsys):
+    working = tmp_path / "memory-os" / "working" / "lingering.json"
+    working.parent.mkdir(parents=True)
+    working.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {"status": "expired", "updated_at": "2020-01-01T00:00:00+00:00", "text": "old"},
+                    {"status": "active", "text": "keep"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert working_cleanup.main(str(tmp_path)) == 0
+
+    record = read_lane_last_run(tmp_path, "working_cleanup")
+    assert record["reason"] == "removed_expired_items"
+    assert record["counters"]["items_removed"] == 1
+    remaining = json.loads(working.read_text(encoding="utf-8"))["items"]
+    assert [item["text"] for item in remaining] == ["keep"]
+    assert "Working Memory Cleanup" in capsys.readouterr().out
+
+
+def test_state_source_mirror_helper_persists_scan_outcome(tmp_path, monkeypatch, capsys):
+    from scripts import memory_os_state_source_mirror_helper as mirror_helper
+
+    class _StubStore:
+        def __init__(self, roots):
+            self.roots = roots
+
+        def initialize(self):
+            return None
+
+    class _StubMirror:
+        def __init__(self, _store):
+            pass
+
+        def scan(self, dry_run):
+            return {
+                "status": "warning",
+                "findings": [{"code": "state_root_missing"}, {"code": "state_root_missing"}],
+            }
+
+    monkeypatch.setattr(mirror_helper, "_HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(mirror_helper, "load_config", lambda _home: {})
+    monkeypatch.setattr(mirror_helper, "MemoryOSStore", _StubStore)
+    monkeypatch.setattr(mirror_helper, "StateSourceMirror", _StubMirror)
+
+    assert mirror_helper.main() == 0
+
+    record = read_lane_last_run(tmp_path, "state_source_mirror")
+    assert record["status"] == "ok"
+    assert record["reason"] == "scan_warning"
+    assert record["counters"] == {"findings": 2, "state_root_missing": 2}
+    capsys.readouterr()
+
+
+def test_working_cleanup_records_unreadable_file(tmp_path, capsys):
+    working = tmp_path / "memory-os" / "working" / "lingering.json"
+    working.parent.mkdir(parents=True)
+    working.write_text("{broken json", encoding="utf-8")
+
+    assert working_cleanup.main(str(tmp_path)) == 1
+
+    record = read_lane_last_run(tmp_path, "working_cleanup")
+    assert record["status"] == "error"
+    assert record["reason"] == "working_file_unreadable"
+    assert "cannot read" in capsys.readouterr().err

--- a/tests/scripts/test_memory_os_owner_review_digest_helper.py
+++ b/tests/scripts/test_memory_os_owner_review_digest_helper.py
@@ -64,7 +64,7 @@ def test_digest_helper_review_mode_can_render_pull_review_content():
     )
 
 
-def test_digest_helper_uses_single_delivery_render_command(monkeypatch, capsys):
+def test_digest_helper_uses_single_delivery_render_command(tmp_path, monkeypatch, capsys):
     module = _load_helper_module()
     commands = []
 
@@ -80,6 +80,7 @@ def test_digest_helper_uses_single_delivery_render_command(monkeypatch, capsys):
             "permanent_promotion_delivery": {"shown_proposal_ids": ["ppm_test"]},
         }
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("MEMORY_OS_OWNER_REVIEW_CHANNEL", "telegram")
     monkeypatch.setattr(module, "_run_json", fake_run_json)
 
@@ -87,3 +88,31 @@ def test_digest_helper_uses_single_delivery_render_command(monkeypatch, capsys):
     assert len(commands) == 1
     assert commands[0][2:4] == ["review", "render-delivery-digest"]
     assert "memory approve ppmt_" in capsys.readouterr().out
+
+    from plugins.memory.memory_os.lane_last_run import read_lane_last_run
+
+    record = read_lane_last_run(tmp_path, "owner_review_digest_render")
+    assert record["status"] == "ok"
+    assert record["reason"] == "digest_rendered"
+
+
+def test_digest_helper_persists_no_meaningful_content_reason(tmp_path, monkeypatch):
+    # A quiet day and a crashed render used to leave identical (empty)
+    # evidence; the skip must now be explainable from disk.
+    module = _load_helper_module()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MEMORY_OS_OWNER_REVIEW_CHANNEL", "telegram")
+    monkeypatch.setattr(
+        module,
+        "_run_json",
+        lambda _command: {"counts": {"action_required_shown": 0}, "text": ""},
+    )
+
+    assert module.main() == 0
+
+    from plugins.memory.memory_os.lane_last_run import read_lane_last_run
+
+    record = read_lane_last_run(tmp_path, "owner_review_digest_render")
+    assert record["status"] == "skipped"
+    assert record["reason"] == "no_meaningful_content"

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -57,6 +57,9 @@ def test_installer_copies_monitor_dashboard_snapshot_operational_helper(tmp_path
     assert closure_evidence_installed.read_bytes() == closure_evidence_source.read_bytes()
     assert retirement_installed.read_bytes() == retirement_source.read_bytes()
     assert community_retirement_installed.read_bytes() == community_retirement_source.read_bytes()
+    loop_health_source = scripts_root / "memory_os_loop_health_view.py"
+    loop_health_installed = target_home / "scripts" / loop_health_source.name
+    assert loop_health_installed.read_bytes() == loop_health_source.read_bytes()
 
 
 def test_installer_copies_agent_os_shell_by_default_without_cache_files(tmp_path):

--- a/tests/scripts/test_memory_os_version_consistency_check.py
+++ b/tests/scripts/test_memory_os_version_consistency_check.py
@@ -1,0 +1,69 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "memory_os_version_consistency_check.py"
+_SPEC = importlib.util.spec_from_file_location("memory_os_version_consistency_check", _SCRIPT)
+version_check = importlib.util.module_from_spec(_SPEC)
+sys.modules.setdefault("memory_os_version_consistency_check", version_check)
+_SPEC.loader.exec_module(version_check)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_pyproject(tmp_path: Path, version_line: str) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "hermes-memory-os"',
+                version_line,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_repo_pyproject_version_is_readable():
+    version = version_check.read_pyproject_version(_REPO_ROOT)
+    assert version
+    parts = version.split(".")
+    assert len(parts) == 3 and all(part.isdigit() for part in parts)
+
+
+def test_matching_tag_passes(tmp_path):
+    root = _write_pyproject(tmp_path, 'version = "0.2.1"')
+    assert version_check.main(["--repo-root", str(root), "--tag", "v0.2.1"]) == 0
+
+
+def test_mismatched_tag_fails(tmp_path):
+    # Counterfactual for the v0.2.0-release-vs-0.1.0-pyproject drift: without
+    # this gate a tag cut from a stale pyproject sails through silently.
+    root = _write_pyproject(tmp_path, 'version = "0.1.0"')
+    assert version_check.main(["--repo-root", str(root), "--tag", "v0.2.0"]) == 1
+
+
+def test_tag_without_v_prefix_fails(tmp_path):
+    root = _write_pyproject(tmp_path, 'version = "0.2.1"')
+    assert version_check.main(["--repo-root", str(root), "--tag", "0.2.1"]) == 1
+
+
+def test_missing_version_key_fails(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+    assert version_check.main(["--repo-root", str(tmp_path), "--tag", "v0.2.1"]) == 1
+
+
+def test_print_mode_reports_version(tmp_path, capsys):
+    root = _write_pyproject(tmp_path, 'version = "1.2.3"')
+    assert version_check.main(["--repo-root", str(root), "--print"]) == 0
+    assert capsys.readouterr().out.strip() == "1.2.3"
+
+
+def test_check_tag_message_names_both_sides():
+    error = version_check.check_tag("v0.2.0", "0.1.0")
+    assert error is not None
+    assert "v0.2.0" in error and "0.1.0" in error


### PR DESCRIPTION
# P0–P2：Profile 归属主线化 + Reason-code 覆盖补全 + Loop Health View + 版本单一真源 + 召回评测扩展

背景：3.200 迁入 sannai 后成为 main + sannai 双 profile 主机，暴露了 ExecutionGate 记录的 profile 归属错误（cron wrapper 只传 `HERMES_HOME=/root/.hermes/profiles/sannai`，旧代码 `HERMES_PROFILE or "default"` 把 sannai 的记录标成 default）。本 PR 将主机上的本地 M 补丁主线化并按计划完成 P0–P2 全部工作项。

## P0-A：Profile 归属解析（最关键）

**爆炸半径比最初评估更大**：`profile` 不只是审计字段——feedback_bridge、scoring、deep_reflection、pipeline_checker、provider 本体都拿它做记录过滤键（`record.profile != self.profile` 即丢弃），写读两侧不一致会静默丢数据。

- `memory_os_execution_gate_runner.py`（保持 stdlib-only）：本地 `_resolve_profile`，优先级 显式 `--profile` > `HERMES_PROFILE` > profiles/<name> 形 home 推导 > `default`；**冲突 fail-closed 但写入 blocked permit**（`permit_reason=profile_home_conflict`）——不是静默退出，那是本项目 No Silent Failures 明令禁止的反模式；helper 子进程 env 注入解析后的 `HERMES_PROFILE`，所有 lane 脚本天然与 envelope stamp 一致。
- `roots.resolve_profile_name`：插件侧孪生实现（等价性守卫测试双向钉死）；`from_hermes_home` 在未显式传 profile 时做 home 形状推导（显式传入无条件优先——Hermes agent identity 可合法不等于目录名，故 roots 层不做冲突拒绝）。
- 清扫约 20 个 lane/helper 脚本的 `or "default"` 回退（含 `v3_wandering` 的硬编码 `profile="default"`）；legacy right-brain 两个脚本与 dashboard 安装器保留宿主校准默认并注释豁免原因。
- 反事实实测：revert→FAIL（`'' == 'sannai'` / `'default' == 'sannai'` / `'ok' == 'permit_blocked'`）→restore→PASS。

**部署提醒**：合并部署到 3.200 后会覆盖大资源主机上的本地 M——请 hash 核对三份副本；manifest 刷新按约定另行处理，不混入本次。

## P0-B：版本单一真源

pyproject 0.1.0 → 0.2.1（v0.2.0 Release 已存在）；新增 `scripts/memory_os_version_consistency_check.py`，CI 在 tag push 时断言 `tag == v{pyproject version}`。

## P1-C：Completion Is Not Output——reason-code 覆盖补全

实测基线 23 条 lane：6 FULL / 10 PARTIAL / 7 NONE。新增标准产物 `plugins/memory/memory_os/lane_last_run.py`（`system/lane_last_run/<lane_id>.json`，原子覆写、fail-open、每 lane 封闭原因集），接线 15 条 lane：

- **纯接线**（码已存在只 print 不落盘）：hindsight_health_probe、hindsight_advisory_digest、memory_sources_feedback_request（cron 路径启用既有 skip_reason 枚举）、state_source_mirror。
- **NONE 补齐**：working_cleanup（顺带修掉 `/root/.hermes` 硬编码与"静默无事可做"）、index_sync、owner_review_digest、expression_feedback_request。
- **PARTIAL 升级**：fact_judge（`error_count>0` 不再报干净 ok）、candidate_aggregation、clearance_cycle、proposal_followups、v3_journal_sweep、event_stats_refresh、full_monitor_refresh（崩溃路径原先删临时文件不留痕）、l3_probe（产物迁出 OS temp）。
- **护栏**：`cron_registry.LANE_LAST_RUN_EVIDENCE` census（23 lane 全定性，双向测试钉死）+ 源码扫描守卫（声明 `lane_last_run` 的 lane 必须真调 `record_lane_last_run`——防"词表绿"）。新 lane 出生即必须定性。

## P2-D：Loop Health View（只读投影）

`plugins/memory/memory_os/loop_health_view.py` + CLI `scripts/memory_os_loop_health_view.py`：把 23 条 lane 分组为 memory/cognition/graph/self_evolution/expression/owner_review/substrate/observability 八个环，状态封闭集 attention/active/idle/no_evidence；新鲜度按 lane 自身 `due_interval_minutes`（绝不从组 cron 表达式推导）。零新账本、零权威。monitor 内嵌探针采集 `lane_last_run` 节 + `classify_snapshot` 输出 INFO-only 条目 `lane_last_run_state`（失败已由 helper-completion 分级，这里只解释"为何没产出"，避免重复告警）。

## P2-E：Recall Eval 仪器侧

golden query 增加 `category` 维度（`RECOMMENDED_CASE_CATEGORIES` 14 类：中文自然句/实体/改写/superseded/no_answer/graph_needed/对抗输入…）；报告增加 `by_category`/`by_classification` 分解与 `metrics`（wrong_memory_injection_count/rate、authority_violation_count、context_insufficient_count）。陈旧注入/诚实无答案的语义靠类别约定承载（superseded 类的旧事实作 must_hit=False 负例）。50 个真实生产 case 的采集流程写进模块 docstring——数据本身被生产 gate（需 owner 漏失实例 + session_fact_extraction 部署后数据）。

## 验证

- 全量：**3324 passed / 13 skipped**（最终树重跑确认）
- 四静态门 + closure matrix + `git diff --check` 全绿；import cycle 0；write surface unclassified 0
- 关键反事实经 revert→fail→restore→pass 实测

P3（边界债务反向棘轮）按 owner 决定暂缓，待本批验证后另行处理。
