### PR TITLE
注入诚实化 + 分层深入闭环(memory_os_session_recall)

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -5864,3 +5864,71 @@ revert→FAIL→restore→PASS）。
 读完再与现实核对、**以现实为准**。这需要一个"按 session_id 取回话history"
 的可调用面，其归属（编排层注入／provider 方法／CLI／Hermes 侧工具）是待定
 的架构决定，另议。
+
+### CR — 注入诚实化 + 分层深入闭环（2026-08-14，PR #60）
+
+owner 实测反馈定性："Hermes agent 看到高度匹配的摘要的部分不完整以为就是
+事实，而且不会召回看具体的会话内容去比对现状"。双 profile 真实注入审计
+（真实预算 12000/20000、带 index）逐字证实，并多出一层：
+
+- **碎片看起来像完整事实**：最相关行恰好切在承重点——URL 切一半
+  （`https://github.c...`）、路径切在要害（`scripts/.en...`，真实是
+  `.env`）、时刻表切在最后一个数字（`09:00、13:00、17:00、21.`）。裸 `...`
+  无法区分"事实到此为止"和"事实在此被截断"。
+- **40%（main）/51%（sannai）预算烧在零相关 floor 填充上**：floor 模式
+  20 条上限 + score-0 照收 + 同一事实重复注入 9 遍。
+- **全文 0 个以现状为准标记**：#58 只盖 event 行，而 event 段全是治理噪音；
+  #59 补的候选/indexed 标记当时未部署。
+
+#### 层1：注入诚实化（纯 prefetch）
+
+- **floor 模式重定义**：score-0 直接排除（floor 自己的注释早就写着
+  "query-aware fallback, not a universal recall"）、上限 20→5、合并两类按
+  分排序（相关性是 floor 唯一准入标准，permanent/provisional 保留位不适用）、
+  **允许空段**——空比 4000 字零相关垃圾好。FTS 命中模式的 20/15/5 上限
+  不变（有守卫测试钉住不外溢）。
+- **注入去重**：规范化正文前 120 字为键，同文只注一次。
+- **诚实截断** `_clip_annotated`：被切的行结尾 `…[片段N/M字]`——agent 一眼
+  知道这是碎片、外面还有多少。零 I/O。
+- **应答查询的段放宽**：候选 180→320、indexed 220→320、event 220→320
+  （event 存储侧本来只有 ~296 字上限，二次裁剪是纯损失）。预算头寸来自
+  floor 砍掉的 ~3000 字。
+
+#### 层2：分层深入的读半边 `memory_os_session_recall`
+
+第 4 个 provider 工具（接缝现成，零宿主管道）。四条治理性质各有测试：
+
+- **读边界强制脱敏**：state.db 正文是 session_mirror 写事件前脱敏对象的
+  未脱敏源头；返回原文=在读取时刻绕过边界，且是提示注入可利用的外泄面
+  （"去核实会话 X"→凭证进上下文）。以现状为准让脱敏零成本：agent 需要的
+  是对话语境，值必须拿现实核对。反事实测试把真密钥喂进 state.db 断言输出
+  缺席。
+- **有界**：max 40 条/600 字/条/12000 字总量 + offset/has_more 分页；
+  超额请求被钳制而非满足。
+- **落台账 + fail-open**：`system/session_transcript_reads.jsonl`（
+  report_only 写面已注册；**metadata_retention 已登记**——顾问抓的，
+  continuity_freshness 的注释原话就是"unregistered ledger grows without
+  bound"，且有 ages-out 测试用真产出器行钉住 created_at 字段名）。
+- **读不设 owner 门**：按两行决策表，读不写永久层 → 不得产生 owner 决策。
+
+**三方互认闭环**：标记文本写明动词（`原始会话 <id> 可用
+memory_os_session_recall 调取`）；system_prompt_block 新增 Layered Recall
+Rule 教协议（`[片段N/M字]`=截断、高匹配≠完整、取回后以现实为准）；工具
+description 教边界（历史快照、必须核对现状、普通聊天勿用）。
+
+#### 顾问预检抓到的三项（合并前处置）
+
+1. **gateway 常驻进程 vs 磁盘代码**（阻塞"部署验证通过"的说法）：
+   `oneshot.py` 在 gateway 进程内 `from run_agent import AIAgent`，provider
+   模块随首会话导入后被模块缓存持有。生产 gateway 今日 15:13 重启、早于
+   19:09 的 a7515c1 部署——**交互路径（prefetch/工具/系统提示）吃到新代码
+   需要 gateway 重启**；systemd 心跳/cron 是新进程不受影响。历史印证：
+   memory 里 V2-0.5 "code green, host-side reply-tool/hook gap" 同型。
+   部署后如实报告"重启后生效"，不得声称"部署验证通过"。
+2. **脱敏从设计声明升级为实测**：部署后对真实含凭证会话跑
+   `read_session_transcript`，断言真值缺席（对齐 #58 telegram 项的标准）。
+3. **复测口径**：截断计数要同时数 `...` 与 `[片段`，否则 after 侧漏计。
+
+**测试计数**：3368 → **3387 passed** / 13 skipped（+19：注入诚实 9、
+transcript 10）。四静态门全绿。层1 反事实 8 项 revert→FAIL→restore→PASS
+（唯一双向通过的是钉"FTS 模式上限不变"的守卫，本该如此）。

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -44,6 +44,7 @@ from .session_approval import build_session_review_block, build_session_feedback
 from .status_tool_contract import (
     MEMORY_OS_REVIEW_REPLY_TOOL_DESCRIPTION,
     MEMORY_OS_REVIEW_SURFACE_TOOL_DESCRIPTION,
+    MEMORY_OS_SESSION_RECALL_TOOL_DESCRIPTION,
     MEMORY_OS_STATUS_TOOL_DESCRIPTION,
 )
 from .store import MemoryOSStore
@@ -603,6 +604,19 @@ class MemoryOSProvider(MemoryProvider):
         lines.extend(
             [
                 "",
+                "## Layered Recall Rule",
+                (
+                    "Injected Memory-OS lines are CLIPPED summaries, not complete facts. A line ending "
+                    "with `[片段N/M字]` was truncated — N of M characters shown; a high-relevance match "
+                    "is NOT evidence the visible fragment is the whole fact. When a line carries "
+                    "`[以现状为准... 原始会话 <session_id>]` or a truncation annotation and you need the "
+                    "specifics (credentials location, deployment facts, configuration, schedules), call "
+                    "`memory_os_session_recall` with that session_id to read the original conversation. "
+                    "The transcript is a historical snapshot: verify any credential/deployment/config "
+                    "fact against current reality before relying on it — 以现实为准. Do not treat a "
+                    "recalled fragment or an old transcript as the current state of any system."
+                ),
+                "",
                 "## Owner Review Command Rule",
                 (
                     "If the latest owner message is a Memory-OS review task, resolve it to a definite action "
@@ -771,6 +785,32 @@ class MemoryOSProvider(MemoryProvider):
                     "additionalProperties": False,
                 },
             },
+            {
+                "name": "memory_os_session_recall",
+                "description": MEMORY_OS_SESSION_RECALL_TOOL_DESCRIPTION,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The session id from an injected pointer, e.g. the <id> in `原始会话 <id>`.",
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Zero-based message offset for paging through a long conversation.",
+                        },
+                        "max_messages": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 40,
+                            "description": "Messages to return in this window (bounded).",
+                        },
+                    },
+                    "required": ["session_id"],
+                    "additionalProperties": False,
+                },
+            },
         ]
 
     def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
@@ -818,6 +858,18 @@ class MemoryOSProvider(MemoryProvider):
                 action_token=str(args.get("action_token") or ""),
                 offset=int(args.get("offset") or 0),
                 limit=int(args.get("limit") or 5),
+            )
+            return json.dumps(result, ensure_ascii=False, sort_keys=True)
+        if tool_name == "memory_os_session_recall":
+            if self._store is None:
+                return json.dumps({"status": "error", "reason": "store_unavailable"}, ensure_ascii=False, sort_keys=True)
+            from .session_mirror import read_session_transcript
+
+            result = read_session_transcript(
+                self._store,
+                str(args.get("session_id") or ""),
+                max_messages=int(args.get("max_messages") or 20),
+                offset=int(args.get("offset") or 0),
             )
             return json.dumps(result, ensure_ascii=False, sort_keys=True)
         return super().handle_tool_call(tool_name, args, **kwargs)

--- a/plugins/memory/memory_os/metadata_retention.py
+++ b/plugins/memory/memory_os/metadata_retention.py
@@ -85,6 +85,16 @@ def metadata_retention_plan(
             now=current,
             actions=actions,
         ),
+        # Session-transcript read audit (memory_os_session_recall tool) — the
+        # fourth report-only ledger written from inside Hermes' request path.
+        # One row per drill-down read; carries created_at so it can age.
+        _ledger_plan(
+            ledger="session_transcript_reads",
+            path=roots.memory_os_root / "system" / "session_transcript_reads.jsonl",
+            retention_days=active_policy.shadow_retention_days,
+            now=current,
+            actions=actions,
+        ),
         # session_fact_extraction's two bookkeeping ledgers. Registering them is
         # the same non-optional step as above, and the growth is not theoretical:
         # an appended-to session mints a NEW fingerprint by design, so an active

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -1558,6 +1558,16 @@ def _crystallized_lines(
     MAX_TOTAL = 20
     MAX_PROVISIONAL = 5
     MAX_PERMANENT = MAX_TOTAL - MAX_PROVISIONAL  # 15 — reserve floor for provisional
+    # Floor mode (degradation 2) gets a much smaller cap and a score>0 gate.
+    # Production audit (2026-08-14): this section in floor mode was 40% of
+    # main's injection (4038/10220 chars) and 51% of sannai's (4469/8765) —
+    # twenty records of zero query relevance (philosophy chats, duplicate
+    # provisional rows) crowding out the sections that actually answered the
+    # query. The floor's own comment already said "a query-aware fallback,
+    # not a universal recall"; score-0 records are pure filler and the
+    # class-reserve logic (permanent/provisional) does not apply because
+    # relevance is the only admission criterion here.
+    FLOOR_MAX_TOTAL = 5
 
     now = datetime.now(timezone.utc)
 
@@ -1634,6 +1644,13 @@ def _crystallized_lines(
     # (rid, line) for permanent, (expires_at_sort_key, rid, line, recurrence) for provisional
     permanent_entries: list[tuple[str, str, int]] = []  # (rid, line, recurrence)
     provisional_entries: list[tuple[datetime, str, str, int]] = []
+    # Injection-time dedup by normalized body. Production audit: the same
+    # proposal-approval fact appeared NINE times in one injection (repeated
+    # provisional extraction of one session), each copy burning a cap slot
+    # and ~220 budget chars. Distinct records with identical normalized text
+    # are one fact for injection purposes; semantic near-duplicates remain
+    # the upstream dedup lane's job (dedup_absorb), not this line's.
+    seen_body_keys: set[str] = set()
 
     # ── File traversal ──────────────────────────────────────────────
     # When FTS5 provides relevance, sort by filename (stable, predictable).
@@ -1699,9 +1716,13 @@ def _crystallized_lines(
                 continue
 
             kind = str(frontmatter.get("kind", "item"))
-            text = _redact(_clip(body, 220))
+            text = _redact(_clip_annotated(body, 220))
             if not text or _is_diagnostic_style_seed(text):
                 continue
+            body_key = "".join(str(body or "").split()).lower()[:120]
+            if body_key in seen_body_keys:
+                continue
+            seen_body_keys.add(body_key)
 
             # Record-level score at degradation level 2 — each record body
             # is scored individually so small files with relevant records
@@ -1764,6 +1785,29 @@ def _crystallized_lines(
     # ── Apply caps and track seen only for surviving records ──────
     result: list[str] = []
     record_ids: list[str] = []
+
+    if degradation_level == 2 and floor_tokens:
+        # Floor mode: relevance is the only admission criterion. Merge both
+        # classes, drop score-0 (pure filler — see FLOOR_MAX_TOTAL comment),
+        # take the top slice by score with rid as the deterministic tiebreak.
+        # An empty result here is correct and better than 4000 chars of
+        # zero-relevance records: build_prefetch simply omits the section.
+        merged = [
+            (score, rid, line)
+            for rid, line, _recurrence, score in permanent_entries
+        ] + [
+            (score, rid, line)
+            for _expires, rid, line, _recurrence, score in provisional_entries
+        ]
+        merged = [entry for entry in merged if entry[0] > 0]
+        merged.sort(key=lambda entry: (-entry[0], entry[1]))
+        for _score, rid, line in merged[:FLOOR_MAX_TOTAL]:
+            result.append(line)
+            record_ids.append(f"crystallized:{rid}")
+            if seen is not None and rid:
+                seen.add(("crystallized_record", rid))
+        return result, degradation_level, record_ids
+
     # Cap permanent records at MAX_PERMANENT (15) — reserve floor for provisional
     for rid, line, _recurrence, _score in permanent_entries[:MAX_PERMANENT]:
         result.append(line)
@@ -1887,7 +1931,12 @@ def _candidate_lines(
     for candidate in ordered:
         if len(lines) >= MAX_CANDIDATE_LINES:
             break
-        text = _redact(_clip(candidate.body, 180))
+        # 320 (was 180) + honest-truncation annotation: this is one of the two
+        # sections that actually answer a topical query, and the production
+        # audit caught the 180-clip amputating facts at the load-bearing point
+        # ("git push 到 https://github.c..."). Budget headroom comes from the
+        # floor-mode cap in _crystallized_lines (~3000 chars freed).
+        text = _redact(_clip_annotated(candidate.body, 320))
         if _is_diagnostic_style_seed(text):
             continue
         if text:
@@ -1938,9 +1987,13 @@ def _event_lines(
     for event in selected:
         if _is_diagnostic_style_seed(str(event.summary)):
             continue
+        # 320 (was 220): sync_turn stores at most ~296 chars per turn summary
+        # (140 user + 140 assistant + separators), so 320 means the stored
+        # summary is injected whole — clipping an already-tiny summary a
+        # second time was pure loss. Annotated for the rare longer kinds.
         lines.append(
             f"- {_event_source_class(event)}/{event.kind}: "
-            f"{_redact(_clip(event.summary, 220))}{_live_state_marker(event)}"
+            f"{_redact(_clip_annotated(event.summary, 320))}{_live_state_marker(event)}"
         )
         if seen is not None and event.id:
             seen.add(("event", event.id))
@@ -3107,7 +3160,10 @@ def _indexed_lines(
         if seen is not None and record_type and record_id:
             if (record_type, record_id) in seen:
                 continue  # already emitted by a dedicated section
-        snippet = _redact(_clip(str(hit.get("snippet", "")), 220))
+        # 320 (was 220) + honest-truncation annotation — the other section
+        # that answers topical queries; the audit caught "GitHub token 在
+        # scripts/.en..." cut exactly at the fact being asked for.
+        snippet = _redact(_clip_annotated(str(hit.get("snippet", "")), 320))
         if snippet:
             # Indexed recall IS query scoped, so it is one of the paths that
             # actually answers "where is the deploy key" — it needs the
@@ -3215,7 +3271,11 @@ def _live_state_marker_for(text: Any, session_id: Any = "") -> str:
     pointer = ""
     normalized_session = str(session_id or "").strip()
     if normalized_session:
-        pointer = f"; 原始会话 {normalized_session}"
+        # Name the retrieval verb, not just the location: a pointer nothing
+        # can open is half a feature. memory_os_session_recall is the read
+        # half of 分层深入 (bounded, redacted drill-down into the original
+        # conversation) — the marker is what teaches the agent it exists.
+        pointer = f"; 原始会话 {normalized_session} 可用 memory_os_session_recall 调取"
     return f" [以现状为准:此为当时摘要,使用前请核对当前状态{pointer}]"
 
 
@@ -3534,6 +3594,26 @@ def _clip(value: str, limit: int) -> str:
     if len(clean) <= limit:
         return clean
     return clean[: limit - 1].rstrip() + "..."
+
+
+def _clip_annotated(value: str, limit: int) -> str:
+    """Clip like ``_clip`` but say so honestly when text was cut.
+
+    Production audit (2026-08-14, both profiles): recall lines were cut at
+    exactly the load-bearing point — mid-URL (``https://github.c...``),
+    mid-path (``scripts/.en...``), mid-schedule (``09:00、13:00、17:00、21.``)
+    — and the bare ``...`` suffix gave the agent no way to distinguish "the
+    fact ends here" from "the fact was amputated here". A fragment that looks
+    complete gets *believed*; the annotation makes the cut visible and tells
+    the agent how much of the record it is NOT seeing, which is the trigger
+    to drill down instead of trusting the fragment. Zero I/O — both numbers
+    come from strings already in hand.
+    """
+    clean = " ".join(str(value or "").split())
+    if len(clean) <= limit:
+        return clean
+    shown = clean[: limit - 1].rstrip()
+    return f"{shown}…[片段{len(shown)}/{len(clean)}字]"
 
 
 def _clip_multiline(value: str, limit: int) -> str:

--- a/plugins/memory/memory_os/session_mirror.py
+++ b/plugins/memory/memory_os/session_mirror.py
@@ -1403,6 +1403,222 @@ def _bounded_apply_governance(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+SESSION_TRANSCRIPT_SCHEMA_VERSION = "memory-os.session_transcript.v0"
+SESSION_TRANSCRIPT_MAX_MESSAGES = 40
+SESSION_TRANSCRIPT_MAX_CHARS_PER_MESSAGE = 600
+SESSION_TRANSCRIPT_MAX_TOTAL_CHARS = 12000
+
+
+def read_session_transcript(
+    store: MemoryOSStore,
+    session_id: str,
+    *,
+    max_messages: int = 20,
+    max_chars_per_message: int = SESSION_TRANSCRIPT_MAX_CHARS_PER_MESSAGE,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Bounded, redacted drill-down into one original conversation.
+
+    The 分层深入 read half (owner ruling 2026-08-14): injection carries only
+    compact summaries plus a session pointer; when a recalled fragment is not
+    enough, the agent follows the pointer here, reads the original exchange,
+    and verifies against live state — 以现实为准. Reading is not a permanent
+    write, so per the owner's two-line paradigm it produces NO owner
+    decision; it is bounded, redacted, and ledgered instead.
+
+    Governance properties, each load-bearing:
+
+    * **Redaction at the read boundary.** state.db bodies are the unredacted
+      source of exactly the secrets session_mirror strips before writing
+      events; returning raw rows would bypass that boundary at read time and
+      hand a prompt-injected "go verify session X" a credential exfiltration
+      path. 以现状为准 makes this free: the stored value is untrustworthy by
+      definition, so the agent needs the conversation, never the secret —
+      current values are verified against reality, not against memory.
+    * **Bounded.** Hard ceilings on message count, per-message chars, and
+      total chars; pagination via ``offset`` + ``has_more`` instead of a
+      bigger reply.
+    * **Ledgered, fail-open.** Every read appends one audit row (report-only
+      surface, same shape as prefetch's shadow ledgers); losing the ledger
+      write must never fail the read.
+    * **Structural truncation flags**, not inline ellipses: a tool consumer
+      gets ``content_truncated`` + ``content_total_chars`` per message, so a
+      cut is data, not something to eyeball.
+    """
+    normalized_id = str(session_id or "").strip()
+    clamped_messages = max(1, min(int(max_messages or 1), SESSION_TRANSCRIPT_MAX_MESSAGES))
+    clamped_chars = max(80, min(int(max_chars_per_message or 1), SESSION_TRANSCRIPT_MAX_CHARS_PER_MESSAGE))
+    safe_offset = max(0, int(offset or 0))
+    base: dict[str, Any] = {
+        "schema_version": SESSION_TRANSCRIPT_SCHEMA_VERSION,
+        "session_id": normalized_id,
+        "secret_redaction_applied": True,
+        "body_policy": "redacted_clipped_transcript",
+        "agent_instruction": (
+            "这是当时的原始对话（已脱敏截断）。其中的密钥/部署/配置等事实是历史快照，"
+            "使用前必须与当前现实核对，以现实为准。"
+        ),
+    }
+    if not normalized_id:
+        return {**base, "status": "invalid_request", "reason": "empty_session_id"}
+
+    mirror = SessionMirror(store)
+    source_kind = ""
+    platform = ""
+    updated_at = ""
+    raw_messages: list[dict[str, Any]] | None = None
+
+    if mirror.state_db_path.exists():
+        try:
+            uri = f"file:{mirror.state_db_path.as_posix()}?mode=ro"
+            with sqlite3.connect(uri, uri=True) as conn:
+                conn.row_factory = sqlite3.Row
+                if _table_exists(conn, "sessions"):
+                    session_columns = _table_columns(conn, "sessions")
+                    id_col = _first_existing(session_columns, ("id", "session_id", "uuid"))
+                    if id_col:
+                        row = conn.execute(
+                            f"select * from sessions where {id_col} = ?",
+                            (normalized_id,),
+                        ).fetchone()
+                        if row is not None:
+                            source_col = _first_existing(session_columns, ("source", "platform", "channel", "kind"))
+                            updated_col = _first_existing(session_columns, ("updated_at", "last_updated", "created_at"))
+                            platform = str(row[source_col]) if source_col else "unknown"
+                            updated_at = str(row[updated_col]) if updated_col else ""
+                            message_columns = (
+                                _table_columns(conn, "messages") if _table_exists(conn, "messages") else set()
+                            )
+                            raw_messages = _read_messages_for_session(conn, message_columns, normalized_id)
+                            source_kind = "state_db"
+        except Exception as exc:
+            _append_session_transcript_ledger(
+                store,
+                session_id=normalized_id,
+                status="source_error",
+                source_kind="state_db",
+                returned=0,
+                detail=f"{type(exc).__name__}: {exc}"[:200],
+            )
+            return {
+                **base,
+                "status": "source_error",
+                "reason": "state_db_read_failed",
+                "error_type": type(exc).__name__,
+            }
+
+    if raw_messages is None and mirror.sessions_root.exists():
+        direct = mirror.sessions_root / f"session_{normalized_id}.json"
+        candidates = [direct] if direct.exists() else sorted(mirror.sessions_root.glob("session_*.json"))
+        for path in candidates:
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+            candidate_id = str(data.get("id") or data.get("session_id") or path.stem)
+            if candidate_id != normalized_id and path.stem != f"session_{normalized_id}":
+                continue
+            platform = str(data.get("platform") or data.get("source") or data.get("channel") or "unknown")
+            updated_at = str(data.get("updated_at") or data.get("created_at") or "")
+            raw_messages = [dict(item) for item in data.get("messages", []) if isinstance(item, dict)]
+            source_kind = "session_json"
+            break
+
+    if raw_messages is None:
+        _append_session_transcript_ledger(
+            store,
+            session_id=normalized_id,
+            status="not_found",
+            source_kind="",
+            returned=0,
+        )
+        return {
+            **base,
+            "status": "not_found",
+            "reason": "session_not_found_in_state_db_or_session_files",
+            "checked_state_db": mirror.state_db_path.exists(),
+            "checked_sessions_root": mirror.sessions_root.exists(),
+        }
+
+    total_count = len(raw_messages)
+    window = raw_messages[safe_offset : safe_offset + clamped_messages]
+    messages: list[dict[str, Any]] = []
+    spent = 0
+    truncated_by_total = False
+    for item in window:
+        content = _redact_secrets(str(item.get("content") or ""))
+        total_chars = len(content)
+        clipped = content[:clamped_chars]
+        if spent + len(clipped) > SESSION_TRANSCRIPT_MAX_TOTAL_CHARS:
+            truncated_by_total = True
+            break
+        spent += len(clipped)
+        messages.append(
+            {
+                "role": str(item.get("role") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "content": clipped,
+                "content_truncated": total_chars > len(clipped),
+                "content_total_chars": total_chars,
+            }
+        )
+
+    result = {
+        **base,
+        "status": "ok",
+        "source_kind": source_kind,
+        "platform": platform,
+        "updated_at": updated_at,
+        "total_message_count": total_count,
+        "offset": safe_offset,
+        "returned_message_count": len(messages),
+        "has_more": safe_offset + len(messages) < total_count,
+        "truncated_by_total_budget": truncated_by_total,
+        "messages": messages,
+    }
+    _append_session_transcript_ledger(
+        store,
+        session_id=normalized_id,
+        status="ok",
+        source_kind=source_kind,
+        returned=len(messages),
+    )
+    return result
+
+
+def _append_session_transcript_ledger(
+    store: MemoryOSStore,
+    *,
+    session_id: str,
+    status: str,
+    source_kind: str,
+    returned: int,
+    detail: str = "",
+) -> None:
+    """Append-only read audit; fail-open (a lost audit row must not fail a read)."""
+    path = store.roots.memory_os_root / "system" / "session_transcript_reads.jsonl"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        from .jsonl_io import append_jsonl_locked
+
+        append_jsonl_locked(
+            path,
+            {
+                "schema_version": "memory-os.session_transcript_read.v0",
+                "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "session_id": session_id,
+                "status": status,
+                "source_kind": source_kind,
+                "returned_message_count": int(returned),
+                **({"detail": detail} if detail else {}),
+            },
+        )
+    except Exception:
+        pass
+
+
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
     row = conn.execute("select name from sqlite_master where type = 'table' and name = ?", (table_name,)).fetchone()
     return row is not None

--- a/plugins/memory/memory_os/status_tool_contract.py
+++ b/plugins/memory/memory_os/status_tool_contract.py
@@ -48,6 +48,20 @@ MEMORY_OS_REVIEW_SURFACE_TOOL_DESCRIPTION = (
     "a separate apply intent for approved-proposal follow-up items."
 )
 
+MEMORY_OS_SESSION_RECALL_TOOL_DESCRIPTION = (
+    "Retrieve the original conversation behind a recalled memory fragment. "
+    "Use when an injected Memory-OS line carries a session pointer — "
+    "`[以现状为准... 原始会话 <session_id>]` — or a truncation annotation "
+    "(`[片段N/M字]`) and the fragment is not enough to act on: credentials, "
+    "deployment facts, configuration details, schedules. Returns a bounded, "
+    "secret-redacted transcript window with pagination (offset/has_more). "
+    "The transcript is a HISTORICAL snapshot: after reading it, verify any "
+    "credential/deployment/config fact against current reality before "
+    "relying on it — 以现实为准, never memory alone. This tool is read-only "
+    "and never returns unredacted secrets; do not use it for ordinary chat "
+    "or when the injected summary already answers the question."
+)
+
 _REQUIRED_BOUNDARY_PHRASES = (
     "explicitly asks for current architecture",
     "provider/backend",

--- a/scripts/memory_os_write_surface_check.py
+++ b/scripts/memory_os_write_surface_check.py
@@ -89,6 +89,11 @@ ALLOWED_WRITE_SURFACES: dict[str, str] = {
     # on every call and the diagnostic would never be written. Same contract as
     # the two report-only shadow writers above. See the closure plan §4.2.
     "plugins/memory/memory_os/prefetch.py::_record_continuity_freshness::append_jsonl_locked_call::path": "report_only_continuity_freshness",
+    # Session-recall read audit: the drill-down tool runs inside Hermes'
+    # request (tool call), not a cron envelope, so like the prefetch shadow
+    # ledgers it has no permit to spend — report-only, append-bounded,
+    # fail-open.
+    "plugins/memory/memory_os/session_mirror.py::_append_session_transcript_ledger::append_jsonl_locked_call::path": "report_only_session_transcript_read",
     "plugins/memory/memory_os/state_overlay.py::append_overlay_run::path.open_a::out_path": "state_overlay_run_ledger",
     "scripts/memory_os_entity_index_refresh.py::main::path.open_a::run_path": "entity_index_refresh_run_ledger",
     "plugins/memory/memory_os/permanent_promotion.py::ProposalLedger.create_or_get::append_under_lock_call::target": "permanent_promotion_proposal_ledger",

--- a/tests/plugins/memory/test_memory_os_injection_honesty.py
+++ b/tests/plugins/memory/test_memory_os_injection_honesty.py
@@ -1,0 +1,248 @@
+"""Injection honesty (2026-08-14 production audit, both 3.200 profiles).
+
+The audit found the agent was being handed "fragments that look complete":
+
+* recall lines cut at the load-bearing point — mid-URL
+  (``https://github.c...``), mid-path (``scripts/.en...``) — with a bare
+  ``...`` that cannot be told apart from a fact that simply ends there;
+* the crystallized floor section burning 40% (main) / 51% (sannai) of the
+  whole injection on records with zero query relevance, twenty at a time;
+* the same provisional fact injected NINE times in one prefetch.
+
+Each test here is the counterfactual for one of those measured defects.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+from plugins.memory.memory_os.crystallized import (
+    CrystallizedCandidate,
+    CrystallizedMemoryService,
+    append_candidate_queue,
+)
+# _clip_annotated is imported inside its own tests so that reverting the fix
+# makes the floor/dedup tests fail on BEHAVIOR, not on collection.
+from plugins.memory.memory_os.prefetch import (
+    _candidate_lines,
+    _crystallized_lines,
+    _event_lines,
+)
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
+
+def _store(tmp_path) -> MemoryOSStore:
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test"))
+    store.initialize()
+    return store
+
+
+class _ZeroHitIndex:
+    def search(self, _query, *, limit):
+        return {"hits": []}
+
+
+def _write_record(store, service, candidate_id: str, body: str, file_name: str) -> None:
+    candidate = CrystallizedCandidate(
+        candidate_id=candidate_id,
+        kind="moment",
+        body=body,
+        source_event_ids=[f"evt_{candidate_id}"],
+    )
+    decision = ApprovalDecision(
+        candidate_id=candidate_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="owner",
+        reviewed_at="2026-06-25T12:00:00Z",
+        provisional=False,
+    )
+    service.write_approved_record(candidate, decision, file_name=file_name)
+
+
+# ── floor mode: score-0 filler exclusion + cap ──────────────────────────────
+
+
+def test_floor_mode_excludes_zero_score_filler(tmp_path):
+    """Floor is a query-aware fallback, not a universal recall.
+
+    Production: twenty philosophy-chat records with no relation to the query
+    filled this section. Score-0 records are pure filler and must not ride
+    the floor into the injection.
+    """
+    store = _store(tmp_path)
+    service = CrystallizedMemoryService(store)
+    _write_record(store, service, "rel_001", "关于时间管理的记录，明确包含时间这个主题。", "rel_001.md")
+    for i in range(3):
+        _write_record(
+            store, service, f"junk_{i:03d}",
+            f"哲学聊天记录 {i}：讨论了幻觉、想象与梦境的意向对象问题。",
+            f"junk_{i:03d}.md",
+        )
+
+    lines, degradation, _ids = _crystallized_lines(
+        store, query="时间", index=_ZeroHitIndex(), error_records=[],
+    )
+
+    assert degradation == 2
+    assert any("时间" in ln for ln in lines)
+    assert not any("哲学聊天" in ln for ln in lines), (
+        "score-0 filler rode the floor into the injection:\n" + "\n".join(lines)
+    )
+
+
+def test_floor_mode_caps_at_five_records(tmp_path):
+    store = _store(tmp_path)
+    service = CrystallizedMemoryService(store)
+    for i in range(8):
+        _write_record(
+            store, service, f"rel_{i:03d}",
+            f"关于时间管理的记录 {i}：这条记录明确讨论时间安排。",
+            f"rel_{i:03d}.md",
+        )
+
+    lines, degradation, _ids = _crystallized_lines(
+        store, query="时间", index=_ZeroHitIndex(), error_records=[],
+    )
+
+    assert degradation == 2
+    assert len(lines) == 5, f"floor cap: expected 5, got {len(lines)}"
+
+
+def test_floor_mode_may_be_empty_rather_than_filled(tmp_path):
+    """An empty section beats 4000 chars of zero-relevance records."""
+    store = _store(tmp_path)
+    service = CrystallizedMemoryService(store)
+    for i in range(3):
+        _write_record(
+            store, service, f"junk_{i:03d}",
+            f"哲学聊天记录 {i}：讨论了幻觉、想象与梦境。",
+            f"junk_{i:03d}.md",
+        )
+
+    lines, degradation, _ids = _crystallized_lines(
+        store, query="时间", index=_ZeroHitIndex(), error_records=[],
+    )
+
+    assert degradation == 2
+    assert lines == []
+
+
+def test_fts_hit_mode_keeps_the_wide_caps(tmp_path):
+    """The 20/15/5 caps still govern the relevance-gated (non-floor) path —
+    the floor cap must not leak into normal FTS-hit recall."""
+    store = _store(tmp_path)
+    service = CrystallizedMemoryService(store)
+    rids: list[str] = []
+    for i in range(8):
+        _write_record(
+            store, service, f"hit_{i:03d}",
+            f"记录 {i}：与查询相关的内容。",
+            f"hit_{i:03d}.md",
+        )
+    # Collect the real record ids the service assigned.
+    for path in store.roots.crystallized_root.glob("hit_*.md"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("id: "):
+                rids.append(line.split("id: ", 1)[1].strip())
+
+    class AllHitIndex:
+        def search(self, _query, *, limit):
+            return {
+                "hits": [
+                    {"record_type": "crystallized_record", "record_id": rid}
+                    for rid in rids
+                ]
+            }
+
+    lines, degradation, _ids = _crystallized_lines(
+        store, query="记录", index=AllHitIndex(), error_records=[],
+    )
+
+    assert degradation == 0
+    assert len(lines) == 8  # all relevance-gated hits survive (under the 15 cap)
+
+
+# ── injection-time dedup ────────────────────────────────────────────────────
+
+
+def test_duplicate_bodies_inject_once(tmp_path):
+    """Production: one proposal-approval fact injected nine times."""
+    store = _store(tmp_path)
+    service = CrystallizedMemoryService(store)
+    body = "用户已批准 proposal「Review reflection continuity behavior」，其状态为 approved_for_proposal。时间线记录。"
+    for i in range(4):
+        _write_record(store, service, f"dup_{i:03d}", body, f"dup_{i:03d}.md")
+
+    lines, _degradation, _ids = _crystallized_lines(
+        store, query="时间", index=_ZeroHitIndex(), error_records=[],
+    )
+
+    matching = [ln for ln in lines if "Review reflection" in ln]
+    assert len(matching) == 1, (
+        f"duplicate body injected {len(matching)} times:\n" + "\n".join(lines)
+    )
+
+
+# ── honest truncation ───────────────────────────────────────────────────────
+
+
+def test_clip_annotated_marks_the_cut_with_both_lengths():
+    from plugins.memory.memory_os.prefetch import _clip_annotated
+
+    long = "A" * 500
+    out = _clip_annotated(long, 320)
+    assert "…[片段" in out and "/500字]" in out
+
+
+def test_clip_annotated_leaves_short_text_untouched():
+    from plugins.memory.memory_os.prefetch import _clip_annotated
+
+    assert _clip_annotated("short fact", 320) == "short fact"
+
+
+def test_truncated_candidate_line_says_so(tmp_path):
+    store = _store(tmp_path)
+    body = "Owner 交代了 GitHub 部署密钥的存放位置：" + "细节" * 200
+    append_candidate_queue(
+        store,
+        CrystallizedCandidate(
+            candidate_id="cand-long",
+            kind="preference",
+            body=body,
+            source_event_ids=["evt-l1"],
+            bridge_state="owner_eligible",
+            created_at=datetime.now(timezone.utc).isoformat(),
+        ),
+    )
+
+    lines = _candidate_lines(store, query="github 密钥 部署", seen=set(), source_ids=[])
+
+    assert lines, "candidate should surface"
+    assert "…[片段" in lines[0], f"no truncation annotation: {lines[0][-120:]}"
+    # The live-state marker still renders after the annotation.
+    assert "以现状为准" in lines[0]
+
+
+def test_event_summary_is_injected_whole(tmp_path):
+    """sync_turn stores at most ~296 chars; the old second clip at 220 was
+    pure loss. At 320 the stored summary must appear complete."""
+    from plugins.memory.memory_os.fixtures import build_event
+    from plugins.memory.memory_os.store import EventEnvelope
+
+    store = _store(tmp_path)
+    summary = "User: " + "问" * 140 + " | Assistant: " + "答" * 140
+    event = EventEnvelope.from_dict(
+        {**build_event(seed=901, profile="memoryos-test"), "summary": summary}
+    )
+    store.append_event(event)
+
+    lines = _event_lines(store, session_id="", seen=set(), source_ids=[])
+
+    joined = "\n".join(lines)
+    assert summary in joined, "stored summary was re-clipped at injection"

--- a/tests/plugins/memory/test_memory_os_session_transcript.py
+++ b/tests/plugins/memory/test_memory_os_session_transcript.py
@@ -1,0 +1,253 @@
+"""memory_os_session_recall — the read half of 分层深入 (owner ruling 2026-08-14).
+
+Injection carries compact summaries plus a session pointer; this tool is what
+opens the pointer. Before it existed, prefetch labelled lines
+"原始会话 <id>" while nothing in the codebase could retrieve that session —
+a pointer to an unreachable place (verified by inventory: zero
+read-by-session-id surfaces; the only `messages` query was trapped inside
+session_mirror's all-sessions loop).
+
+The security test is the load-bearing one: state.db bodies are the
+unredacted source of exactly the secrets session_mirror strips before
+writing events. A read path returning raw rows would bypass that boundary
+at read time — an injected "go verify session X" becomes a credential
+exfiltration channel. 以现状为准 makes redaction free: the agent needs the
+conversation, never the stored secret value.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.session_mirror import (
+    SESSION_TRANSCRIPT_MAX_MESSAGES,
+    read_session_transcript,
+)
+from plugins.memory.memory_os.store import MemoryOSStore
+
+
+def _store(tmp_path) -> MemoryOSStore:
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test"))
+    store.initialize()
+    return store
+
+
+def _create_state_db(path, *, session_id="drill-session", platform="telegram", message_count=6):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "create table sessions (id text primary key, source text, created_at text, updated_at text)"
+        )
+        conn.execute(
+            "create table messages (id integer primary key autoincrement, session_id text,"
+            " role text, content text, created_at text)"
+        )
+        conn.execute(
+            "insert into sessions(id, source, created_at, updated_at) values (?, ?, ?, ?)",
+            (session_id, platform, "2026-05-21T08:00:00+00:00", "2026-05-21T08:10:00+00:00"),
+        )
+        rows = []
+        for i in range(message_count):
+            role = "user" if i % 2 == 0 else "assistant"
+            rows.append(
+                (session_id, role, f"message {i}: 部署细节第 {i} 条", f"2026-05-21T08:0{i}:01+00:00")
+            )
+        conn.executemany(
+            "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
+            rows,
+        )
+
+
+def test_reads_one_session_from_state_db(tmp_path):
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db")
+
+    report = read_session_transcript(store, "drill-session")
+
+    assert report["status"] == "ok"
+    assert report["source_kind"] == "state_db"
+    assert report["platform"] == "telegram"
+    assert report["total_message_count"] == 6
+    assert report["returned_message_count"] == 6
+    assert report["has_more"] is False
+    assert report["messages"][0]["content"].startswith("message 0")
+    assert report["secret_redaction_applied"] is True
+    assert "以现实为准" in report["agent_instruction"]
+
+
+def test_secrets_are_redacted_at_the_read_boundary(tmp_path):
+    """The exfiltration guard: raw state.db bodies never leave the tool."""
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", message_count=0)
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute(
+            "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
+            (
+                "drill-session",
+                "user",
+                "请记住 api_key=sk-drilldown-UNIQUE-20260814-bbbbbbbbbbbbbbbb 用于部署",
+                "2026-05-21T08:00:01+00:00",
+            ),
+        )
+
+    report = read_session_transcript(store, "drill-session")
+
+    serialized = json.dumps(report, ensure_ascii=False)
+    assert "sk-drilldown-UNIQUE" not in serialized
+    assert "[REDACTED]" in serialized
+
+
+def test_pagination_is_bounded_and_resumable(tmp_path):
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", message_count=10)
+
+    first = read_session_transcript(store, "drill-session", max_messages=4)
+    second = read_session_transcript(store, "drill-session", max_messages=4, offset=8)
+
+    assert first["returned_message_count"] == 4
+    assert first["has_more"] is True
+    assert second["offset"] == 8
+    assert second["returned_message_count"] == 2
+    assert second["has_more"] is False
+    # The hard ceiling clamps oversized asks instead of honouring them.
+    greedy = read_session_transcript(store, "drill-session", max_messages=10_000)
+    assert greedy["returned_message_count"] <= SESSION_TRANSCRIPT_MAX_MESSAGES
+
+
+def test_long_messages_carry_structural_truncation_flags(tmp_path):
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", message_count=0)
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute(
+            "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
+            ("drill-session", "user", "长" * 5000, "2026-05-21T08:00:01+00:00"),
+        )
+
+    report = read_session_transcript(store, "drill-session")
+
+    message = report["messages"][0]
+    assert message["content_truncated"] is True
+    assert message["content_total_chars"] == 5000
+    assert len(message["content"]) <= 600
+
+
+def test_not_found_is_structured_not_an_exception(tmp_path):
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db")
+
+    report = read_session_transcript(store, "no-such-session")
+
+    assert report["status"] == "not_found"
+    assert report["checked_state_db"] is True
+
+
+def test_falls_back_to_session_json_files(tmp_path):
+    store = _store(tmp_path)
+    sessions_root = tmp_path / "sessions"
+    sessions_root.mkdir()
+    (sessions_root / "session_json-drill.json").write_text(
+        json.dumps(
+            {
+                "id": "json-drill",
+                "platform": "cli",
+                "updated_at": "2026-06-01T00:00:00+00:00",
+                "messages": [
+                    {"role": "user", "content": "json 泳道的消息", "created_at": "2026-06-01T00:00:01+00:00"}
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    report = read_session_transcript(store, "json-drill")
+
+    assert report["status"] == "ok"
+    assert report["source_kind"] == "session_json"
+    assert report["messages"][0]["content"] == "json 泳道的消息"
+
+
+def test_every_read_lands_in_the_audit_ledger(tmp_path):
+    """Completion Is Not Output applies to read surfaces too."""
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db")
+
+    read_session_transcript(store, "drill-session")
+    read_session_transcript(store, "no-such-session")
+
+    ledger = store.roots.memory_os_root / "system" / "session_transcript_reads.jsonl"
+    rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert [row["status"] for row in rows] == ["ok", "not_found"]
+    assert rows[0]["session_id"] == "drill-session"
+    assert rows[0]["returned_message_count"] == 6
+
+
+def test_read_ledger_is_registered_for_retention_and_ages_out(tmp_path):
+    """Registration alone is not enough (continuity_freshness precedent):
+    the row must carry a timestamp field retention can actually read, or it
+    is retained forever while looking registered. Rows come from the REAL
+    producer; only the age is rewritten, and the field name is asserted
+    before rewriting so a producer rename fails here instead of silently
+    un-ageing the ledger."""
+    from datetime import datetime, timedelta, timezone
+
+    from plugins.memory.memory_os.metadata_retention import (
+        MetadataRetentionPolicy,
+        metadata_retention_plan,
+    )
+
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db")
+    read_session_transcript(store, "drill-session")
+    read_session_transcript(store, "drill-session")
+
+    ledger = store.roots.memory_os_root / "system" / "session_transcript_reads.jsonl"
+    rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert all("created_at" in row for row in rows), "producer renamed the retention timestamp field"
+    now = datetime(2026, 8, 14, tzinfo=timezone.utc)
+    rows[0]["created_at"] = (now - timedelta(days=45)).isoformat().replace("+00:00", "Z")
+    rows[1]["created_at"] = (now - timedelta(days=2)).isoformat().replace("+00:00", "Z")
+    ledger.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n", encoding="utf-8")
+
+    plan = metadata_retention_plan(
+        store.roots, now=now, policy=MetadataRetentionPolicy(shadow_retention_days=30),
+    )
+
+    summary = next(entry for entry in plan["ledgers"] if entry["ledger"] == "session_transcript_reads")
+    assert summary["exists"] is True
+    assert summary["total_records"] == 2
+    assert summary["retained_records"] == 1
+    assert summary["archive_candidate_records"] == 1
+
+
+def test_provider_registers_and_dispatches_the_tool(tmp_path):
+    _create_state_db(tmp_path / "state.db")
+    from plugins.memory.memory_os import MemoryOSProvider
+
+    provider = MemoryOSProvider()
+    provider.initialize("tool-test-session", hermes_home=str(tmp_path))
+
+    names = [schema["name"] for schema in provider.get_tool_schemas()]
+    assert "memory_os_session_recall" in names
+    schema = next(s for s in provider.get_tool_schemas() if s["name"] == "memory_os_session_recall")
+    assert schema["parameters"]["required"] == ["session_id"]
+    assert "以现实为准" in schema["description"] or "verify" in schema["description"]
+
+    raw = provider.handle_tool_call("memory_os_session_recall", {"session_id": "drill-session"})
+    payload = json.loads(raw)
+    assert payload["status"] == "ok"
+    assert payload["returned_message_count"] == 6
+
+
+def test_system_prompt_teaches_the_layered_protocol(tmp_path):
+    from plugins.memory.memory_os import MemoryOSProvider
+
+    provider = MemoryOSProvider()
+    provider.initialize("prompt-test-session", hermes_home=str(tmp_path))
+
+    block = provider.system_prompt_block()
+    assert "Layered Recall Rule" in block
+    assert "memory_os_session_recall" in block
+    assert "以现实为准" in block
+    assert "[片段N/M字]" in block


### PR DESCRIPTION
# 注入诚实化 + 分层深入闭环（memory_os_session_recall）

owner 实测反馈："agent 看到高度匹配的摘要的部分不完整以为就是事实，而且不会召回看具体的会话内容去比对现状"。

双 profile **真实注入审计**（真实预算 12000/20000、带 index）逐字证实，还多出一层：

- 最相关的行恰好切在承重点：URL 切一半（`https://github.c...`）、路径切在要害（`scripts/.en...`，真实是 `.env`）、时刻表切在最后一个数字（`09:00、13:00、17:00、21.`）。裸 `...` 无法区分"事实到此为止"和"事实被截断于此"。
- **40%（main）/ 51%（sannai）的注入预算烧在零相关的 floor 填充上**：20 条上限、score-0 照收、同一事实重复注入 **9 遍**。
- 全文 **0 个**以现状为准标记（#58 只盖 event 行而 event 段全是治理噪音；#59 当时未部署）。

## 层1：注入诚实化（纯 prefetch）

- **floor 模式重定义**：score-0 直接排除（floor 自己的注释早写着 "a query-aware fallback, not a universal recall"）、上限 **20→5**、两类合并按分排序（相关性是 floor 唯一准入标准）、**允许空段**——空比 4000 字零相关垃圾好。FTS 命中模式 20/15/5 上限不变，守卫测试钉住不外溢。
- **注入去重**：规范化正文前 120 字为键，同文只注一次。
- **诚实截断**：被切的行结尾 `…[片段N/M字]`——碎片可见即碎片，还知道缺多少。零 I/O。
- **应答查询的段放宽**：候选 180→320、indexed 220→320、event 220→320（event 存储侧本就只有 ~296 字，二次裁剪纯损失）。头寸来自 floor 释放的 ~3000 字。

## 层2：分层深入的读半边 `memory_os_session_recall`

第 4 个 provider 工具，走现成 `get_tool_schemas`/`handle_tool_call` 接缝，零宿主新管道。按 session_id 取回原始对话（单会话查询从 session_mirror 的全量循环里抬出来），sessions/*.json 兜底。治理四性质各有测试：

- **读边界强制脱敏**：state.db 正文是 session_mirror 写事件前脱敏对象的**未脱敏源头**；返回原文=读取时刻绕过边界，且是提示注入可利用的外泄面。以现状为准让脱敏零成本——agent 需要对话语境，值必须拿现实核对。反事实测试把真密钥喂进 state.db、断言输出缺席。
- **有界**：40 条 / 600 字/条 / 12000 字总量，offset+has_more 分页，超额请求被钳制；截断是结构化字段（`content_truncated`/`content_total_chars`）不是省略号。
- **落台账 + fail-open**：`session_transcript_reads.jsonl`，report_only 写面已注册，**metadata_retention 已登记**并有 ages-out 测试（注册表自己的注释：unregistered ledger grows without bound）。
- **读不设 owner 门**：读不写永久层 → 不产生 owner 决策（两行决策表）。

**三方互认**：标记文本写明动词（`原始会话 <id> 可用 memory_os_session_recall 调取`）、system_prompt_block 新增 **Layered Recall Rule**（注入行是截断摘要、`[片段N/M字]`=截断、高匹配≠完整、取回后**以现实为准**）、工具 description 教自己的边界。

## 顾问预检三项（已处置）

1. **gateway 常驻进程**：`oneshot.py` 进程内导入 AIAgent → provider 模块被缓存持有。**交互路径吃到新代码需 gateway 重启**（systemd 心跳/cron 是新进程不受影响）。部署报告如实写"重启后生效"。
2. **脱敏部署后实测**：对真实含凭证会话跑取回、断言真值缺席（对齐 #58 标准）。
3. **复测口径**：截断计数同时数 `...` 与 `[片段`。

## 测试与门

**3387 passed / 13 skipped**（+19）。四静态门全绿。层1 反事实 8 项 revert→FAIL→restore→PASS；唯一双向通过的是钉"FTS 模式不变"的守卫，本该如此。
