### PR TITLE
Per-profile systemd units, canonical source-id prefixes (era v3), monitor probe budget

### DIFF
--- a/plugins/memory/memory_os/memory_sources.py
+++ b/plugins/memory/memory_os/memory_sources.py
@@ -34,7 +34,16 @@ SCHEMA_VERSION = "memory-os.memory_sources.v0"
 # v2 从今日(S1 归属线程钉死后的首个真正完备 producer)起受门约束;
 # 零 v2 样本走既有 healthy_no_sample + attribution_era_no_sample 冻结
 # 护栏,不买绿。
-ATTRIBUTION_SCHEMA_VERSION = "memory-os.memory_sources_attribution.v2"
+# v2→v3(2026-08-14):v2 又被生产数据证伪 — graph_layer/indexed 两类段的
+# 生产者用存储层类型名拼 source_ids(`crystallized_record:`/
+# `crystallized_candidate:`),而 source_ids.py 安全过滤器与
+# exposure_rollup.CANONICAL_SOURCE_ID_PREFIXES 只认规范引用前缀
+# (`crystallized:`/`candidate:`),ID 在写入前被静默滤空 — CJ/CL 图谱注入
+# 上线后的首批真实入选段全部落成 v2 纪元内 gap(实测 10 行:graph_layer 7
+# + indexed 3,08-07~08-12),已披露、不可追溯补齐。生产者已改为归一化
+# (prefetch._canonical_source_id),v2 行按同一纪元边界模式整体降为已分类
+# 债务;v3 空样本仍走 healthy_no_sample + attribution_era_no_sample 护栏。
+ATTRIBUTION_SCHEMA_VERSION = "memory-os.memory_sources_attribution.v3"
 LAST_SCHEMA_VERSION = "memory-os.memory_sources_last.v0"
 HISTORY_SCHEMA_VERSION = "memory-os.memory_sources_history.v0"
 STATS_SCHEMA_VERSION = "memory-os.memory_sources_stats.v0"

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -2110,6 +2110,32 @@ GRAPH_SHADOW_OUTCOMES = frozenset({
 })
 
 
+# Storage-layer record_type names → canonical citation prefixes. The FTS
+# index and the graph edge store speak in storage types
+# ("crystallized_record", "crystallized_candidate"), but every downstream
+# source_id consumer — source_ids.filter_safe_source_id_values (safety
+# allowlist) and the audit-side classification vocabulary
+# (CANONICAL_SOURCE_ID_PREFIXES; module deliberately not named here, same
+# one-way X.3 contract as the section-attribution comment above) — speaks
+# canonical citation prefixes ("crystallized:", "candidate:"). Emitting the
+# raw storage name got the ID silently dropped by the safety filter, which
+# is how the first real graph_layer/indexed selected sections all landed as
+# attribution gaps (the v2→v3 attribution era bump in memory_sources.py
+# records the consequence). A guard test pins the index writer's
+# record_type vocabulary against this mapping.
+_CANONICAL_SOURCE_ID_PREFIX_BY_RECORD_TYPE = {
+    "crystallized_record": "crystallized",
+    "crystallized_candidate": "candidate",
+}
+
+
+def _canonical_source_id(record_type: str, record_id: str) -> str:
+    prefix = _CANONICAL_SOURCE_ID_PREFIX_BY_RECORD_TYPE.get(
+        str(record_type), str(record_type)
+    )
+    return f"{prefix}:{record_id}"
+
+
 def _graph_layer_shadow_lines(
     store: MemoryOSStore,
     anchor_ids: list[str],
@@ -2450,7 +2476,7 @@ def _render_graph_layer_lines(
         if seen is not None:
             seen.add((group["neighbor_type"], group["neighbor_id"]))
         if source_ids is not None:
-            source_ids.append(f"{group['neighbor_type']}:{group['neighbor_id']}")
+            source_ids.append(_canonical_source_id(group["neighbor_type"], group["neighbor_id"]))
 
     return lines, decisions
 
@@ -3030,7 +3056,7 @@ def _indexed_lines(
         if snippet:
             lines.append(f"- {record_type}/{record_id}: {snippet}")
             if source_ids is not None and record_type and record_id:
-                source_ids.append(f"{record_type}:{record_id}")
+                source_ids.append(_canonical_source_id(record_type, record_id))
     if lines:
         display_query = str(route.get("display_query", ""))
         lines.insert(0, f"- query route: {route.get('route', 'slow_path')}; search: {display_query}")

--- a/scripts/install_memory_os.sh
+++ b/scripts/install_memory_os.sh
@@ -387,6 +387,22 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+# Per-profile systemd unit-name suffix. MUST match
+# install_memory_os_plugin.py::_runtime_unit_suffix: '' for a root home,
+# '-<name>' for a profiles/<name>-shaped HERMES_HOME. Fixed unit names made
+# every install overwrite the previous profile's units on multi-profile
+# hosts (last deploy won; the loser's heartbeat silently stopped).
+unit_suffix() {
+  local home_base home_parent
+  home_base="$(basename "${HERMES_HOME}")"
+  home_parent="$(basename "$(dirname "${HERMES_HOME}")")"
+  if [[ "${home_parent}" == "profiles" && -n "${home_base}" ]]; then
+    echo "-${home_base}"
+  else
+    echo ""
+  fi
+}
+
 inspect_current_state() {
   echo "Memory-OS install preflight"
   echo "---------------------------"
@@ -396,7 +412,7 @@ inspect_current_state() {
   echo "provider_dir=$([[ -d "${HERMES_HOME}/plugins/memory_os" ]] && echo present || echo missing)"
   echo "shell_dir=$([[ -d "${HERMES_HOME}/plugins/memory-os-agent-os" ]] && echo present || echo missing)"
   echo "runtime_dir=$([[ -d "${HERMES_HOME}/memory-os/runtime/python" ]] && echo present || echo missing)"
-  echo "cognitive_loop_unit=$([[ -f "${HERMES_HOME}/memory-os/systemd/hermes-memory-os-cognitive-loop.timer" ]] && echo present || echo missing)"
+  echo "cognitive_loop_unit=$([[ -f "${HERMES_HOME}/memory-os/systemd/hermes-memory-os-cognitive-loop$(unit_suffix).timer" ]] && echo present || echo missing)"
 
   if command_exists hermes; then
     echo
@@ -412,11 +428,11 @@ inspect_current_state() {
   if command_exists systemctl; then
     echo
     echo "Heartbeat timer state:"
-    systemctl --user show hermes-memory-os-heartbeat.timer \
+    systemctl --user show "hermes-memory-os-heartbeat$(unit_suffix).timer" \
       -p LoadState -p ActiveState -p SubState -p UnitFileState --no-pager 2>/dev/null || true
     echo
     echo "Cognitive loop timer state:"
-    systemctl --user show hermes-memory-os-cognitive-loop.timer \
+    systemctl --user show "hermes-memory-os-cognitive-loop$(unit_suffix).timer" \
       -p LoadState -p ActiveState -p SubState -p UnitFileState --no-pager 2>/dev/null || true
   fi
   echo
@@ -773,12 +789,12 @@ verify_install() {
   if command_exists systemctl; then
     # ── Heartbeat timer (core #1) ────────────────────────────────
     if [[ "${ENABLE_RUNTIME}" == "1" ]]; then
-      if systemctl --user is-active hermes-memory-os-heartbeat.timer >/dev/null 2>&1; then
+      if systemctl --user is-active "hermes-memory-os-heartbeat$(unit_suffix).timer" >/dev/null 2>&1; then
         echo "  [PASS] heartbeat timer is active"
       else
         verify_failures+=("heartbeat timer is not active (ENABLE_RUNTIME=1)")
       fi
-      if systemctl --user is-enabled hermes-memory-os-heartbeat.timer >/dev/null 2>&1; then
+      if systemctl --user is-enabled "hermes-memory-os-heartbeat$(unit_suffix).timer" >/dev/null 2>&1; then
         echo "  [PASS] heartbeat timer is enabled"
       else
         verify_failures+=("heartbeat timer is not enabled (ENABLE_RUNTIME=1)")
@@ -787,12 +803,12 @@ verify_install() {
 
     # ── Cognitive-loop timer (core #2) ───────────────────────────
     if [[ "${ENABLE_COGNITIVE_LOOP}" == "1" ]]; then
-      if systemctl --user is-active hermes-memory-os-cognitive-loop.timer >/dev/null 2>&1; then
+      if systemctl --user is-active "hermes-memory-os-cognitive-loop$(unit_suffix).timer" >/dev/null 2>&1; then
         echo "  [PASS] cognitive-loop timer is active"
       else
         verify_failures+=("cognitive-loop timer is not active (ENABLE_COGNITIVE_LOOP=1)")
       fi
-      if systemctl --user is-enabled hermes-memory-os-cognitive-loop.timer >/dev/null 2>&1; then
+      if systemctl --user is-enabled "hermes-memory-os-cognitive-loop$(unit_suffix).timer" >/dev/null 2>&1; then
         echo "  [PASS] cognitive-loop timer is enabled"
       else
         verify_failures+=("cognitive-loop timer is not enabled (ENABLE_COGNITIVE_LOOP=1)")

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -11,6 +11,7 @@ import stat
 import shutil
 import subprocess
 import sys
+import zlib
 from pathlib import Path
 from typing import Any
 
@@ -518,14 +519,15 @@ def install_plugin(
                 dry_run=dry_run,
             )
         unit_dir = (systemd_dir or (Path.home() / ".config" / "systemd" / "user")).expanduser().resolve()
-        service_src = hermes_home / "memory-os" / "systemd" / "hermes-memory-os-heartbeat.service"
-        timer_src = hermes_home / "memory-os" / "systemd" / "hermes-memory-os-heartbeat.timer"
+        unit_suffix = _runtime_unit_suffix(hermes_home)
+        service_src = hermes_home / "memory-os" / "systemd" / f"hermes-memory-os-heartbeat{unit_suffix}.service"
+        timer_src = hermes_home / "memory-os" / "systemd" / f"hermes-memory-os-heartbeat{unit_suffix}.timer"
         runtime_enable_command = [
             "systemctl",
             "--user",
             "enable",
             "--now",
-            "hermes-memory-os-heartbeat.timer",
+            f"hermes-memory-os-heartbeat{unit_suffix}.timer",
         ]
         if not dry_run:
             unit_dir.mkdir(parents=True, exist_ok=True)
@@ -559,14 +561,15 @@ def install_plugin(
                 dry_run=dry_run,
             )
         unit_dir = (systemd_dir or (Path.home() / ".config" / "systemd" / "user")).expanduser().resolve()
-        service_src = hermes_home / "memory-os" / "systemd" / "hermes-memory-os-cognitive-loop.service"
-        timer_src = hermes_home / "memory-os" / "systemd" / "hermes-memory-os-cognitive-loop.timer"
+        unit_suffix = _runtime_unit_suffix(hermes_home)
+        service_src = hermes_home / "memory-os" / "systemd" / f"hermes-memory-os-cognitive-loop{unit_suffix}.service"
+        timer_src = hermes_home / "memory-os" / "systemd" / f"hermes-memory-os-cognitive-loop{unit_suffix}.timer"
         cognitive_loop_enable_command = [
             "systemctl",
             "--user",
             "enable",
             "--now",
-            "hermes-memory-os-cognitive-loop.timer",
+            f"hermes-memory-os-cognitive-loop{unit_suffix}.timer",
         ]
         if not dry_run:
             unit_dir.mkdir(parents=True, exist_ok=True)
@@ -1011,11 +1014,44 @@ def _read_yaml_config(config_path: Path) -> dict[str, Any]:
     return dict(loaded)
 
 
+def _runtime_unit_suffix(hermes_home: Path) -> str:
+    """Per-profile systemd unit-name suffix: '' for a root home, '-<name>'
+    for a profiles/<name>-shaped home.
+
+    The systemd user units used to carry FIXED names, so on a multi-profile
+    host every install overwrote the previous profile's units — last deploy
+    won, and the losing profile's heartbeat/cognitive loop silently stopped
+    (production: main's heartbeat was dead for ~2 days after the sannai
+    migration re-pointed hermes-memory-os-heartbeat.service). Root homes
+    keep the legacy unsuffixed names so single-profile hosts are unaffected.
+    """
+    home = Path(hermes_home).expanduser().resolve()
+    if home.name and home.parent.name == "profiles":
+        return f"-{home.name}"
+    return ""
+
+
+def _timer_boot_stagger(hermes_home: Path, interval: str) -> str:
+    """OnBootSec value with a stable per-profile offset for suffixed homes.
+
+    Deterministic (crc32 of the profile name, no randomness) so co-tenant
+    profiles' timers do not all fire in the same second after boot;
+    OnUnitActiveSec periods stay identical — relative scheduling naturally
+    dephases them afterwards.
+    """
+    suffix = _runtime_unit_suffix(hermes_home)
+    if not suffix:
+        return interval
+    offset = zlib.crc32(suffix.encode("utf-8")) % 120
+    return f"{interval} {offset}s" if offset else interval
+
+
 def _write_runtime_artifacts(hermes_home: Path, *, interval: str, dry_run: bool) -> list[Path]:
     runtime_root = hermes_home / "memory-os"
+    unit_suffix = _runtime_unit_suffix(hermes_home)
     wrapper = runtime_root / "bin" / "memory_os_heartbeat.sh"
-    service = runtime_root / "systemd" / "hermes-memory-os-heartbeat.service"
-    timer = runtime_root / "systemd" / "hermes-memory-os-heartbeat.timer"
+    service = runtime_root / "systemd" / f"hermes-memory-os-heartbeat{unit_suffix}.service"
+    timer = runtime_root / "systemd" / f"hermes-memory-os-heartbeat{unit_suffix}.timer"
     artifacts = [wrapper, service, timer]
     if dry_run:
         return artifacts
@@ -1042,7 +1078,7 @@ def _write_runtime_artifacts(hermes_home: Path, *, interval: str, dry_run: bool)
         "[Unit]\n"
         "Description=Run Hermes Memory-OS heartbeat periodically\n\n"
         "[Timer]\n"
-        f"OnBootSec={interval}\n"
+        f"OnBootSec={_timer_boot_stagger(hermes_home, interval)}\n"
         f"OnUnitActiveSec={interval}\n"
         "AccuracySec=30s\n\n"
         "[Install]\n"
@@ -1054,9 +1090,10 @@ def _write_runtime_artifacts(hermes_home: Path, *, interval: str, dry_run: bool)
 
 def _write_cognitive_loop_artifacts(hermes_home: Path, *, interval: str, dry_run: bool) -> list[Path]:
     runtime_root = hermes_home / "memory-os"
+    unit_suffix = _runtime_unit_suffix(hermes_home)
     wrapper = runtime_root / "bin" / "memory_os_cognitive_loop.sh"
-    service = runtime_root / "systemd" / "hermes-memory-os-cognitive-loop.service"
-    timer = runtime_root / "systemd" / "hermes-memory-os-cognitive-loop.timer"
+    service = runtime_root / "systemd" / f"hermes-memory-os-cognitive-loop{unit_suffix}.service"
+    timer = runtime_root / "systemd" / f"hermes-memory-os-cognitive-loop{unit_suffix}.timer"
     artifacts = [wrapper, service, timer]
     if dry_run:
         return artifacts
@@ -1083,7 +1120,7 @@ def _write_cognitive_loop_artifacts(hermes_home: Path, *, interval: str, dry_run
         "[Unit]\n"
         "Description=Run Hermes Memory-OS test-host cognitive loop periodically\n\n"
         "[Timer]\n"
-        f"OnBootSec={interval}\n"
+        f"OnBootSec={_timer_boot_stagger(hermes_home, interval)}\n"
         f"OnUnitActiveSec={interval}\n"
         "AccuracySec=30s\n"
         "Persistent=true\n\n"

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -93,6 +93,9 @@ INDEX_CATCHUP_MAX_EVENT_BACKLOG = 1
 FULL_MONITOR_LIVE_TARGET_SECONDS = 180
 FULL_MONITOR_CLEAN_HOST_TARGET_SECONDS = 240
 FULL_MONITOR_MIN_CALLER_TIMEOUT_SECONDS = 300
+# Reserved for post-probe classification/render when deriving the probe
+# budget from a caller-declared timeout (see collect_snapshot).
+FULL_MONITOR_PROBE_TIMEOUT_MARGIN_SECONDS = 30
 FAST_PROBE_RECOMMENDED_TIMEOUT_SECONDS = 120
 MEMORY_PROJECTION_55C_REQUIRED_PAYLOAD_FIELDS: dict[str, set[str]] = {
     "hindsight_provider_stats": {
@@ -4964,8 +4967,28 @@ def collect_snapshot(
     python_bin: str = "python3",
     previous: dict[str, Any] | None = None,
     monitor_profile: str = "live",
+    caller_timeout_seconds: int = 0,
 ) -> dict[str, Any]:
-    raw = _run_probe(host, _remote_probe_script(hermes_home), python_bin=python_bin)
+    # The probe subprocess used to be capped at the 300s floor regardless of
+    # the caller's declared budget, so a caller that passed
+    # --caller-timeout-seconds 480/600 still saw the probe killed at exactly
+    # 300.0s (production: nightly refresh runs with a 600s envelope while
+    # sannai co-tenancy pushed the probe past 300s → probe_script_timeout
+    # FAIL every night). Grant the probe the caller's budget minus a bounded
+    # margin for classification/rendering, never below the 300s floor.
+    probe_timeout = FULL_MONITOR_MIN_CALLER_TIMEOUT_SECONDS
+    declared = max(int(caller_timeout_seconds or 0), 0)
+    if declared > 0:
+        probe_timeout = max(
+            FULL_MONITOR_MIN_CALLER_TIMEOUT_SECONDS,
+            declared - FULL_MONITOR_PROBE_TIMEOUT_MARGIN_SECONDS,
+        )
+    raw = _run_probe(
+        host,
+        _remote_probe_script(hermes_home),
+        python_bin=python_bin,
+        timeout_seconds=probe_timeout,
+    )
     if raw.get("_probe_timeout"):
         # The whole probe script hung/timed out before producing any JSON.
         # Short-circuit with an explicit FAIL rather than feeding a
@@ -5095,6 +5118,7 @@ def main(argv: list[str] | None = None) -> int:
         python_bin=args.python_bin,
         previous=previous,
         monitor_profile=monitor_profile,
+        caller_timeout_seconds=int(args.caller_timeout_seconds or 0),
     )
     elapsed = time.monotonic() - started
     snapshot.setdefault("host_runtime_profile", host_profile.to_dict())
@@ -9098,7 +9122,14 @@ cfg_path = Path(_hermes_home) / "memory-os" / "config.json"
 cfg = json.loads(cfg_path.read_text(encoding="utf-8")) if cfg_path.exists() else {}
 df = run(["df", "-h", os.path.join(_hermes_home, "memory-os")])["out"]
 du = run(["du", "-sh", os.path.join(_hermes_home, "memory-os")])["out"]
-heartbeat_list = run(["systemctl", "--user", "list-timers", "hermes-memory-os-heartbeat.timer", "--no-pager"])["out"]
+# Per-profile unit suffix: must match install_memory_os_plugin.py::
+# _runtime_unit_suffix — profiles/<name>-shaped homes carry suffixed unit
+# names so multi-profile hosts stop overwriting each other's timers.
+_home_path = Path(_hermes_home).resolve()
+_unit_suffix = f"-{_home_path.name}" if _home_path.name and _home_path.parent.name == "profiles" else ""
+_hb_timer = f"hermes-memory-os-heartbeat{_unit_suffix}.timer"
+_cl_timer = f"hermes-memory-os-cognitive-loop{_unit_suffix}.timer"
+heartbeat_list = run(["systemctl", "--user", "list-timers", _hb_timer, "--no-pager"])["out"]
 
 print(json.dumps({
   "hostname": run(["hostname"])["out"],
@@ -9106,13 +9137,13 @@ print(json.dumps({
   "date_local": run(["date", "+%Y-%m-%d %H:%M:%S %Z"])["out"],
   "gateway": system_show("hermes-gateway.service"),
   "hermes_status": hermes_status_summary(),
-  "heartbeat_timer": system_show("hermes-memory-os-heartbeat.timer"),
-  "heartbeat_service": system_show("hermes-memory-os-heartbeat.service"),
+  "heartbeat_timer": system_show(_hb_timer),
+  "heartbeat_service": system_show(f"hermes-memory-os-heartbeat{_unit_suffix}.service"),
   "heartbeat_state": heartbeat_state(),
-  "heartbeat_listed": "hermes-memory-os-heartbeat.timer" in heartbeat_list,
-  "cognitive_loop_timer": system_show("hermes-memory-os-cognitive-loop.timer"),
-  "cognitive_loop_service": system_show("hermes-memory-os-cognitive-loop.service"),
-  "cognitive_loop_listed": "hermes-memory-os-cognitive-loop.timer" in run(["systemctl", "--user", "list-timers", "hermes-memory-os-cognitive-loop.timer", "--no-pager"])["out"],
+  "heartbeat_listed": _hb_timer in heartbeat_list,
+  "cognitive_loop_timer": system_show(_cl_timer),
+  "cognitive_loop_service": system_show(f"hermes-memory-os-cognitive-loop{_unit_suffix}.service"),
+  "cognitive_loop_listed": _cl_timer in run(["systemctl", "--user", "list-timers", _cl_timer, "--no-pager"])["out"],
   "memory_status": {
     "counts": status.get("counts") if isinstance(status, dict) else None,
     "index_counts": status.get("index_counts") if isinstance(status, dict) else None,

--- a/scripts/memory_os_full_monitor_refresh.py
+++ b/scripts/memory_os_full_monitor_refresh.py
@@ -102,6 +102,12 @@ def refresh(
                 str(temp_path),
                 "--output",
                 "json",
+                # Declare this wrapper's envelope so the monitor can grant its
+                # probe subprocess the real budget instead of the 300s floor
+                # (the nightly probe_script_timeout FAILs were the probe being
+                # killed at the floor while this wrapper still had 300s left).
+                "--caller-timeout-seconds",
+                str(max(int(timeout_seconds), 1)),
             ]
         if monitor_profile:
             monitor_command.extend(["--monitor-profile", monitor_profile])

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -1794,8 +1794,18 @@ def test_render_formats_direction_normalized_chinese_lines(tmp_path):
     assert len(line) <= 220
     assert ("crystallized_record", rid_b) in seen, "dedup registers the NEIGHBOR"
     assert ("crystallized_record", rid_a) not in seen, "anchor must not be re-registered"
-    assert source_ids == [f"crystallized_record:{rid_b}"], (
+    # Canonical citation prefix, NOT the storage-layer type name: the old
+    # f"crystallized_record:{id}" format was silently dropped by
+    # filter_safe_source_id_values, so every graph disclosure landed as an
+    # attribution gap. This assertion (and the filter round-trip below) pins
+    # the producer to a format the safety allowlist actually accepts.
+    assert source_ids == [f"crystallized:{rid_b}"], (
         f"attribution must follow the displayed neighbor: {source_ids}"
+    )
+    from plugins.memory.memory_os.source_ids import filter_safe_source_id_values
+
+    assert filter_safe_source_id_values(source_ids) == source_ids, (
+        f"graph source_ids must survive the safety allowlist: {source_ids}"
     )
     assert decisions[0]["injected"] is True
     assert decisions[0]["outcome"] == "emitted_full"
@@ -2233,8 +2243,8 @@ def test_exploration_slots_rotate_daily_and_bound_selection(tmp_path):
     not_selected = [d for d in decisions_a if d["outcome"] == "not_selected"]
     assert len(not_selected) == 12 - cap, "the rest must be ledgered as not_selected"
 
-    # top-6 按权重恒在(exploit 位)
-    top6 = {f"crystallized_record:{nid}" for nid in neighbor_ids[:GRAPH_EXPLOIT_SLOTS]}
+    # top-6 按权重恒在(exploit 位)— source_ids 用规范引用前缀(见 1797 行注释)
+    top6 = {f"crystallized:{nid}" for nid in neighbor_ids[:GRAPH_EXPLOIT_SLOTS]}
     assert top6 <= set(sel_a), f"exploit slots must keep the top-{GRAPH_EXPLOIT_SLOTS}"
 
     # 探索位跨日轮转:一周内至少出现两种探索子集(确定性哈希,非随机)

--- a/tests/plugins/memory/test_memory_os_source_id_vocabulary.py
+++ b/tests/plugins/memory/test_memory_os_source_id_vocabulary.py
@@ -1,0 +1,108 @@
+"""Producer/filter source_id vocabulary guard.
+
+The 2026-08 production incident this pins: prefetch's graph_layer and
+indexed sections emitted source_ids using the FTS index's storage-layer
+record_type names (``crystallized_record:``/``crystallized_candidate:``),
+which the safety allowlist (source_ids.filter_safe_source_id_values) and
+the audit-side classification vocabulary
+(exposure_rollup.CANONICAL_SOURCE_ID_PREFIXES) do not accept — so every ID
+was silently dropped before the disclosure row was written, and the first
+real graph/indexed selected sections all landed as attribution gaps
+(10 rows, 2026-08-07..08-12, unrecoverable → attribution era v2→v3).
+
+Per the CLAUDE.md rule "a gate whose vocabulary drifts from its producer's
+checks nothing, silently", this guard enumerates the producer vocabulary
+from source rather than trusting one fixture value.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from plugins.memory.memory_os.exposure_rollup import CANONICAL_SOURCE_ID_PREFIXES
+from plugins.memory.memory_os.memory_sources import ATTRIBUTION_SCHEMA_VERSION
+from plugins.memory.memory_os.prefetch import (
+    _CANONICAL_SOURCE_ID_PREFIX_BY_RECORD_TYPE,
+    _canonical_source_id,
+)
+from plugins.memory.memory_os.source_ids import filter_safe_source_id_values
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3] / "plugins" / "memory" / "memory_os"
+
+# The record types the FTS index writers actually store (source-scanned
+# below so a new writer type must be triaged here at birth).
+_EXPECTED_INDEX_RECORD_TYPES = {"event", "crystallized_record", "crystallized_candidate"}
+
+_RECORD_TYPE_LITERAL = re.compile(r"record_type=\"([a-z_]+)\"")
+
+
+def _scan_record_type_literals(path: Path) -> set[str]:
+    return set(_RECORD_TYPE_LITERAL.findall(path.read_text(encoding="utf-8")))
+
+
+def test_index_writer_record_type_vocabulary_is_pinned():
+    scanned = _scan_record_type_literals(_PLUGIN_ROOT / "index.py")
+    # Writers only; the scan may also catch defaulted query params, which is
+    # fine — they use the same vocabulary.
+    assert scanned == _EXPECTED_INDEX_RECORD_TYPES, (
+        f"index.py record_type vocabulary changed ({scanned}); triage the new "
+        f"type in prefetch._CANONICAL_SOURCE_ID_PREFIX_BY_RECORD_TYPE and here"
+    )
+
+
+def test_edge_endpoint_record_types_stay_within_index_vocabulary():
+    proposer_files = (
+        "structural_edge_proposer.py",
+        "llm_edge_proposer.py",
+        "vector_edge_proposer.py",
+        "edge_provenance.py",
+        "llm_contradiction_lane.py",
+    )
+    pattern = re.compile(r"(?:from|to)_record_type=\"([a-z_]+)\"")
+    endpoint_types: set[str] = set()
+    for name in proposer_files:
+        path = _PLUGIN_ROOT / name
+        if path.exists():
+            endpoint_types |= set(pattern.findall(path.read_text(encoding="utf-8")))
+    assert endpoint_types, "no edge endpoint types found — proposer scan is broken"
+    assert endpoint_types <= _EXPECTED_INDEX_RECORD_TYPES, (
+        f"edge endpoints use record types outside the index vocabulary: "
+        f"{endpoint_types - _EXPECTED_INDEX_RECORD_TYPES}"
+    )
+
+
+def test_every_index_record_type_normalizes_to_an_accepted_source_id():
+    for record_type in sorted(_EXPECTED_INDEX_RECORD_TYPES):
+        sid = _canonical_source_id(record_type, "some_id_123")
+        assert filter_safe_source_id_values([sid]) == [sid], (
+            f"{record_type} normalizes to {sid!r}, which the safety allowlist drops"
+        )
+        assert sid.startswith(CANONICAL_SOURCE_ID_PREFIXES), (
+            f"{record_type} normalizes to {sid!r}, which the audit classification "
+            f"vocabulary cannot classify"
+        )
+
+
+def test_normalization_map_targets_exist_and_raw_storage_names_are_dropped():
+    # Counterfactual for the incident: the RAW storage-layer form is exactly
+    # what the old producer emitted, and the safety filter drops it. If the
+    # allowlist is ever widened to accept these raw forms instead, this test
+    # must be updated consciously together with the classification vocabulary.
+    assert filter_safe_source_id_values(["crystallized_record:x"]) == []
+    assert filter_safe_source_id_values(["crystallized_candidate:x"]) == []
+    for storage_name, canonical in _CANONICAL_SOURCE_ID_PREFIX_BY_RECORD_TYPE.items():
+        assert storage_name in _EXPECTED_INDEX_RECORD_TYPES, (
+            f"normalization maps unknown storage type {storage_name!r}"
+        )
+        assert f"{canonical}:" in {p for p in CANONICAL_SOURCE_ID_PREFIXES}, (
+            f"normalization target {canonical!r} is not a canonical prefix"
+        )
+
+
+def test_attribution_era_is_v3_after_producer_vocabulary_fix():
+    # The v2 era's rows were written while graph/indexed IDs were being
+    # dropped; they can never be repaired (the disclosure already happened),
+    # so the era boundary advanced. Rolling back this constant resurrects a
+    # permanent FAIL built from unrepairable rows.
+    assert ATTRIBUTION_SCHEMA_VERSION == "memory-os.memory_sources_attribution.v3"

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -116,8 +116,8 @@ def test_collect_snapshot_probe_timeout_short_circuits_to_fail_without_crash(mon
     the near-empty dict through the summarize_*/classify_snapshot chain (an
     unverified assumption) — it short-circuits to an explicit FAIL with a
     named code, and main()'s exit-code contract (0 vs 2) still works."""
-    def fake_run_probe(host, script, python_bin="python3"):
-        return {"_probe_timeout": True, "_probe_timeout_seconds": 300}
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
+        return {"_probe_timeout": True, "_probe_timeout_seconds": timeout_seconds}
 
     monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
 
@@ -129,6 +129,30 @@ def test_collect_snapshot_probe_timeout_short_circuits_to_fail_without_crash(mon
     assert any(item["code"] == "probe_script_timeout" for item in snapshot["classification"]["fail"])
     # render_chinese_summary must also tolerate the near-empty snapshot.
     assert "监控结果: FAIL" in render_chinese_summary(snapshot)
+
+
+def test_collect_snapshot_grants_probe_the_caller_budget_minus_margin(monkeypatch):
+    """Counterfactual for the nightly probe_script_timeout FAILs: the probe
+    subprocess was hard-capped at the 300s floor no matter what the caller
+    declared, so a 600s nightly envelope still killed the probe at exactly
+    300.0s. The probe budget must follow the declared envelope (minus the
+    render margin), and must never drop below the floor."""
+    captured: list[int] = []
+
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
+        captured.append(timeout_seconds)
+        return {"_probe_timeout": True, "_probe_timeout_seconds": timeout_seconds}
+
+    monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
+
+    kwargs = dict(host="fake-host", hermes_home="/root/.hermes", python_bin="python3", previous=None, monitor_profile="live")
+    monitor.collect_snapshot(**kwargs, caller_timeout_seconds=600)
+    monitor.collect_snapshot(**kwargs)  # undeclared → floor
+    monitor.collect_snapshot(**kwargs, caller_timeout_seconds=200)  # below floor → floor
+
+    floor = monitor.FULL_MONITOR_MIN_CALLER_TIMEOUT_SECONDS
+    margin = monitor.FULL_MONITOR_PROBE_TIMEOUT_MARGIN_SECONDS
+    assert captured == [600 - margin, floor, floor]
 
 
 def test_embedded_remote_command_timeout_is_bounded_and_fail_closed(tmp_path, monkeypatch):
@@ -490,7 +514,7 @@ def test_collect_snapshot_remote_populates_v2_exposure_from_successful_probe(mon
     fake_v2_exposure = {"schema_era_health": "PASS", "conservation_total_passes": True}
     fake_clearance = {"status": "fresh"}
 
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         assert host == "fake-host"
         return {
             "v2_exposure_and_clearance_probe": {
@@ -514,7 +538,7 @@ def test_collect_snapshot_remote_probe_failure_becomes_explicit_unavailable_with
     """Fix 1: SSH/runtime/bad-JSON style remote sub-probe failure never
     silently skips — it becomes an explicit unavailable+error_code shape
     which classify_snapshot turns into a WARN (Fix 2)."""
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         return {"v2_exposure_and_clearance_probe": {"ok": False, "error_code": "ImportError"}}
 
     monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
@@ -535,7 +559,7 @@ def test_collect_snapshot_remote_probe_missing_field_is_not_silent(monkeypatch):
     v2_exposure_and_clearance_probe field entirely (e.g. an unexpected/older
     remote payload shape), this must still surface as an explicit failure —
     never silently 'unavailable' with no signal at all."""
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         return {}
 
     monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
@@ -564,7 +588,7 @@ def test_collect_snapshot_remote_populates_living_memory_promotion_ledger_from_s
         "stale_open_proposal_count": 3,
     }
 
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         return {"living_memory_promotion_probe": {"ok": True, "counts": fake_counts}}
 
     monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
@@ -587,7 +611,7 @@ def test_collect_snapshot_remote_ledger_probe_failure_becomes_explicit_warn(monk
     never silently leaves the ledger counts looking like a verified zero —
     it becomes an explicit unavailable+error_code shape which classify_snapshot
     turns into a WARN (never a silent pass)."""
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         return {"living_memory_promotion_probe": {"ok": False, "error_code": "ImportError"}}
 
     monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
@@ -609,7 +633,7 @@ def test_collect_snapshot_remote_ledger_probe_missing_field_is_not_silent(monkey
     """Defensive: even if the remote probe response is missing the
     living_memory_promotion_probe field entirely, this must still surface
     as an explicit failure — never silently 'unavailable' with no signal."""
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         return {}
 
     monkeypatch.setattr(monitor, "_run_probe", fake_run_probe)
@@ -629,7 +653,7 @@ def test_collect_snapshot_remote_probe_field_present_but_not_dict_is_not_silent(
     remote script) must be treated the same as a missing field — explicit
     unavailable+error_code, never a silent pass. Covers the
     _consume_remote_probe branch that a present-but-absent test cannot."""
-    def fake_run_probe(host, script, python_bin="python3"):
+    def fake_run_probe(host, script, python_bin="python3", timeout_seconds=300):
         return {
             "v2_exposure_and_clearance_probe": "not-a-dict",
             "living_memory_promotion_probe": ["also", "not", "a", "dict"],
@@ -5970,7 +5994,7 @@ def test_main_can_save_current_snapshot_for_next_delta(tmp_path, monkeypatch, ca
         encoding="utf-8",
     )
 
-    def fake_collect_snapshot(*, host, hermes_home, python_bin, previous, monitor_profile):
+    def fake_collect_snapshot(*, host, hermes_home, python_bin, previous, monitor_profile, caller_timeout_seconds=0):
         assert host == "fake-host"
         assert monitor_profile == "clean_host"
         assert previous["memory_status"]["counts"]["audit_entries"] == 5

--- a/tests/scripts/test_memory_os_full_monitor_refresh.py
+++ b/tests/scripts/test_memory_os_full_monitor_refresh.py
@@ -39,12 +39,18 @@ def _write_fake_monitor(path: Path, *, write_snapshot: bool, exit_code: int) -> 
                 "p.add_argument('--python-bin', required=True)",
                 "p.add_argument('--snapshot-out', type=Path, required=True)",
                 "p.add_argument('--output')",
+                # required=True is the counterfactual for the probe-budget fix:
+                # a refresh wrapper that stops declaring its envelope makes
+                # this fake monitor exit 2 with an argparse error, failing
+                # every test below.
+                "p.add_argument('--caller-timeout-seconds', type=int, required=True)",
                 "a = p.parse_args()",
                 "assert a.python_bin == sys.executable",
                 (
                     "a.snapshot_out.write_text(json.dumps({"
                     "'schema_version': 'memory-os.monitor.v1', "
                     "'probe_cwd': str(Path.cwd()), "
+                    "'fake_caller_timeout_seconds': a.caller_timeout_seconds, "
                     "'classification': {'status': 'FAIL', 'fail_codes': ['expected_observation_gate']}"
                     "}), encoding='utf-8')"
                     if write_snapshot
@@ -96,6 +102,9 @@ def test_refresh_publishes_valid_fail_classification_without_alerting(tmp_path):
     assert payload["producer_receipt"]["monitor_exit_code"] == 2
     assert payload["producer_receipt"]["receipt_id"].startswith("fmpr_")
     assert payload["classification"]["status"] == "FAIL"
+    # The wrapper must declare its own envelope to the monitor so the probe
+    # budget can exceed the 300s floor (nightly probe_script_timeout fix).
+    assert payload["fake_caller_timeout_seconds"] == 10
     assert Path(payload["probe_cwd"]).parent == artifacts[0].parent
     assert not Path(payload["probe_cwd"]).exists()
     assert not list(artifacts[0].parent.glob("*.tmp"))
@@ -144,6 +153,7 @@ def test_refresh_rejects_monitor_payload_without_schema_version(tmp_path):
                 "p.add_argument('--python-bin', required=True)",
                 "p.add_argument('--snapshot-out', type=Path, required=True)",
                 "p.add_argument('--output')",
+                "p.add_argument('--caller-timeout-seconds', type=int)",
                 "a=p.parse_args()",
                 "assert a.python_bin == sys.executable",
                 "a.snapshot_out.write_text(json.dumps({'classification': {'status': 'PASS'}}))",

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -379,6 +379,47 @@ def test_installer_can_write_cognitive_loop_artifacts(tmp_path):
     assert "OnUnitActiveSec=6h" in timer.read_text(encoding="utf-8")
 
 
+def test_installer_writes_profile_suffixed_units_for_profile_shaped_home(tmp_path):
+    """Multi-profile hosts: profiles/<name>-shaped homes get per-profile unit
+    names so co-tenant installs stop overwriting each other's timers.
+    Counterfactual (the 3.200 incident): with fixed unit names the sannai
+    install re-pointed hermes-memory-os-heartbeat.service and main's
+    heartbeat silently stopped for ~2 days."""
+    home = tmp_path / ".hermes" / "profiles" / "sannai"
+    report = install_plugin(
+        hermes_home=home,
+        install_runtime=True,
+        install_cognitive_loop=True,
+        cognitive_loop_interval="6h",
+    )
+
+    assert report["runtime_artifacts_installed"] is True
+    systemd_dir = home / "memory-os" / "systemd"
+    hb_service = systemd_dir / "hermes-memory-os-heartbeat-sannai.service"
+    hb_timer = systemd_dir / "hermes-memory-os-heartbeat-sannai.timer"
+    cl_timer = systemd_dir / "hermes-memory-os-cognitive-loop-sannai.timer"
+    assert hb_service.is_file()
+    assert hb_timer.is_file()
+    assert cl_timer.is_file()
+    assert not (systemd_dir / "hermes-memory-os-heartbeat.service").exists()
+    # Deterministic per-profile boot stagger; the recurring period is
+    # untouched so the lane cadence does not change.
+    timer_text = hb_timer.read_text(encoding="utf-8")
+    assert "OnUnitActiveSec=5min" in timer_text
+    assert "OnBootSec=5min" in timer_text  # base interval retained (offset may follow)
+
+
+def test_root_home_keeps_legacy_unsuffixed_unit_names(tmp_path):
+    home = tmp_path / "home"
+    install_plugin(hermes_home=home, install_runtime=True)
+
+    systemd_dir = home / "memory-os" / "systemd"
+    assert (systemd_dir / "hermes-memory-os-heartbeat.service").is_file()
+    assert not list(systemd_dir.glob("hermes-memory-os-heartbeat-*.service"))
+    timer_text = (systemd_dir / "hermes-memory-os-heartbeat.timer").read_text(encoding="utf-8")
+    assert "OnBootSec=5min\n" in timer_text  # no stagger suffix for root homes
+
+
 def test_installer_does_not_write_cognitive_loop_artifacts_by_default(tmp_path):
     report = install_plugin(hermes_home=tmp_path / "home")
 


### PR DESCRIPTION
# 三项迁移期遗留修复：per-profile systemd 单元 / 规范 source-id 前缀(纪元 v3) / 监控探针预算

owner 指示处理 CN 部署验证暴露的三项遗留(考古证实均始于 08-12 sannai 迁移，先于 CN 部署)。owner 对 ① 的推测**完全正确**：定时心跳是单例进程冲突，定时任务需要多 profile 适配。

## ① main 心跳停摆 → per-profile systemd 单元

**根因链(实抓)**：心跳由 systemd **用户级** timer 驱动(`hermes-memory-os-heartbeat.timer`，5min，父进程 `systemd --user`，实抓命令 `python3 -m plugins.memory.memory_os heartbeat`)。安装器写**固定名**单元 → 多 profile 主机上谁最后部署谁赢：08-12 迁移把 ExecStart 指到 sannai wrapper，main 心跳自 05:26 死亡；今晨 CN 部署 main apply 曾在 01:33 短暂夺回(那次孤立心跳的成因)，随后 sannai apply 又抢走。

**修复**：`profiles/<name>` 形 home 生成带后缀单元(`hermes-memory-os-heartbeat-sannai.*`)+ 确定性 OnBootSec 错峰(crc32(profile)%120s，周期不变)；根 home 保留旧名(单 profile 主机零变化)。`install_memory_os.sh` 的 status/verify 探测与 monitor 内嵌探针同步后缀感知。部署双 home 后 main(固定名)与 sannai(-sannai)各自持有单元，互不覆盖。

## ② 图谱/索引段归因缺口 → 生产者规范前缀归一 + 纪元 v3

**根因**：`_render_graph_layer_lines`/`_indexed_lines` 用存储层类型名拼 source_ids(`crystallized_record:`/`crystallized_candidate:`)，而 `source_ids.py` 安全白名单与审计端分类词表只认规范引用前缀(`crystallized:`/`candidate:`)——ID 在披露写入前被**静默滤空**(CC 记载的"生产者与门词表漂移"第三例)。CJ/CL 图谱注入上线后的首批真实入选段全部落成 v2 纪元内缺口(实测 10 行=graph_layer 7+indexed 3)。

**修复**：生产者归一(`prefetch._canonical_source_id`)；词表守卫测试双向钉死(源扫描 index 写入端 record_type 集 ↔ 归一映射 ↔ 白名单+分类词表)；既有 graph 测试原本钉着**从未过滤器验证的错误格式**，已改并加过滤器往返断言。10 条已披露 v2 行不可追溯补齐 → 按文档化纪元边界模式(v1→v2 先例就写在常量注释里)`ATTRIBUTION_SCHEMA_VERSION` v2→v3：v2 行整体降为已分类债务，空 v3 纪元走 `healthy_no_sample` + `attribution_era_no_sample` 冻结护栏，不买绿。

## ③ 监控探针 300s 超时 → caller 预算接线

**根因**：`collect_snapshot` 调 `_run_probe` 从不传 timeout → 无论 `--caller-timeout-seconds` 传多少，探针固定 300s 被杀(两次实测均精确 300.0s；夜间 600s 包络同样)。sannai 共存负载把探针推过 300s(历史 183-186s → 08-12 起 257-300s+)。

**修复**：探针预算 = max(300, caller−30s 渲染余量)；`full_monitor_refresh` 向 monitor 声明自身 600s 包络(`--caller-timeout-seconds`)。夜间产物从 probe_script_timeout FAIL 转为诚实的 runtime_over_target WARN + 完整数据。测试伪 monitor 的该参数为 required——旧版 wrapper 不传即失败(内建反事实)。

## V2/V3 毕业核查(随批报告，不改代码)

- **V2**：观察期**已达标**(production_observation_days 31/30、自然周期 15/3)；解冻剩两条：纪元健康(本 PR ②修)+ `budget_pressure_streak 0/7`(需连续 7 天真实预算压力，数据驱动)。
- **V3**：ready=False；30 连续有效日要求下最长纪录 6 天(08-05~08-10)，**08-11 自然日行缺失**(迁移日 00:05 tick 未产出该日行)致断档，08-12 起重算 → 最早 ~09-11 达标；09-05 复查日按 owner 裁定应记录成因并顺延明确新日期。

## 验证

- 四项反事实 revert→FAIL→restore→PASS 实测(词表测试在旧代码上 ImportError 级失败)
- 全量 **3332 passed / 13 skipped**(+8)；四静态门 + closure matrix + whitespace 全绿
- 部署后宿主验证计划：4 个 timer 并存、main 心跳 ≤6min 内恢复、480s 包络下监控完整跑完、era 转 healthy_no_sample
