### PR TITLE
Multi-profile sweep residuals + V2C unfreeze gate redefined as selection pressure (owner ruling) + cross-surface census

### DIFF
--- a/plugins/memory/memory_os/exposure_rollup.py
+++ b/plugins/memory/memory_os/exposure_rollup.py
@@ -632,10 +632,32 @@ def exposure_monitor_stats(store: Any, *, now: datetime | None = None) -> dict[s
         if timestamp is None or int(record.get("records_processed") or 0) <= 0:
             continue
         date_key = timestamp.date().isoformat()
-        bucket = daily.setdefault(date_key, {"budget": 0, "valid": True})
+        bucket = daily.setdefault(date_key, {"budget": 0, "rank": 0, "valid": True})
         bucket["budget"] = int(bucket["budget"]) + int(record.get("dropped_by_budget") or 0)
+        bucket["rank"] = int(bucket["rank"]) + int(record.get("dropped_by_rank") or 0)
         bucket["valid"] = bool(bucket["valid"]) and record.get("conservation_passes") is True
     valid_natural_days = sum(1 for bucket in daily.values() if bucket["valid"] is True)
+    # Owner ruling 2026-08-14 — "selection pressure", not "budget pressure".
+    #
+    # The streak gate used to require dropped_by_budget > 0. Production
+    # evidence: across ALL natural rollup rows that counter has never once
+    # been non-zero, while dropped_by_rank accumulated freely — at the
+    # deployed prefetch_char_budget the per-section rank caps always bind
+    # first, so the byte budget is never the constraint. The gate was
+    # therefore waiting on a signal this configuration structurally cannot
+    # emit: not "not yet", but "never", which is a gate nothing can satisfy
+    # (the same shape as the pre-era-boundary attribution FAIL).
+    #
+    # The owner chose to widen the predicate to any real selection pressure
+    # (budget OR rank) rather than lower the production budget to
+    # manufacture the old signal — changing production behavior to move a
+    # metric is what the roadmap's "do not buy green" rule forbids.
+    #
+    # This DOES change what the gate proves: "behaves correctly while
+    # discarding candidates under scarcity" instead of the narrower "…under
+    # BYTE scarcity". The budget-only evidence is not erased — the
+    # per-class day counts below keep it visible, so a later reader can
+    # still see that byte pressure never occurred.
     pressure_streak = 0
     latest_completed_date = current.date() - timedelta(days=1)
     ordered_dates = sorted(
@@ -647,7 +669,8 @@ def exposure_monitor_stats(store: Any, *, now: datetime | None = None) -> dict[s
         if expected_date is None or observed_date != expected_date:
             break
         date_key = observed_date.isoformat()
-        if int(daily[date_key]["budget"]) <= 0 or daily[date_key]["valid"] is not True:
+        day_pressure = int(daily[date_key]["budget"]) + int(daily[date_key]["rank"])
+        if day_pressure <= 0 or daily[date_key]["valid"] is not True:
             break
         pressure_streak += 1
         expected_date = observed_date - timedelta(days=1)
@@ -661,7 +684,7 @@ def exposure_monitor_stats(store: Any, *, now: datetime | None = None) -> dict[s
     if observation_days < 30:
         freeze_reasons.append(f"production_observation_days:{observation_days:.1f}/30")
     if pressure_streak < 7:
-        freeze_reasons.append(f"budget_pressure_streak:{pressure_streak}/7")
+        freeze_reasons.append(f"selection_pressure_streak:{pressure_streak}/7")
     if schema_gap or conservation_failures or telemetry_degraded_count:
         freeze_reasons.append("schema_era_health_not_pass")
     if natural_records and not attribution_era_records:
@@ -728,7 +751,14 @@ def exposure_monitor_stats(store: Any, *, now: datetime | None = None) -> dict[s
         "telemetry_degraded_count": telemetry_degraded_count,
         "initial_natural_cycle_count": valid_natural_days,
         "production_observation_days": round(observation_days, 1),
-        "budget_pressure_streak_days": pressure_streak,
+        # Renamed from budget_pressure_streak_days with the 2026-08-14 owner
+        # ruling: a key whose meaning silently widens is exactly the drift
+        # this project keeps paying for, so the old name is retired rather
+        # than redefined. The two day-counts below preserve the pre-ruling
+        # evidence (byte pressure has never occurred on this deployment).
+        "selection_pressure_streak_days": pressure_streak,
+        "budget_pressure_day_count": sum(1 for bucket in daily.values() if int(bucket["budget"]) > 0),
+        "rank_pressure_day_count": sum(1 for bucket in daily.values() if int(bucket["rank"]) > 0),
         "v2c_unfreeze_ready": not freeze_reasons,
         "downstream_clearance_closure_frozen": bool(freeze_reasons),
         "freeze_reasons": freeze_reasons,

--- a/scripts/install_memory_os_monitor_dashboard_service.py
+++ b/scripts/install_memory_os_monitor_dashboard_service.py
@@ -15,6 +15,21 @@ from typing import Any, Callable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SERVICE_NAME = "hermes-memory-os-monitor-dashboard.service"
+
+
+def _default_service_name(hermes_home: Path) -> str:
+    """Per-profile default unit name: root homes keep the legacy fixed name;
+    profiles/<name>-shaped homes get a suffixed default so installing a
+    second profile's dashboard cannot silently overwrite the first (the
+    last-deploy-wins class fixed for the heartbeat/cognitive-loop units in
+    install_memory_os_plugin.py::_runtime_unit_suffix — same rule). An
+    explicit --service-name always wins; note a second dashboard also needs
+    its own --port, which fails loudly at bind time rather than silently.
+    """
+    home = Path(hermes_home).expanduser().resolve()
+    if home.name and home.parent.name == "profiles":
+        return f"hermes-memory-os-monitor-dashboard-{home.name}.service"
+    return DEFAULT_SERVICE_NAME
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 3693
 DEFAULT_PROFILE = "main"
@@ -45,7 +60,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=Path("/etc/systemd/system"),
         help="Systemd unit directory. Default: /etc/systemd/system.",
     )
-    parser.add_argument("--service-name", default=DEFAULT_SERVICE_NAME, help=f"Default: {DEFAULT_SERVICE_NAME}.")
+    parser.add_argument(
+        "--service-name",
+        default="",
+        help=(
+            f"Default: {DEFAULT_SERVICE_NAME} for a root home, "
+            "hermes-memory-os-monitor-dashboard-<profile>.service for a "
+            "profiles/<name>-shaped --hermes-home."
+        ),
+    )
     parser.add_argument("--enable", action="store_true", help="Run systemctl daemon-reload and enable --now.")
     parser.add_argument("--dry-run", action="store_true", help="Print the report without writing or enabling.")
     return parser
@@ -217,7 +240,7 @@ def main(argv: list[str] | None = None) -> int:
         port=args.port,
         python_bin=args.python_bin,
         systemd_dir=args.systemd_dir,
-        service_name=args.service_name,
+        service_name=args.service_name or _default_service_name(args.hermes_home),
         enable=args.enable,
         dry_run=args.dry_run,
     )

--- a/scripts/memory_os_upgrade_compat_check.py
+++ b/scripts/memory_os_upgrade_compat_check.py
@@ -69,6 +69,45 @@ COMMANDS: tuple[CommandSpec, ...] = (
 RunCommand = Callable[[tuple[str, ...], str | None, str | None, int], dict[str, Any]]
 
 
+def _unit_suffix_for_home(hermes_home: str | None) -> str:
+    """Per-profile systemd unit suffix, mirroring
+    install_memory_os_plugin.py::_runtime_unit_suffix ('' for a root home,
+    '-<name>' for a profiles/<name>-shaped home)."""
+    if not hermes_home:
+        return ""
+    home = Path(hermes_home).expanduser()
+    if home.name and home.parent.name == "profiles":
+        return f"-{home.name}"
+    return ""
+
+
+def _commands_for(hermes_home: str | None) -> tuple[CommandSpec, ...]:
+    """COMMANDS with the cognitive-loop timer probe pointed at the target
+    home's own unit. The static tuple used to probe the fixed legacy name,
+    so on a profile-shaped home the informational timer check reported the
+    DEFAULT profile's unit state — misleading, though never gating
+    (required=False)."""
+    suffix = _unit_suffix_for_home(hermes_home)
+    if not suffix:
+        return COMMANDS
+    adjusted: list[CommandSpec] = []
+    for spec in COMMANDS:
+        if spec.name == "cognitive_loop_timer":
+            argv = tuple(
+                part.replace(
+                    "hermes-memory-os-cognitive-loop.timer",
+                    f"hermes-memory-os-cognitive-loop{suffix}.timer",
+                )
+                for part in spec.argv
+            )
+            adjusted.append(
+                CommandSpec(spec.name, argv, json_output=spec.json_output, required=spec.required)
+            )
+        else:
+            adjusted.append(spec)
+    return tuple(adjusted)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run read-only Memory-OS Hermes upgrade compatibility checks.")
     parser.add_argument("--host", default="", help="Optional SSH host, for example hermes-media.")
@@ -99,7 +138,7 @@ def run_upgrade_compat_check(
     runner = run_command or run_command_default
     command_results = {
         spec.name: _run_spec(spec, host=host, hermes_home=hermes_home, timeout=timeout, run_command=runner)
-        for spec in COMMANDS
+        for spec in _commands_for(hermes_home)
     }
     classification = classify_report(command_results, hermes_home=hermes_home)
     return {

--- a/scripts/probe_l3_prefetch_behavior.py
+++ b/scripts/probe_l3_prefetch_behavior.py
@@ -39,7 +39,24 @@ HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
 # self-cleaning: after a successful revoke the probe compacts it,
 # removing all inactive records, and deletes it when empty.
 NONCE_FILE = HERMES_HOME / "memory-os" / "crystallized" / "_system_probe.md"
-LOG_FILE = Path(tempfile.gettempdir()) / f"l3_probe_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}.log"
+
+def _probe_log_slug(hermes_home: Path) -> str:
+    """Per-home slug for the shared-tempdir probe log.
+
+    Both profiles' evidence ticks fire on the same minute, and the filename
+    is only second-granular, so two co-tenant probes could overwrite each
+    other's diagnostics in the shared temp directory (the same shared-name
+    collision class as the systemd units and the l3 last-result file, which
+    now lives under HERMES_HOME). Root homes keep the legacy bare name.
+    """
+    home = Path(hermes_home).expanduser().resolve()
+    return f"_{home.name}" if home.name and home.parent.name == "profiles" else ""
+
+
+LOG_FILE = (
+    Path(tempfile.gettempdir())
+    / f"l3_probe{_probe_log_slug(HERMES_HOME)}_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}.log"
+)
 
 def _resolve_probe_budget(hermes_home: Path) -> int:
     """Read prefetch_char_budget from Memory-OS config, with 20000 fallback.

--- a/tests/plugins/memory/test_memory_os_phase1_observability.py
+++ b/tests/plugins/memory/test_memory_os_phase1_observability.py
@@ -114,11 +114,11 @@ def test_exposure_stats_separate_legacy_debt_from_schema_era_health_and_freeze_g
     assert stats["schema_era_attribution_gap_count"] == 0
     assert stats["schema_era_health"] == "PASS"
     assert stats["initial_natural_cycle_count"] == 2
-    assert stats["budget_pressure_streak_days"] == 0
+    assert stats["selection_pressure_streak_days"] == 0
     assert stats["v2c_unfreeze_ready"] is False
     assert "initial_natural_cycles:2/3" in stats["freeze_reasons"]
     assert any(reason.startswith("production_observation_days:") for reason in stats["freeze_reasons"])
-    assert "budget_pressure_streak:0/7" in stats["freeze_reasons"]
+    assert "selection_pressure_streak:0/7" in stats["freeze_reasons"]
     assert stats["conservation_total_passes"] is True
 
 
@@ -154,7 +154,7 @@ def test_v1_era_gapped_rows_are_debt_not_permanent_gate_fail(tmp_path):
     assert "attribution_era_no_sample" in stats["freeze_reasons"]
 
 
-def test_budget_pressure_streak_requires_consecutive_calendar_days(tmp_path):
+def test_selection_pressure_streak_requires_consecutive_calendar_days(tmp_path):
     store = _store(tmp_path)
     append_memory_source_record(store.roots, {
         "record_id": "natural-anchor",
@@ -186,12 +186,12 @@ def test_budget_pressure_streak_requires_consecutive_calendar_days(tmp_path):
     stats = exposure_monitor_stats(store, now=datetime(2026, 8, 15, tzinfo=timezone.utc))
 
     assert stats["initial_natural_cycle_count"] == 7
-    assert stats["budget_pressure_streak_days"] == 0
+    assert stats["selection_pressure_streak_days"] == 0
     assert stats["v2c_unfreeze_ready"] is False
-    assert "budget_pressure_streak:0/7" in stats["freeze_reasons"]
+    assert "selection_pressure_streak:0/7" in stats["freeze_reasons"]
 
 
-def test_budget_pressure_streak_accepts_seven_recent_completed_calendar_days(tmp_path):
+def test_selection_pressure_streak_accepts_seven_recent_completed_calendar_days(tmp_path):
     store = _store(tmp_path)
     append_memory_source_record(store.roots, {
         "record_id": "natural-anchor",
@@ -222,9 +222,89 @@ def test_budget_pressure_streak_accepts_seven_recent_completed_calendar_days(tmp
 
     stats = exposure_monitor_stats(store, now=datetime(2026, 8, 15, 12, tzinfo=timezone.utc))
 
-    assert stats["budget_pressure_streak_days"] == 7
+    assert stats["selection_pressure_streak_days"] == 7
     assert stats["v2c_unfreeze_ready"] is True
     assert stats["freeze_reasons"] == []
+
+
+def test_rank_only_pressure_counts_toward_the_streak(tmp_path):
+    """Owner ruling 2026-08-14: the streak counts real SELECTION pressure
+    (budget OR rank), not byte pressure alone.
+
+    Counterfactual: every row here has dropped_by_budget == 0, which is
+    exactly the production shape — that counter has never once been
+    non-zero, while rank drops accumulate freely. Under the old
+    budget-only predicate this streak is 0/7 and V2C stays frozen forever;
+    under the ruling it counts. The per-class day counts must still show
+    that byte pressure never occurred, so widening the gate does not erase
+    the evidence that motivated it."""
+    store = _store(tmp_path)
+    append_memory_source_record(store.roots, {
+        "record_id": "natural-anchor",
+        "created_at": "2026-07-01T00:00:00Z",
+        "natural_production": True,
+        "traffic_class": "production",
+        "attribution_schema": ATTRIBUTION_SCHEMA_VERSION,
+        "selected": [_section(source_ids=["crystallized:one"])],
+        "dropped": [],
+    })
+    _write_rollups(store, [
+        {
+            "window_start": f"2026-08-{day:02d}T00:00:00Z",
+            "window_end": f"2026-08-{day:02d}T23:00:00Z",
+            "records_processed": 1,
+            "records_classified": 1,
+            "eligible": 1,
+            "selected": 0,
+            "dropped_by_budget": 0,
+            "dropped_by_rank": 1,
+            "conservation_passes": True,
+        }
+        for day in range(8, 15)
+    ])
+
+    stats = exposure_monitor_stats(store, now=datetime(2026, 8, 15, 12, tzinfo=timezone.utc))
+
+    assert stats["selection_pressure_streak_days"] == 7
+    assert stats["v2c_unfreeze_ready"] is True
+    assert stats["budget_pressure_day_count"] == 0
+    assert stats["rank_pressure_day_count"] == 7
+
+
+def test_a_day_without_any_drop_still_breaks_the_streak(tmp_path):
+    """The widened predicate must not become always-true: a day that
+    selected everything (no drops of either class) is not evidence of
+    scarcity and must still break the streak."""
+    store = _store(tmp_path)
+    append_memory_source_record(store.roots, {
+        "record_id": "natural-anchor",
+        "created_at": "2026-07-01T00:00:00Z",
+        "natural_production": True,
+        "traffic_class": "production",
+        "attribution_schema": ATTRIBUTION_SCHEMA_VERSION,
+        "selected": [_section(source_ids=["crystallized:one"])],
+        "dropped": [],
+    })
+    _write_rollups(store, [
+        {
+            "window_start": f"2026-08-{day:02d}T00:00:00Z",
+            "window_end": f"2026-08-{day:02d}T23:00:00Z",
+            "records_processed": 1,
+            "records_classified": 1,
+            "eligible": 1,
+            # 08-13 is the most recent completed day and has zero pressure.
+            "selected": 1 if day == 13 else 0,
+            "dropped_by_budget": 0,
+            "dropped_by_rank": 0 if day == 13 else 1,
+            "conservation_passes": True,
+        }
+        for day in range(7, 14)
+    ])
+
+    stats = exposure_monitor_stats(store, now=datetime(2026, 8, 14, 12, tzinfo=timezone.utc))
+
+    assert stats["selection_pressure_streak_days"] == 0
+    assert "selection_pressure_streak:0/7" in stats["freeze_reasons"]
 
 
 def test_candidate_cluster_defer_is_a_cooldown_not_permanent_closure():
@@ -347,10 +427,10 @@ def test_manual_trigger_rollups_do_not_count_toward_natural_cycle_gate(tmp_path)
     stats = exposure_monitor_stats(store, now=datetime(2026, 8, 15, 12, tzinfo=timezone.utc))
 
     # Same 7-consecutive-day shape as
-    # test_budget_pressure_streak_accepts_seven_recent_completed_calendar_days,
+    # test_selection_pressure_streak_accepts_seven_recent_completed_calendar_days,
     # but every row is a manual run — none of it may count as natural cadence.
     assert stats["initial_natural_cycle_count"] == 0
-    assert stats["budget_pressure_streak_days"] == 0
+    assert stats["selection_pressure_streak_days"] == 0
     assert stats["v2c_unfreeze_ready"] is False
     assert "initial_natural_cycles:0/3" in stats["freeze_reasons"]
     assert stats["legacy_unmarked_rollup_count"] == 0
@@ -400,7 +480,7 @@ def test_legacy_unmarked_rollups_counted_separately_and_excluded_from_natural_ga
 
     assert stats["legacy_unmarked_rollup_count"] == 7
     assert stats["initial_natural_cycle_count"] == 0
-    assert stats["budget_pressure_streak_days"] == 0
+    assert stats["selection_pressure_streak_days"] == 0
     assert stats["v2c_unfreeze_ready"] is False
 def test_rolling_attribution_window_is_era_scoped_and_has_a_reader(tmp_path):
     """Item 17: rolling_7d_attribution_gap_count was computed and read by nothing.
@@ -501,7 +581,12 @@ def test_exposure_monitor_stats_key_census_every_key_has_a_disposition(tmp_path)
         "telemetry_degraded_count": "internal",
         "initial_natural_cycle_count": "internal",
         "production_observation_days": "internal",
-        "budget_pressure_streak_days": "internal",
+        # Owner ruling 2026-08-14: budget_pressure_streak_days was RETIRED
+        # (not redefined) when the gate widened to selection pressure, and
+        # the two day-counts keep the byte-pressure evidence visible.
+        "selection_pressure_streak_days": "internal",  # drives freeze_reasons
+        "budget_pressure_day_count": "info",           # v2_exposure_rollup_ledger_state
+        "rank_pressure_day_count": "info",             # v2_exposure_rollup_ledger_state
         "v2c_unfreeze_ready": "graded",
         "downstream_clearance_closure_frozen": "graded",
         "freeze_reasons": "graded",

--- a/tests/scripts/test_install_memory_os_monitor_dashboard_service.py
+++ b/tests/scripts/test_install_memory_os_monitor_dashboard_service.py
@@ -103,3 +103,43 @@ def test_dashboard_service_rejects_invalid_options(tmp_path: Path) -> None:
         except SystemExit:
             continue
         raise AssertionError(f"invalid installer options were accepted: {case}")
+
+
+def test_default_service_name_is_profile_suffixed_for_profile_shaped_home(tmp_path):
+    # Same last-deploy-wins class as the heartbeat/cognitive-loop units: with
+    # the fixed default name, installing a second profile's dashboard would
+    # silently overwrite the first profile's unit.
+    from scripts.install_memory_os_monitor_dashboard_service import (
+        DEFAULT_SERVICE_NAME,
+        _default_service_name,
+    )
+
+    assert _default_service_name(tmp_path / "home") == DEFAULT_SERVICE_NAME
+    assert (
+        _default_service_name(tmp_path / ".hermes" / "profiles" / "sannai")
+        == "hermes-memory-os-monitor-dashboard-sannai.service"
+    )
+
+
+def test_main_resolves_suffixed_default_but_explicit_name_wins(tmp_path, capsys):
+    import json as _json
+
+    from scripts.install_memory_os_monitor_dashboard_service import main
+
+    home = tmp_path / ".hermes" / "profiles" / "sannai"
+    assert main([
+        "--hermes-home", str(home),
+        "--systemd-dir", str(tmp_path / "systemd"),
+        "--dry-run",
+    ]) == 0
+    report = _json.loads(capsys.readouterr().out)
+    assert report["service_name"] == "hermes-memory-os-monitor-dashboard-sannai.service"
+
+    assert main([
+        "--hermes-home", str(home),
+        "--systemd-dir", str(tmp_path / "systemd"),
+        "--service-name", "custom.service",
+        "--dry-run",
+    ]) == 0
+    report = _json.loads(capsys.readouterr().out)
+    assert report["service_name"] == "custom.service"

--- a/tests/scripts/test_memory_os_upgrade_compat_check.py
+++ b/tests/scripts/test_memory_os_upgrade_compat_check.py
@@ -363,3 +363,22 @@ def _healthy_command_results():
         }
         for name, raw in _healthy_outputs().items()
     }
+
+
+def test_cognitive_loop_timer_probe_follows_profile_shaped_home(tmp_path):
+    # The static COMMANDS tuple used to probe the fixed legacy unit name, so
+    # on a profiles/<name>-shaped home the (informational) timer check showed
+    # the DEFAULT profile's unit state instead of the target profile's.
+    from scripts.memory_os_upgrade_compat_check import COMMANDS, _commands_for
+
+    root_home_specs = _commands_for(str(tmp_path / "home"))
+    assert root_home_specs is COMMANDS
+
+    profile_specs = _commands_for(str(tmp_path / ".hermes" / "profiles" / "sannai"))
+    by_name = {spec.name: spec for spec in profile_specs}
+    assert "hermes-memory-os-cognitive-loop-sannai.timer" in by_name["cognitive_loop_timer"].argv
+    assert by_name["cognitive_loop_timer"].required is False
+    # Every other spec is untouched.
+    for spec in profile_specs:
+        if spec.name != "cognitive_loop_timer":
+            assert spec in COMMANDS

--- a/tests/scripts/test_multiprofile_home_shape_census.py
+++ b/tests/scripts/test_multiprofile_home_shape_census.py
@@ -1,0 +1,127 @@
+"""Census: every copy of the profiles/<name> home-shape derivation agrees.
+
+The multi-profile work grew EIGHT independent implementations of one rule
+("is this HERMES_HOME a profiles/<name> home, and if so what is the profile
+called?"): the ExecutionGate runner (stdlib-only, cannot import the plugin),
+roots, the plugin installer's unit suffix, the monitor's embedded probe, the
+upgrade compat probe, the dashboard installer's default unit name, the l3
+probe's log slug, and the agent-os shell. Only runner<->roots were pinned to
+each other.
+
+That is the same shape as the producer/gate vocabulary drift this project
+keeps paying for: N copies of a predicate, one guard. This census pins all
+of them to a single behavior table, so a future edit to any one copy fails
+here instead of silently splitting behavior across surfaces (e.g. units
+suffixed but attribution not, or vice versa).
+
+The bash copy in install_memory_os.sh cannot be imported, so it is checked
+by source scan for the same parent=="profiles" rule.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS = _REPO_ROOT / "scripts"
+
+
+def _load(script_name: str, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPTS / script_name)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_profile(monkeypatch):
+    # Every derivation below must answer from the HOME SHAPE alone.
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_AGENT_IDENTITY", raising=False)
+    monkeypatch.delenv("HERMES_AGENT_NAME", raising=False)
+
+
+def _expected(shaped: bool) -> dict[str, object]:
+    from scripts.install_memory_os_monitor_dashboard_service import DEFAULT_SERVICE_NAME
+
+    if shaped:
+        return {
+            "roots_derive": "sannai",
+            "roots_resolve": "sannai",
+            "runner": "sannai",
+            "unit_suffix": "-sannai",
+            "compat_suffix": "-sannai",
+            "dashboard_unit": "hermes-memory-os-monitor-dashboard-sannai.service",
+            "probe_slug": "_sannai",
+            "agent_os": "sannai",
+        }
+    return {
+        "roots_derive": "",
+        "roots_resolve": "default",
+        "runner": "default",
+        "unit_suffix": "",
+        "compat_suffix": "",
+        "dashboard_unit": DEFAULT_SERVICE_NAME,
+        "probe_slug": "",
+        "agent_os": "default",
+    }
+
+
+def _observed(home: Path, monkeypatch) -> dict[str, object]:
+    from plugins.memory.memory_os.roots import _derive_profile_from_home, resolve_profile_name
+    from scripts.install_memory_os_monitor_dashboard_service import _default_service_name
+    from scripts.install_memory_os_plugin import _runtime_unit_suffix
+    from scripts.memory_os_upgrade_compat_check import _unit_suffix_for_home
+
+    runner = _load("memory_os_execution_gate_runner.py", "_census_runner")
+    probe = _load("probe_l3_prefetch_behavior.py", "_census_l3_probe")
+
+    # agent-os lives under a dash-named package dir, so it is loaded by path
+    # like the script modules above. Its _resolve_profile() reads HERMES_HOME
+    # at call time, hence the env set here.
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    agent_os_spec = importlib.util.spec_from_file_location(
+        "_census_agent_os", _REPO_ROOT / "plugins" / "memory-os-agent-os" / "__init__.py"
+    )
+    agent_os = importlib.util.module_from_spec(agent_os_spec)
+    agent_os_spec.loader.exec_module(agent_os)
+
+    return {
+        "roots_derive": _derive_profile_from_home(home.expanduser().resolve()),
+        "roots_resolve": resolve_profile_name(home, environ={}),
+        "runner": runner._resolve_profile(home)[0],
+        "unit_suffix": _runtime_unit_suffix(home),
+        "compat_suffix": _unit_suffix_for_home(str(home)),
+        "dashboard_unit": _default_service_name(home),
+        "probe_slug": probe._probe_log_slug(home),
+        "agent_os": agent_os._resolve_profile(),
+    }
+
+
+def test_all_home_shape_derivations_agree_on_a_plain_home(tmp_path, monkeypatch):
+    assert _observed(tmp_path / ".hermes", monkeypatch) == _expected(shaped=False)
+
+
+def test_all_home_shape_derivations_agree_on_a_profile_shaped_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes" / "profiles" / "sannai"
+    assert _observed(home, monkeypatch) == _expected(shaped=True)
+
+
+def test_a_directory_merely_named_profiles_is_not_a_profile_home(tmp_path, monkeypatch):
+    # Only the PARENT being "profiles" makes a home profile-shaped; a home
+    # called "profiles" is a plain home, and every copy must agree on that.
+    observed = _observed(tmp_path / "profiles", monkeypatch)
+    assert observed == _expected(shaped=False)
+
+
+def test_bash_installer_carries_the_same_rule(tmp_path):
+    # install_memory_os.sh cannot be imported; pin its predicate by source.
+    source = (_SCRIPTS / "install_memory_os.sh").read_text(encoding="utf-8")
+    assert "unit_suffix()" in source, "bash unit_suffix helper disappeared"
+    assert 'home_parent}" == "profiles"' in source, (
+        "bash unit_suffix no longer keys on the parent directory being 'profiles' — "
+        "it has drifted from the Python copies pinned above"
+    )

--- a/tests/scripts/test_probe_l3_prefetch_behavior.py
+++ b/tests/scripts/test_probe_l3_prefetch_behavior.py
@@ -24,3 +24,13 @@ def test_l3_probe_failure_revokes_and_compacts_provisional_record(tmp_path, monk
     store = MemoryOSStore(roots)
     service = CrystallizedMemoryService(store)
     assert service.read_records("_system_probe.md") == []
+
+
+def test_probe_log_name_is_namespaced_per_profile(tmp_path):
+    """Both profiles' evidence ticks fire on the same minute and the log name
+    is only second-granular, so a shared tempdir name could let co-tenant
+    probes overwrite each other's diagnostics."""
+    probe = importlib.import_module("scripts.probe_l3_prefetch_behavior")
+
+    assert probe._probe_log_slug(tmp_path / ".hermes") == ""
+    assert probe._probe_log_slug(tmp_path / ".hermes" / "profiles" / "sannai") == "_sannai"


### PR DESCRIPTION
# 多 profile 清扫收尾 + V2C 解冻门重定义(owner 裁定)+ 跨面 census

三部分：① owner 追问"是不是要看全部定时任务和部署脚本"后的 Rule-5 全面清扫收尾；② owner 裁定的 V2C 压力门重定义；③ Advisor 建议的跨面 census 护栏。

## ① 多 profile 清扫收尾

**宿主全量盘点(只读)**：systemd 用户级 12 单元(4 个 Memory-OS timer 已 per-profile 化且全部 enabled/active)、系统级仅 dashboard、gateway 2 进程 env 正确、main cron 22 条 / sannai cron 19 条**零跨 profile 路径污染**(tick wrapper 无硬编码，靠各自 gateway 的 HERMES_HOME 继承)、main 表内 3 条 sannai 命名任务是有意的主链协同报告(脚本均在)、其余 6 个 profile 无 Memory-OS cron。

**修掉三处残留**：
1. `install_memory_os_monitor_dashboard_service.py` 的 `--service-name` **默认值**是固定名——装第二个 profile 的 dashboard 会静默覆盖第一个的单元(与 #56 同类)。改为 profiles 形 home 默认带后缀，根 home 保留旧名，显式传参仍优先。
2. `memory_os_upgrade_compat_check.py` 的静态探测固定单元名——在 profile home 上显示的是 default 的单元状态(误导，`required=False` 不 gate)。改为跟随目标 home。
3. `probe_l3_prefetch_behavior.py` 的 temp 日志名只到秒级且不含 profile——两个 profile 的 evidence tick 同在 :12 分，同秒会互相覆盖诊断。改为按 profile 命名。

**硬编码 `/root/.hermes` 22 处逐条定性(全部良性，核心运转链无硬编码 home)**：5 处是文档/被检测的禁用字面量、1 处是生产目标探测启发式(sannai home 为其子串故照样命中)、13 处是 `--hermes-home` 可覆盖默认值、3 处是 CI 挂载隔离目标。

## ② V2C 解冻门重定义(owner 裁定 2026-08-14)

**问题**：门要求 `dropped_by_budget > 0` 连续 7 天，而生产实测该计数器**从未非零过一次**(全部自然 rollup 行)，同期 `dropped_by_rank` 持续累积——当前 `prefetch_char_budget` 下每段 rank 上限总是先绑死，字节预算永远不是约束。门在等一个该配置结构上无法产生的信号：不是"还没到"，是**不可达**。

**裁定**：判据扩为真实**选择压力**(budget **或** rank)，而不是调低生产预算去制造旧信号(路线图明令禁止为移动指标而改行为)。这确实改变了门的含义(证明"稀缺下行为正确"而非"**字节**稀缺下")，是知情的取舍。

- `budget_pressure_streak_days` **退休而非改义**(键义静默变宽正是本项目反复付代价的漂移)→ `selection_pressure_streak_days`；freeze 标签 → `selection_pressure_streak:<n>/7`
- 新增 `budget_pressure_day_count` / `rank_pressure_day_count` **保留"字节压力从未发生"的证据**，不因扩门而抹掉动机
- `exposure_monitor_stats` 键 census 已更新(退休键移除、3 个新键显式定性)

**反事实**：rank-only 压力在裁定后计数、在旧代码上 KeyError；零丢弃日仍然打断连击(扩宽的谓词不得变成恒真)。

**生产预演(部署前只读)**：新判据将读 **1/7**——08-05→08-10 已有**连续 6 天**真实排序压力，随后 sannai 迁移窗口(08-11/08-12)完全没有自然 rollup 行(与 V3 断档同源)重置了连击。可达性由历史证明，不是假设。

## ③ 跨面 census(Advisor 建议)

`profiles/<name>` 形状推导已散在**八处**(gate runner、roots、插件安装器、monitor 内嵌探针、compat 探测、dashboard 安装器、l3 日志 slug、agent-os)，此前只有 runner↔roots 两处互钉。新增一张行为表把八处全钉死(含"仅父目录为 profiles 才算"的边界)，bash 那份用源码扫描守住。

## 验证

- 全量 **3341 passed / 13 skipped** + 1 个已知 flaky(sidecar 并行索引，隔离复跑 3/3 通过，改动未触及该路径)
- 四静态门 + closure matrix + whitespace 全绿
- 三组反事实均 revert→FAIL→restore→PASS 实测
