### PR TITLE
注入构成测量 + 簿记潮防挤占(continuity 补位过滤)

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -5995,3 +5995,36 @@ profile 的**自指污染**——建造期元讨论（架构/治理/测试）充
 
 **测试计数**：3387 → **3390 passed** / 13 skipped（+3）；反事实
 revert→2 FAIL→restore→PASS（语义稀缺守卫双向通过，钉不变路径）。
+
+### CT — 注入构成测量 + 簿记潮防挤占（2026-08-14，PR #62）
+
+owner 转来 main 自查报告，要求深挖是否有高收益优化。按 8 条代表性查询
+（7 现实 + 1 元）电池实测 main 注入构成（46017 字）：
+
+- **meta 自指内容 = 32%（下界）**：问 GTX 960 驱动也有 28% 是记忆系统自谈。
+  载体：Indexed 50%、Working 82%、候选段 40%、Related 44%。
+  问记忆系统本身时 49% = **正确**——所以按查询区分，不能对内容一刀切降权。
+- **治理簿记 = 6%**，其中 bridge 的 2 席是**钉了测试的设计**
+  （state/governance 各 1 行跨 lane 感知）——不动；真暴露面是**全局补位**：
+  近期事件窗 883 条中簿记 ~40%（一次清仓周期发 158 条 resolver_approved +
+  118 条 invalidated），纯 recency 补位会被一次潮水淹没。
+- **候选队列 85/153（56%）是元讨论**——但抽查含真偏好（"审批闭环走主会话
+  推送"是 owner 真实偏好），**不能机器一刀切，移交 owner 批量审查**
+  （reject_candidate_cluster 本日已修复可用）。
+
+**探针工件第 4 例（当场自抓）**：首版分类器把候选段测成 100% meta——行的
+**结构前缀** "- candidate only / review candidate..." 自带 "candidate" 词。
+修法：剥结构前缀再分类 + 收紧到高精度词表。44%→32%，按下界报。
+
+**机制修复（本 PR）**：`_select_continuity_events` 全局补位排除簿记 kind
+（`governance_*`/`state_source_*`/`session_fact_extracted`/`session_observed`）。
+种子席原样保留（钉住的桥设计不动）；**fail-open**：未知 kind 永不隐藏——
+隐藏须显式进名单，生产者词表漂移的后果是"新 kind 出现"而非"消失"（CC 教训
+反相到安全侧）。反事实：还原→对话回合被 20 条 resolver 潮挤光→FAIL。
+
+**放弃的优化（记录否决理由）**：候选注入去重——PAT 对是互补事实（一条
+helper=store 配置、一条 push 验证），算法合并丢信息，收益不抵风险。
+
+**移交 owner 的高收益项**：①候选队列元讨论批量审查（85 条，digest 簇拒绝）；
+②Indexed 50% meta 属数据存量（5-6 月建造期事件被 FTS 正当命中），机制侧无
+安全改法，随 owner 清淤与时间自然稀释。

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -58,6 +58,33 @@ _BRIDGE_SEED_SLOTS = {
 
 _MAX_CONTINUITY_RECORDS = 8
 
+# Bookkeeping event kinds are excluded from the selector's GLOBAL recency
+# fill — and only from the fill. The seeded slots above stay untouched: one
+# state_source line and one governance line per bridge is a pinned design
+# (test_prefetch_continuity_selector_preserves_bridge_seed_events) giving the
+# agent cross-lane awareness. The fill is a different animal: production's
+# recent event window carries bursts of producer bookkeeping (a clearance
+# cycle emitted 158 governance_resolver_approved + 118 _invalidated events),
+# and a pure-recency fill lets one burst crowd every conversation turn out of
+# Recent Event Summaries. Fail-open by construction: an UNKNOWN kind is never
+# hidden — hiding requires opting into this list, so producer-vocabulary
+# drift shows new kinds instead of losing them (the CC lesson, inverted to
+# the safe side).
+_BOOKKEEPING_FILL_KIND_MARKERS = (
+    "governance_",
+    "state_source_",
+    "session_fact_extracted",
+    "session_observed",
+)
+
+
+def _is_bookkeeping_event_kind(event: Any) -> bool:
+    kind = str(getattr(event, "kind", "") or "").lower()
+    return any(
+        kind == marker or kind.startswith(marker)
+        for marker in _BOOKKEEPING_FILL_KIND_MARKERS
+    )
+
 _DIAGNOSTIC_QUERY_PATTERNS = (
     re.compile(r"(当前|现在|目前|当前的).{0,12}记忆.{0,8}(架构|系统|后端|provider|提供商|状态)"),
     re.compile(r"当前.*(memory_os|memory-os|记忆|memory).*(状态|架构|系统|provider|backend)", re.I),
@@ -3044,7 +3071,11 @@ def _select_continuity_events(
             selected.append(event)
             selected_ids.add(event.id)
 
-    remaining = [event for event in events if event.id not in selected_ids]
+    remaining = [
+        event
+        for event in events
+        if event.id not in selected_ids and not _is_bookkeeping_event_kind(event)
+    ]
     for event in sorted(remaining, key=_global_sort_key, reverse=True):
         if len(selected) >= _MAX_CONTINUITY_RECORDS:
             break

--- a/tests/plugins/memory/test_memory_os_injection_honesty.py
+++ b/tests/plugins/memory/test_memory_os_injection_honesty.py
@@ -229,6 +229,83 @@ def test_truncated_candidate_line_says_so(tmp_path):
     assert "以现状为准" in lines[0]
 
 
+def test_bookkeeping_burst_cannot_crowd_conversation_out_of_recency_fill(tmp_path):
+    """Production shape: a clearance cycle emitted 158 governance_resolver_
+    approved + 118 _invalidated events in one window. The selector's global
+    recency fill is pure-recency, so one burst crowded every conversation
+    turn out of Recent Event Summaries. Bookkeeping kinds are excluded from
+    the FILL only — the seeded one-line state/governance slots are pinned
+    design and must keep working."""
+    from plugins.memory.memory_os.fixtures import build_event
+    from plugins.memory.memory_os.prefetch import _event_lines
+    from plugins.memory.memory_os.store import EventEnvelope
+
+    store = _store(tmp_path)
+    for i in range(3):
+        store.append_event(EventEnvelope.from_dict({
+            **build_event(seed=700 + i, profile="memoryos-test"),
+            "ts": f"2026-08-14T07:{i:02d}:00+00:00",
+            "source": "telegram",
+            "kind": "conversation_turn",
+            "summary": f"CONV_MARKER_{i} 用户和助手的真实对话回合。",
+        }))
+    # Newer burst of resolver bookkeeping (would win every recency slot).
+    for i in range(20):
+        store.append_event(EventEnvelope.from_dict({
+            **build_event(seed=800 + i, profile="memoryos-test"),
+            "ts": f"2026-08-14T09:{i:02d}:00+00:00",
+            "source": "governance_feedback",
+            "kind": "governance_resolver_approved",
+            "summary": f"Resolver approved crystallized record cand_{i:04d}",
+            # Classify as the governance source class for real (the fixture's
+            # default safe_ref.source_module would classify as foreground).
+            "safe_ref": {"source_module": "evidence_scoring"},
+        }))
+
+    lines = _event_lines(store, session_id="", seen=set(), source_ids=[])
+    joined = "\n".join(lines)
+
+    for i in range(3):
+        assert f"CONV_MARKER_{i}" in joined, (
+            f"conversation turn {i} crowded out by bookkeeping burst:\n{joined}"
+        )
+    # The flood is capped at the ONE seeded governance slot (cross-lane
+    # awareness, pinned by the bridge-seed test). Whether that single line
+    # renders is up to the pre-existing diagnostic-style render filter —
+    # what this change guarantees is that the fill contributes ZERO extras.
+    assert joined.count("Resolver approved") <= 1, joined
+    from plugins.memory.memory_os.prefetch import _select_continuity_events
+
+    selected, _dropped = _select_continuity_events(store)
+    governance_selected = [
+        e for e in selected if str(getattr(e, "kind", "")).startswith("governance_")
+    ]
+    assert len(governance_selected) == 1, (
+        f"fill leaked bookkeeping past the seeded slot: {len(governance_selected)}"
+    )
+
+
+def test_unknown_event_kind_is_never_hidden(tmp_path):
+    """Fail-open: hiding requires opting into the marker list, so a new
+    producer kind surfaces instead of vanishing (vocabulary-drift guard,
+    inverted to the safe side)."""
+    from plugins.memory.memory_os.fixtures import build_event
+    from plugins.memory.memory_os.prefetch import _event_lines
+    from plugins.memory.memory_os.store import EventEnvelope
+
+    store = _store(tmp_path)
+    store.append_event(EventEnvelope.from_dict({
+        **build_event(seed=900, profile="memoryos-test"),
+        "source": "telegram",
+        "kind": "totally_new_producer_kind",
+        "summary": "NEW_KIND_MARKER something a future lane wrote.",
+    }))
+
+    lines = _event_lines(store, session_id="", seen=set(), source_ids=[])
+
+    assert any("NEW_KIND_MARKER" in ln for ln in lines)
+
+
 def test_event_summary_is_injected_whole(tmp_path):
     """sync_turn stores at most ~296 chars; the old second clip at 220 was
     pure loss. At 320 the stored summary must appear complete."""


### PR DESCRIPTION
## 测量(main,8 条代表性查询电池,46017 字)

- **meta 自指 = 32%(下界)**:问 GTX 960 驱动也有 28% 是记忆系统自谈(Indexed 50%/Working 82%/候选 40%);问记忆系统时 49% = 正确,故不能对内容一刀切降权。
- **治理簿记 = 6%**:bridge 2 席是钉了测试的设计(不动);真暴露面是**全局补位**——近期事件窗 ~40% 簿记,一次清仓周期发 276 条 resolver 事件,纯 recency 补位被一次潮水淹没。
- **候选队列 85/153(56%)元讨论**,但混有真偏好 → 移交 owner 批量簇拒绝(本日修复的 reject_candidate_cluster)。
- 探针工件第 4 例当场自抓:首版分类器被行结构前缀的 'candidate' 一词污染,测出 100% meta 假象;剥前缀+高精度词表后 44%→32%。

## 修复

`_select_continuity_events` **全局补位**排除簿记 kind(`governance_*`/`state_source_*`/`session_fact_extracted`/`session_observed`)。种子席原样(钉住的桥设计);**fail-open**:未知 kind 永不隐藏,词表漂移的后果是新 kind 出现而非消失。

## 否决记录

候选注入去重:PAT 对是互补事实,合并丢信息,不做。

## 测试

3392/13(+2);反事实:还原→resolver 潮把对话回合挤光→FAIL。四门全绿。