### PR TITLE
候选自动闭环饿死洞修复：14 天 stale TTL 对关键词候选结构性不可达

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -6040,3 +6040,40 @@ helper=store 配置、一条 push 验证），算法合并丢信息，收益不�
   或声明混杂）。
 - 遗留观察登记：镜像事件 ts=导入时刻而非原会话时刻的语义问题——排水结束后
   评估是否需要 original_ts 参与 recency 排序。
+
+### CU — 候选自动闭环饿死洞：14 天 stale TTL 结构性不可达（2026-08-14，PR #63）
+
+owner 问"元讨论候选不是有自动闭环吗"——**有，且被一个饿死洞废掉了**。
+
+**生命周期机制全景（存在且完整）**：5 生产者（心跳/session_fact_extraction/
+inner_drive/v3_outlet/CLI）；3 晋升通道（关键词聚簇→resolver 判定栈→
+provisional；fact_judge durable 单条直通；owner 批准→永久）；6 条自动消失路
+（拒绝阈值/3 天 TTL/owner_eligible 14 天 stale TTL/fleeting/近重 absorbed/
+与永久近重 demoted）+ 终态即归档 + 进召回排除。
+
+**缺陷**：流水线 `拒绝→晋升→老化→fleeting` 共用单轮 processed 集，而
+`min_cluster_size` 默认 1——**凡带信号关键词的候选每轮被晋升阶段先占**
+（resolver 不批就写 owner_eligible 继续等），老化阶段永远轮不到 → 14 天
+TTL 结构性不可达。**代码 406 行注释明写设计意图"promoted 候选留在 pending
+好让 _demote_aged 重估 stale owner_eligible"——代码违背自己的注释**。
+生产坐实：8/8 条前八月候选（66–98 天）全部 clustered、每轮
+promote→owner_eligible；85 条元讨论候选全是关键词富集型——正好全体豁免。
+老化只对无关键词闲聊生效过。
+
+**修复（外科手术，非全量调序）**：`_demote_aged` 加
+`stale_owner_eligible_only`（默认 False 保旧行为），run_once 在晋升**前**
+先跑 14 天 stale 专段；**3 天无 triage 分支留在晋升后原位**——放前面会误杀
+resolver 从未评估过的积压候选（有测试钉住这条否决理由）。结果新增
+`stale_owner_eligible_demoted_count`，`demoted_count` 聚合含 stale 份额。
+
+**fact_judge 核对（owner 记忆确认）**：owner 记得的"LLM 帮审批"= fact_judge
+（在跑：919 判决/465 durable=True，晋升侧辅助）；消失侧按设计无 LLM（A5）。
+8 条不死候选 fact_judge 全判 durable=False——LLM 没背书、resolver 56 轮没
+批、owner 67 天没动，清扫正是给它们的。durable=True 候选走直通道已转
+provisional 出队不受影响；候选层是晋升管道，事实本体仍在事件层可被 indexed
+召回。任务 #18（session_mirror LLM 辅助审批）核对后关闭：#58 范围退休已
+取消整个审批环节。
+
+**测试**：3 条 run_once 级新测试（stale 20 天→当轮 demote+compact 出队；
+2 天年轻→不动；4 天无 triage 积压→仍先到 resolver）。反事实
+revert→3 FAIL（KeyError 证明旧代码无此通路）→restore→PASS。

--- a/plugins/modules/governance/candidate_aggregation.py
+++ b/plugins/modules/governance/candidate_aggregation.py
@@ -434,6 +434,12 @@ def run_candidate_aggregation_lane(
     processed_ids: set[str] = set()
 
     rejected_results = _auto_demote_rejected(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records)
+    # The 14-day stale-owner_eligible sweep runs BEFORE promote so the
+    # promote stage cannot re-claim (and thereby age-exempt) keyword-rich
+    # candidates every run — see _demote_aged's docstring for the measured
+    # starvation hole this closes. The full aged pass (3-day no-triage
+    # branch) stays after promote, unchanged.
+    stale_results = _demote_aged(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records, stale_owner_eligible_only=True)
     promote_results = _cluster_and_promote(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, error_records=candidate_error_records)
     demote_results = _demote_aged(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records)
     fleeting_results = _tag_fleeting(pending, store, processed_ids, envelope_id=execution_gate_envelope_id, now=_now, triage_records=triage_records)
@@ -492,7 +498,11 @@ def run_candidate_aggregation_lane(
         "promoted_count": promote_results["promoted_count"],
         "promoted_clusters": promote_results["clusters"],
         "rejected_demoted_count": rejected_results["rejected_demoted_count"],
-        "demoted_count": demote_results["demoted_count"],
+        # Aggregate keeps its historical meaning (all age-driven demotions
+        # this run); the stale share is also reported on its own so the
+        # starvation fix is observable per run.
+        "demoted_count": demote_results["demoted_count"] + stale_results["demoted_count"],
+        "stale_owner_eligible_demoted_count": stale_results["demoted_count"],
         "fleeting_count": fleeting_results["fleeting_count"],
         "compacted_count": compact_count,
         "action": "candidate_aggregation_tick",
@@ -1150,6 +1160,7 @@ def _demote_aged(
     now: datetime | None = None,
     ttl_seconds: int = CANDIDATE_DEMOTE_TTL_SECONDS,
     triage_records: list[dict[str, Any]] | None = None,
+    stale_owner_eligible_only: bool = False,
 ) -> dict[str, Any]:
     """Auto-demote candidates past TTL with no triage action.
 
@@ -1160,6 +1171,22 @@ def _demote_aged(
 
     Owner_eligible candidates get a longer stale TTL (14 days) to give
     the owner time to process them before auto-demotion.
+
+    ``stale_owner_eligible_only=True`` runs ONLY the 14-day stale sweep and
+    exists because of a measured starvation hole: run order used to be
+    rejected → promote → aged over one shared processed set, and any
+    candidate with a signal keyword (min_cluster_size defaults to 1, so a
+    singleton clusters too) was re-claimed by the promote stage EVERY run —
+    resolver declines it, writes owner_eligible again, marks it processed —
+    and the aged stage never saw it. The 14-day TTL was structurally
+    unreachable for exactly the noisiest class (near-duplicate build-era
+    meta candidates are keyword-rich by nature). Production proof: all 8
+    pre-August queue rows, 66–98 days old, each with a promote→owner_eligible
+    triage row per run. The stale sweep therefore runs BEFORE promote — 14
+    days means the resolver already declined ~56 runs and the owner never
+    acted — while the 3-day no-triage branch deliberately stays AFTER
+    promote, because running it first would demote backlogged candidates the
+    resolver has never evaluated.
     """
     _now = now or datetime.now(timezone.utc)
     demoted_count = 0
@@ -1170,6 +1197,8 @@ def _demote_aged(
             continue
         effective = resolve_candidate_effective_state(c, _triage)
         if effective in _TERMINAL_STATES:
+            continue
+        if stale_owner_eligible_only and effective != "owner_eligible":
             continue
         age = _candidate_age_seconds(c.created_at, _now)
 

--- a/tests/plugins/memory/test_candidate_aggregation_pipeline.py
+++ b/tests/plugins/memory/test_candidate_aggregation_pipeline.py
@@ -200,3 +200,158 @@ def test_rejection_count_dataclass_field():
 
     c_default = _candidate("cand-default", body="记住：规则1")
     assert c_default.rejection_count == 0
+
+
+# ── 14-day stale TTL vs the promote shield (starvation hole, 2026-08-14) ────
+#
+# Production proof of the hole: all 8 pre-August queue rows (66–98 days old)
+# carried one promote→owner_eligible triage row per run — the promote stage
+# re-claimed every keyword-rich candidate each run before _demote_aged could
+# see it, making the 14-day stale TTL structurally unreachable. run_once's
+# own comment ("Promoted candidates remain in pending so _demote_aged can
+# re-evaluate stale owner_eligible ones") documented the intent the stage
+# order defeated.
+
+
+def _stale_owner_eligible_candidate(store, candidate_id, *, days_old):
+    """Real-producer setup: an appended candidate plus a genuine
+    promote→owner_eligible triage row, aged past the stale TTL."""
+    from datetime import timedelta
+
+    from plugins.memory.memory_os.crystallized import (
+        append_candidate_queue,
+        append_candidate_triage,
+    )
+
+    now = datetime.now(timezone.utc)
+    created = (now - timedelta(days=days_old)).isoformat().replace("+00:00", "Z")
+    candidate = _candidate(
+        candidate_id,
+        body="记住：Memory-OS 的部署配置讨论,关键词富集必然成簇的建造期元讨论。",
+        created_at=created,
+    )
+    append_candidate_queue(store, candidate)
+    append_candidate_triage(
+        store,
+        candidate_id=candidate_id,
+        action="promote",
+        target_state="owner_eligible",
+        reason="cluster match (test fixture, resolver declined)",
+        cluster_key="moment:记住",
+        cluster_size=2,
+        execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        now=now - timedelta(days=days_old),
+    )
+    return candidate
+
+
+def test_stale_owner_eligible_candidate_finally_ages_out_through_run_once(tmp_path):
+    """The counterfactual for the starvation fix: with the old stage order
+    (promote before aged) this candidate is re-claimed by promote every run
+    and stays owner_eligible forever; with the stale sweep running first it
+    must come out of run_once demoted."""
+    from plugins.memory.memory_os.crystallized import resolve_candidate_effective_state
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    _stale_owner_eligible_candidate(store, "cand-stale-20d", days_old=20)
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    assert result["stale_owner_eligible_demoted_count"] == 1, result
+    assert result["demoted_count"] >= 1
+    triage_rows = []
+    triage_path = store.roots.crystallized_root / "candidate_triage.jsonl"
+    for line in triage_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            triage_rows.append(json.loads(line))
+    stale_demotes = [
+        row for row in triage_rows
+        if row.get("candidate_id") == "cand-stale-20d"
+        and row.get("action") == "demote"
+        and "stale owner_eligible" in str(row.get("reason") or "")
+    ]
+    assert stale_demotes, (
+        "no stale-owner_eligible demote triage row — the promote stage "
+        f"re-claimed it before the stale sweep. triage={triage_rows}"
+    )
+    # The full loop closes in the SAME run: demoted → compacted out of the
+    # live queue immediately (terminal states are archived at once).
+    from plugins.memory.memory_os.crystallized import read_candidate_queue
+
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-stale-20d" not in live_ids, "demoted candidate not compacted"
+
+
+def _stale_candidate_from_queue(store, candidate_id):
+    from plugins.memory.memory_os.crystallized import read_candidate_queue
+
+    for candidate in read_candidate_queue(store.roots):
+        if candidate.candidate_id == candidate_id:
+            return candidate
+    raise AssertionError(f"{candidate_id} missing from queue")
+
+
+def test_young_owner_eligible_candidate_is_untouched_by_the_stale_sweep(tmp_path):
+    """Two days old: the stale sweep must skip it, and the promote stage
+    keeps owning it (waiting for the owner) — the fix ages out only what the
+    resolver has already declined for 14+ days."""
+    from plugins.memory.memory_os.crystallized import resolve_candidate_effective_state
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    _stale_owner_eligible_candidate(store, "cand-young-2d", days_old=2)
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    assert result["stale_owner_eligible_demoted_count"] == 0, result
+    triage_rows = []
+    triage_path = store.roots.crystallized_root / "candidate_triage.jsonl"
+    for line in triage_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            triage_rows.append(json.loads(line))
+    candidate = _stale_candidate_from_queue(store, "cand-young-2d")
+    effective = resolve_candidate_effective_state(candidate, triage_rows)
+    assert effective == "owner_eligible", effective
+
+
+def test_backlogged_raw_candidate_still_reaches_the_resolver_first(tmp_path):
+    """The reason the fix is NOT a blanket reorder: a 4-day-old candidate
+    with NO triage history must still get the promote stage's evaluation —
+    running the full aged pass before promote would demote backlogged
+    candidates the resolver has never seen."""
+    from datetime import timedelta
+
+    from plugins.memory.memory_os.crystallized import append_candidate_queue
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    now = datetime.now(timezone.utc)
+    created = (now - timedelta(days=4)).isoformat().replace("+00:00", "Z")
+    append_candidate_queue(
+        store,
+        _candidate(
+            "cand-backlog-4d",
+            body="记住：每次都必须备份用户数据,这是不可妥协的规则。",
+            created_at=created,
+        ),
+    )
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    # The promote stage owned it (any promote outcome counts); the stale
+    # sweep must not have touched a candidate with no owner_eligible state.
+    assert result["stale_owner_eligible_demoted_count"] == 0, result
+    assert result["promoted_count"] >= 1, result


### PR DESCRIPTION
## 缺陷(生产 8/8 坐实)

流水线 `拒绝→晋升→老化→fleeting` 共用单轮 processed 集,`min_cluster_size` 默认 1——**凡带信号关键词的候选每轮被晋升阶段先占**(resolver 不批就写 owner_eligible 继续等),老化永远轮不到 → **14 天 stale TTL 结构性不可达**。代码 406 行注释明写设计意图('promoted 候选留在 pending 好让 _demote_aged 重估 stale owner_eligible')——**代码违背自己的注释**。

生产证据:8/8 条前八月候选(66–98 天)全部 clustered、每轮 promote→owner_eligible;fact_judge 全判 durable=False。85 条元讨论候选全是关键词富集型——正好全体豁免于老化。

## 修复(外科手术,非全量调序)

`_demote_aged` 加 `stale_owner_eligible_only`(默认 False 保旧行为),run_once 在晋升**前**跑 14 天 stale 专段;**3 天无 triage 分支留在晋升后原位**——放前面会误杀 resolver 从未评估的积压候选(有测试钉住这条否决理由)。结果新增 `stale_owner_eligible_demoted_count`。

## fact_judge 交互核对(owner 记忆确认)

owner 记得的'LLM 帮审批' = fact_judge(在跑:919 判决/465 durable=True,晋升侧)。durable 单条走直通道出队**不受影响**;清扫只收 LLM 没背书+resolver ~56 轮没批+owner 14 天没动的。降级可逆(归档+召回排除),事实本体仍在事件层可召回。

## 测试

3395/13(+3,run_once 级:20 天 stale 当轮 demote+compact 出队/2 天年轻不动/4 天积压仍先到 resolver)。反事实 revert→3 FAIL→restore→PASS。四门全绿。