### PR TITLE
图谱注入位关系感知：语义边优先于同源共现

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -5966,3 +5966,32 @@ transcript 10）。四静态门全绿。层1 反事实 8 项 revert→FAIL→res
   应答段放宽）+ 分层深入读半边 `memory_os_session_recall`（脱敏/有界/台账/
   无 owner 门）+ 三方互认（标记点名工具、说明书教协议、description 教边界）；
   双 home 部署复测 floor 归零、标记上线、脱敏实测咬住；全量 3387/13。
+
+### CS — 图谱注入位关系感知：语义边优先于同源共现（2026-08-14，PR #61）
+
+owner 反馈图谱注入"还没活起来"。shadow 账本量化（main，376 行 8847 条边
+决策）三个成因：①**59% 产出是已列出存根**（emitted_stub 1223 >
+emitted_full 844）——结晶 floor 20 条把 `seen` 塞满，图谱邻居全被降级；
+**CR 的 floor 修复已顺带解决**（复测 5 行 4 全预览）。②**边池 79% 是
+co_occurs**（6967/8847）：同一场会话抽取物互连，语义弱但出生权重高
+（均值 0.7+），纯权重排序把 6 个 exploit 位全给它们；真正有价值的语义边
+（refines/evidence_for/contradicts/depends_on 合计 21%）抢不到位。
+③锚点预览「相关记忆」泛化标签=被 resolver 驱逐记录的 index 残行——登记
+观察不动。
+
+**修复（②，选择侧不碰出生/权重/反馈闭环——2026-08-06 裁定）**：exploit 位
+语义边优先按权重占位，co_occurs 只填语义稀缺剩下的位；explore 轮转保持
+类型盲（反饿死不变）。0.50 的 refines 现在能挤掉 0.90 的 co_occurs。
+
+**注入模块自动匹配普查**（owner 问）：Indexed(FTS5)/结晶(FTS+向量+floor
+按分)/候选(#58 按查询打分+同义词)/图谱(锚点来自查询 FTS)全部查询驱动；
+**故意不按查询**的只有事件段（连续性）与 Overlay（任务状态）。
+
+**gateway 已由 owner 重启**：main 自查报告可见 Layered Recall Rule 注入，
+#58/#59/#60 交互路径实证生效。报告另暴露一个新发现登记待诊断：main
+profile 的**自指污染**——建造期元讨论（架构/治理/测试）充满记忆库，FTS
+什么查询都命中它们；sannai 无此问题，属建造期遗产非机制缺陷，先测量占比
+再定治理。
+
+**测试计数**：3387 → **3390 passed** / 13 skipped（+3）；反事实
+revert→2 FAIL→restore→PASS（语义稀缺守卫双向通过，钉不变路径）。

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -2196,6 +2196,20 @@ GRAPH_MAX_LINES = 8
 GRAPH_EDGE_CANDIDATE_LIMIT = 32
 GRAPH_EXPLOIT_SLOTS = 6
 GRAPH_EXPLORE_SLOTS = 2
+# Semantic relations outrank co-occurrence at injection-slot selection.
+# Measured on production main (8847 edge decisions in the shadow ledger):
+# co_occurs is 79% of the candidate pool with high birth weights (avg 0.7+),
+# so weight-only sorting filled all six exploit slots with same-session
+# co-occurrence — the weakest relation ("extracted from the same session" is
+# not "semantically related") — while refines / evidence_for / contradicts /
+# depends_on (21% of the pool, the edges that carry the graph's actual
+# value) rarely got a slot. This is selection-side only: edge birth, weights
+# and the feedback loop are untouched (2026-08-06 owner ruling); co_occurs
+# still fills whatever exploit slots semantic scarcity leaves empty, and the
+# explore rotation stays type-blind so no class can be starved out entirely.
+_GRAPH_SEMANTIC_RELATIONS = frozenset(
+    {"refines", "evidence_for", "contradicts", "depends_on"}
+)
 GRAPH_ANCHOR_PREVIEW_CHARS = 12
 # 跨段去重命中的短预览长度:是结晶段同一正文 220 字符裁剪的精确前缀,
 # 对阅读方 LLM 是零歧义对齐键(比 record_id 可靠——其它区段不显示 id)。
@@ -2469,8 +2483,21 @@ def _render_graph_layer_lines(
     # invalidated_never_hit 计数验证轮转覆盖。
     workable.sort(key=lambda item: -item["weight"])
     if len(workable) > GRAPH_EXPLOIT_SLOTS + GRAPH_EXPLORE_SLOTS:
-        exploit = workable[:GRAPH_EXPLOIT_SLOTS]
-        remainder = workable[GRAPH_EXPLOIT_SLOTS:]
+        # Relation-aware exploit fill (see _GRAPH_SEMANTIC_RELATIONS):
+        # semantic edges claim exploit slots first (weight order within the
+        # class preserved by the stable sort above); co_occurs fills only the
+        # slots semantic scarcity leaves empty.
+        semantic = [
+            item for item in workable
+            if str(item["edge"].get("relation_type") or "") in _GRAPH_SEMANTIC_RELATIONS
+        ]
+        co_occurrence = [
+            item for item in workable
+            if str(item["edge"].get("relation_type") or "") not in _GRAPH_SEMANTIC_RELATIONS
+        ]
+        exploit = (semantic + co_occurrence)[:GRAPH_EXPLOIT_SLOTS]
+        exploit_marks = {id(item) for item in exploit}
+        remainder = [item for item in workable if id(item) not in exploit_marks]
         if day_ordinal is None:
             day_ordinal = datetime.now(timezone.utc).date().toordinal()
 

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -2558,3 +2558,124 @@ def test_w1_pair_debias_unedged_records_first(tmp_path):
         "with max_pairs=1 the single examined pair must be the unedged records "
         f"(new_c,new_d); got result={result}"
     )
+
+
+# ── 关系感知注入位(2026-08-14):语义边优先于同源共现 ─────────────────────────
+
+
+def _slot_edge(edge_id, from_id, to_id, relation, weight):
+    return {
+        "edge_id": edge_id,
+        "from_record_type": "crystallized_record",
+        "from_record_id": from_id,
+        "to_record_type": "crystallized_record",
+        "to_record_id": to_id,
+        "relation_type": relation,
+        "weight": weight,
+        "state": "active",
+    }
+
+
+def _slot_store(tmp_path, neighbor_count):
+    """真实 producer 造 1 锚点 + N 邻居,返回 (store, anchor_id, [neighbor_ids])。"""
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    anchor = _write_cry_record(
+        store, body="锚点记录:关系感知注入位测试", candidate_id="cand-slot-anchor",
+        file_name="slot_anchor.md",
+    )
+    neighbors = [
+        _write_cry_record(
+            store,
+            body=f"邻居记录 {i}:内容各不相同便于断言 NEIGHBOR_MARK_{i}",
+            candidate_id=f"cand-slot-n{i}",
+            file_name=f"slot_n{i}.md",
+        )
+        for i in range(neighbor_count)
+    ]
+    return store, anchor, neighbors
+
+
+def test_semantic_edges_claim_exploit_slots_before_heavier_co_occurs(tmp_path):
+    """生产测量的反事实:边池 79% 是高权重 co_occurs,纯权重排序把 6 个
+    exploit 位全给它们,语义边(21%,图谱的真正价值)抢不到位。修复后语义边
+    先占位——一条 0.50 的 refines 必须挤掉 0.90 的 co_occurs。"""
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
+
+    store, anchor, neighbors = _slot_store(tmp_path, 10)
+    # 8 条高权重 co_occurs + 2 条低权重语义边 → 溢出触发切位。
+    edges = [
+        _slot_edge(f"co-{i}", anchor, neighbors[i], "co_occurs", 0.90 - i * 0.01)
+        for i in range(8)
+    ] + [
+        _slot_edge("sem-refines", anchor, neighbors[8], "refines", 0.50),
+        _slot_edge("sem-evidence", anchor, neighbors[9], "evidence_for", 0.45),
+    ]
+
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[anchor], seen=set(),
+    )
+
+    injected = {
+        str(d["edge"]["edge_id"]) for d in decisions if d.get("injected")
+    }
+    assert "sem-refines" in injected and "sem-evidence" in injected, (
+        f"semantic edges lost their exploit slots to co_occurs: {sorted(injected)}"
+    )
+    joined = "\n".join(lines)
+    assert "NEIGHBOR_MARK_8" in joined and "NEIGHBOR_MARK_9" in joined
+
+
+def test_co_occurs_still_fills_when_semantic_edges_are_scarce(tmp_path):
+    """语义稀缺时 co_occurs 照常填满 exploit 位——不是禁令,是排序。"""
+    from plugins.memory.memory_os.prefetch import _render_graph_layer_lines
+
+    store, anchor, neighbors = _slot_store(tmp_path, 10)
+    edges = [
+        _slot_edge(f"co-{i}", anchor, neighbors[i], "co_occurs", 0.90 - i * 0.01)
+        for i in range(10)
+    ]
+
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[anchor], seen=set(),
+    )
+
+    injected = [d for d in decisions if d.get("injected")]
+    assert len(injected) == 8  # 6 exploit + 2 explore, all co_occurs
+    assert len(lines) == 8
+
+
+def test_explore_rotation_stays_type_blind(tmp_path):
+    """探索位轮转不看关系类型——反饿死语义不变:落选的 co_occurs 仍能通过
+    当日轮转拿到 explore 位。用固定 day_ordinal 保证确定性。"""
+    from plugins.memory.memory_os.prefetch import (
+        GRAPH_EXPLOIT_SLOTS,
+        GRAPH_EXPLORE_SLOTS,
+        _render_graph_layer_lines,
+    )
+
+    store, anchor, neighbors = _slot_store(tmp_path, 10)
+    # 6 条语义边占满 exploit 位,4 条 co_occurs 只能竞争 2 个 explore 位。
+    edges = [
+        _slot_edge(f"sem-{i}", anchor, neighbors[i], "refines", 0.80 - i * 0.01)
+        for i in range(6)
+    ] + [
+        _slot_edge(f"co-{i}", anchor, neighbors[6 + i], "co_occurs", 0.95)
+        for i in range(4)
+    ]
+
+    lines, decisions = _render_graph_layer_lines(
+        store, edges, anchor_ids=[anchor], seen=set(), day_ordinal=738000,
+    )
+
+    injected = {str(d["edge"]["edge_id"]) for d in decisions if d.get("injected")}
+    semantic_injected = {e for e in injected if e.startswith("sem-")}
+    co_injected = {e for e in injected if e.startswith("co-")}
+    assert len(semantic_injected) == GRAPH_EXPLOIT_SLOTS
+    assert len(co_injected) == GRAPH_EXPLORE_SLOTS, (
+        f"explore rotation must stay open to co_occurs: {sorted(injected)}"
+    )


### PR DESCRIPTION
## 成因(shadow 账本量化,main 8847 条边决策)

边池 **79% 是 co_occurs**(同会话抽取物互连,语义弱但出生权重高,均值 0.7+),纯权重排序把 6 个 exploit 位全给它们;真正有价值的语义边(refines/evidence_for/contradicts/depends_on,合计 21%)抢不到位。另 59% 产出是「已列出」存根的问题已被 #60 的 floor 修复顺带解决(复测 5 行 4 全预览)。

## 修复

**选择侧**改动,不碰出生/权重/反馈闭环(2026-08-06 owner 裁定):exploit 位语义边优先按权重占位,co_occurs 只填语义稀缺剩下的位;explore 轮转保持类型盲(反饿死不变)。0.50 的 refines 现在能挤掉 0.90 的 co_occurs。

## 测试

3390 passed / 13 skipped(+3)。反事实 revert→2 FAIL→restore→PASS;语义稀缺守卫双向通过(钉不变路径)。四静态门全绿。