### PR TITLE
结晶残影不朽洞修复(B1 驱逐记录挡刀 + B2 compact 视图盲区)

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -6077,3 +6077,27 @@ provisional 出队不受影响；候选层是晋升管道，事实本体仍在�
 **测试**：3 条 run_once 级新测试（stale 20 天→当轮 demote+compact 出队；
 2 天年轻→不动；4 天无 triage 积压→仍先到 resolver）。反事实
 revert→3 FAIL（KeyError 证明旧代码无此通路）→restore→PASS。
+
+#### CU.1 — 洞 B：结晶残影不朽（同批补修，生产 8/8 的真正成因）
+
+部署 CU 后手动跑 lane 验证：`stale_owner_eligible_demoted_count=0`，8 条老
+候选纹丝不动——**它们走的不是饿死洞**。追链发现全部 8 条**都曾被结晶过**
+（各有 1 条结晶记录），命中两个叠加的洞：
+
+- **B1 驱逐记录挡刀**：run_once 前置过滤按"有无结晶记录"排除 pending，
+  **不查活性**——3 条的 provisional 已被 resolver 驱逐（inactive），被驱逐
+  的记录还在替队列行挡刀，任何阶段（含新清扫）永远碰不到。修：过滤只认
+  **active** 记录（`is_active_crystallized_frontmatter`）。
+- **B2 compact 的 triage-only 视图**：5 条 effective=crystallized（terminal、
+  已进召回排除）的行，因最新 triage 还写着 owner_eligible 而被 compact 的
+  triage-only 状态解析当成"owner 还要看"→ 活队列永生。修：
+  `compact_candidate_queue` 增可选 `terminal_candidate_ids`，lane 把它刚为
+  召回排除投影算好的**同一个**完整终态集传入——一个语义一个来源；默认 None
+  保持历史行为（有测试钉住默认不是陷阱）。lane 顺带把完整视图计算提到
+  compact 前、失败记 `candidate_effective_view_failed` 降级 triage-only。
+
+**测试环境暴露的一个既有事实**：conftest autouse 夹具把 resolver gate 桩成
+永远放行，pytest 里年轻候选会被晋升为 provisional——洞 B 修复后其队列行被
+正确归档（好结局），钉"年轻不被清扫"的测试原断言"仍在队列"因此环境依赖；
+改钉真不变量（无 stale 降级 triage 行）。测量教训第 6 例：**断言要钉不变量
+本身，不钉环境合成的下游状态**。

--- a/plugins/memory/memory_os/crystallized.py
+++ b/plugins/memory/memory_os/crystallized.py
@@ -1743,8 +1743,21 @@ def compact_candidate_queue(
     *,
     archive_path: Path | None = None,
     retention_days: int = 7,
+    terminal_candidate_ids: set[str] | None = None,
 ) -> int:
     """Archive-and-compact: move stale candidates to archive file.
+
+    ``terminal_candidate_ids`` (optional) lets the caller pass the FULL
+    terminal view from ``read_effective_candidates`` — which also sees the
+    crystallized-record and owner-action overlays this function's own
+    triage-only resolution cannot. Measured hole (2026-08-14, production):
+    five queue rows whose candidates had been crystallized long ago resolved
+    ``crystallized``/terminal in the full view (and were recall-excluded),
+    but their latest *triage* row still said owner_eligible, so this
+    function kept them in the live queue forever. The aggregation lane
+    passes the same id set it just published as the recall-exclusion
+    projection — one semantics, one source. ``None`` keeps the historical
+    triage-only behavior.
 
     A candidate is 'active' (stays in main file) if:
       - effective state resolves to owner_eligible (owner needs to see it)
@@ -1808,7 +1821,13 @@ def compact_candidate_queue(
             # they stop cluttering the live queue (previously only archived
             # once aged past retention_days, leaving young demoted/fleeting/
             # absorbed in active).
-            if effective == "owner_eligible" or (
+            if terminal_candidate_ids is not None and cand.candidate_id in terminal_candidate_ids:
+                # The full effective view says this candidate is closed
+                # (crystallized / owner_closed / demoted / ...) even if its
+                # latest triage row does not — archive it now.
+                archived.append(line_stripped)
+                archived_count += 1
+            elif effective == "owner_eligible" or (
                 effective not in ("demoted", "fleeting", "absorbed") and age < retention_days * 86400
             ):
                 active.append(line_stripped)

--- a/plugins/modules/governance/candidate_aggregation.py
+++ b/plugins/modules/governance/candidate_aggregation.py
@@ -424,9 +424,20 @@ def run_candidate_aggregation_lane(
     # in owner_approved.md (or any crystallized .md file). Prevents duplicate
     # promotion of already-crystallized memories.
     crystallized_service = CrystallizedMemoryService(store)
+    # Only an ACTIVE crystallized record shields a candidate from the
+    # pipeline. Measured hole (2026-08-14, production): three queue rows
+    # whose provisional records had been resolver-evicted were still
+    # pre-filtered here — an inactive record kept shielding the row, so no
+    # stage (including the stale sweep) could ever reach it, while compact's
+    # triage-only state view kept the row alive: immortal by construction.
+    from plugins.memory.memory_os.crystallized import is_active_crystallized_frontmatter
+
     pending = [
         c for c in pending
-        if not crystallized_service.find_records_by_candidate_id(c.candidate_id)
+        if not any(
+            is_active_crystallized_frontmatter(record.frontmatter)
+            for record in crystallized_service.find_records_by_candidate_id(c.candidate_id)
+        )
     ]
 
     # Shared processed_ids set ensures each candidate is handled by exactly
@@ -449,46 +460,71 @@ def run_candidate_aggregation_lane(
     # Compaction is an all-or-nothing rewrite. If the tolerant reader observed
     # corruption, preserve the queue byte-for-byte and surface the bounded
     # errors instead of allowing a partial archive/replace transaction.
-    compact_count = 0 if candidate_error_records else compact_candidate_queue(
-        store,
-        archive_path=archive,
-        retention_days=7,
-    )
-
-    # Publish the hot-path recall exclusion projection (owner ruling
-    # 2026-08-14: candidates are admitted to recall at candidate authority
-    # without approval, so the owner's reject must actually take effect).
-    # read_effective_candidates is the authority but costs ~61ms on
-    # production — affordable here in an offline lane, never on the per-turn
-    # prefetch path, which reads the small file this publishes instead.
-    # Fail-open by contract: a failure here leaves the previous snapshot (or
-    # none), which degrades to the pre-ruling behavior rather than blanking
-    # candidate recall.
-    recall_exclusion_count = -1
+    # Compute the FULL terminal view once (crystallized-record + owner-action
+    # overlays included) and let it drive BOTH the queue compaction and the
+    # recall-exclusion projection — one semantics, one source. Before this,
+    # compaction resolved state from triage rows alone and kept
+    # crystallized-long-ago rows in the live queue forever (measured: five
+    # production rows, 66–98 days old, recall-excluded yet never archived).
+    # read_effective_candidates costs ~61ms on production — affordable here
+    # in an offline lane, never on the per-turn prefetch path.
+    effective_terminal_ids: set[str] | None = None
+    effective_count = 0
     try:
         effective = read_effective_candidates(store)
-        excluded = {item.candidate.candidate_id for item in effective if item.terminal}
-        write_candidate_recall_exclusions(
-            store,
-            excluded,
-            now=_now,
-            source_counts={
-                "effective_candidates": len(effective),
-                "terminal": len(excluded),
-            },
-        )
-        recall_exclusion_count = len(excluded)
-    except Exception as exc:  # noqa: BLE001 - projection must not break the lane
+        effective_count = len(effective)
+        effective_terminal_ids = {
+            item.candidate.candidate_id for item in effective if item.terminal
+        }
+    except Exception as exc:  # noqa: BLE001 - view failure degrades, never breaks the lane
         candidate_error_records.append(
             build_error_record(
                 component="candidate_aggregation",
-                operation="write_candidate_recall_exclusions",
-                error_code="candidate_recall_exclusion_publish_failed",
+                operation="read_effective_candidates",
+                error_code="candidate_effective_view_failed",
                 severity="warning",
                 recoverable=True,
                 details={"error_type": type(exc).__name__, "message": str(exc)[:200]},
             )
         )
+
+    compact_count = 0 if candidate_error_records else compact_candidate_queue(
+        store,
+        archive_path=archive,
+        retention_days=7,
+        terminal_candidate_ids=effective_terminal_ids,
+    )
+
+    # Publish the hot-path recall exclusion projection (owner ruling
+    # 2026-08-14: candidates are admitted to recall at candidate authority
+    # without approval, so the owner's reject must actually take effect).
+    # Fail-open by contract: a failure here leaves the previous snapshot (or
+    # none), which degrades to the pre-ruling behavior rather than blanking
+    # candidate recall.
+    recall_exclusion_count = -1
+    if effective_terminal_ids is not None:
+        try:
+            write_candidate_recall_exclusions(
+                store,
+                effective_terminal_ids,
+                now=_now,
+                source_counts={
+                    "effective_candidates": effective_count,
+                    "terminal": len(effective_terminal_ids),
+                },
+            )
+            recall_exclusion_count = len(effective_terminal_ids)
+        except Exception as exc:  # noqa: BLE001 - projection must not break the lane
+            candidate_error_records.append(
+                build_error_record(
+                    component="candidate_aggregation",
+                    operation="write_candidate_recall_exclusions",
+                    error_code="candidate_recall_exclusion_publish_failed",
+                    severity="warning",
+                    recoverable=True,
+                    details={"error_type": type(exc).__name__, "message": str(exc)[:200]},
+                )
+            )
 
     result = {
         "candidates_read": len(candidates),

--- a/tests/plugins/memory/test_candidate_aggregation_pipeline.py
+++ b/tests/plugins/memory/test_candidate_aggregation_pipeline.py
@@ -7,6 +7,8 @@ a pre-created execution gate envelope so append_candidate_triage succeeds.
 import json
 from datetime import datetime, timezone
 
+import pytest
+
 from plugins.memory.memory_os.crystallized import (
     CrystallizedCandidate,
 )
@@ -250,7 +252,6 @@ def test_stale_owner_eligible_candidate_finally_ages_out_through_run_once(tmp_pa
     (promote before aged) this candidate is re-claimed by promote every run
     and stays owner_eligible forever; with the stale sweep running first it
     must come out of run_once demoted."""
-    from plugins.memory.memory_os.crystallized import resolve_candidate_effective_state
     from plugins.modules.governance.candidate_aggregation import (
         run_candidate_aggregation_lane,
     )
@@ -300,7 +301,6 @@ def test_young_owner_eligible_candidate_is_untouched_by_the_stale_sweep(tmp_path
     """Two days old: the stale sweep must skip it, and the promote stage
     keeps owning it (waiting for the owner) — the fix ages out only what the
     resolver has already declined for 14+ days."""
-    from plugins.memory.memory_os.crystallized import resolve_candidate_effective_state
     from plugins.modules.governance.candidate_aggregation import (
         run_candidate_aggregation_lane,
     )
@@ -313,14 +313,21 @@ def test_young_owner_eligible_candidate_is_untouched_by_the_stale_sweep(tmp_path
     )
 
     assert result["stale_owner_eligible_demoted_count"] == 0, result
-    triage_rows = []
+    # The pinned invariant is exactly "the stale sweep did not touch it".
+    # What promote does next is environment-dependent (the conftest autouse
+    # stub auto-allows the resolver gate, so under pytest the young candidate
+    # may legitimately crystallize provisionally and leave the queue — a GOOD
+    # outcome; under the real gate it stays owner_eligible). Either way, a
+    # stale-demote triage row for it must not exist.
     triage_path = store.roots.crystallized_root / "candidate_triage.jsonl"
-    for line in triage_path.read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            triage_rows.append(json.loads(line))
-    candidate = _stale_candidate_from_queue(store, "cand-young-2d")
-    effective = resolve_candidate_effective_state(candidate, triage_rows)
-    assert effective == "owner_eligible", effective
+    stale_rows = [
+        json.loads(line)
+        for line in triage_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+        and json.loads(line).get("candidate_id") == "cand-young-2d"
+        and "stale owner_eligible" in str(json.loads(line).get("reason") or "")
+    ]
+    assert stale_rows == [], stale_rows
 
 
 def test_backlogged_raw_candidate_still_reaches_the_resolver_first(tmp_path):
@@ -355,3 +362,109 @@ def test_backlogged_raw_candidate_still_reaches_the_resolver_first(tmp_path):
     # sweep must not have touched a candidate with no owner_eligible state.
     assert result["stale_owner_eligible_demoted_count"] == 0, result
     assert result["promoted_count"] >= 1, result
+
+
+# ── 洞 B：结晶残影不朽 (2026-08-14 生产 8/8 坐实) ───────────────────────────
+#
+# 生产队列的 8 条 66–98 天候选走的不是 promote 饿死洞——它们都曾被结晶过：
+# ① run_once 的前置过滤按"有无结晶记录"把它们排除出 pending（不查活性），
+#   其中 3 条的 provisional 已被 resolver 驱逐——被驱逐的记录还在替队列行
+#   挡刀，任何阶段永远碰不到它；
+# ② compact 用 triage-only 状态视图，看不到结晶 overlay——5 条 effective=
+#   crystallized(terminal、已进召回排除) 的行因最新 triage 还写着
+#   owner_eligible 而在活队列里永生。
+
+
+def _crystallize_candidate(store, candidate, *, provisional):
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import CrystallizedMemoryService
+
+    service = CrystallizedMemoryService(store)
+    decision = ApprovalDecision(
+        candidate_id=candidate.candidate_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="resolver" if provisional else "owner",
+        reviewed_at=datetime.now(timezone.utc).isoformat(),
+        provisional=provisional,
+        expires_at=(
+            datetime.now(timezone.utc).isoformat() if provisional else ""
+        ),
+    )
+    path = service.write_approved_record(
+        candidate, decision, file_name=f"{candidate.candidate_id}.md",
+    )
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("id: "):
+            return service, line.split("id: ", 1)[1].strip()
+    raise AssertionError("record id not found")
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_evicted_provisional_no_longer_shields_the_queue_row(tmp_path):
+    """被驱逐的 provisional 不再替队列行挡刀：候选重回 pending，且因 20 天
+    stale 被当轮清扫降级。反事实：旧前置过滤(不查活性)下它永远不进 pending。"""
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _stale_owner_eligible_candidate(store, "cand-evicted-20d", days_old=20)
+    service, record_id = _crystallize_candidate(store, candidate, provisional=True)
+    service.revoke_record(record_id, revoked_by="resolver", reason="resolver_cap_evicted")
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    assert result["stale_owner_eligible_demoted_count"] == 1, result
+    from plugins.memory.memory_os.crystallized import read_candidate_queue
+
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-evicted-20d" not in live_ids, "evicted-record shield survived"
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_actively_crystallized_row_is_archived_by_the_full_terminal_view(tmp_path):
+    """活跃结晶的候选不进 pending(不得重复晋升)，但其队列行必须被完整终态
+    视图归档、其 id 必须进召回排除集——不再靠 triage-only 视图在活队列永生。"""
+    from plugins.memory.memory_os.crystallized import (
+        read_candidate_queue,
+        read_candidate_recall_exclusions,
+    )
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _stale_owner_eligible_candidate(store, "cand-crystal-old", days_old=60)
+    _crystallize_candidate(store, candidate, provisional=False)
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    # Not re-promoted, not stale-swept (it is closed, not stale):
+    assert result["stale_owner_eligible_demoted_count"] == 0, result
+    assert "cand-crystal-old" in read_candidate_recall_exclusions(store.roots)
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-crystal-old" not in live_ids, (
+        "crystallized-long-ago row still immortal in the live queue"
+    )
+
+
+def test_compact_without_terminal_view_keeps_triage_only_behavior(tmp_path):
+    """默认参数 = 历史行为：不传终态视图时，triage 说 owner_eligible 的行
+    保留在活队列（钉住默认不是陷阱、老调用方行为不变）。"""
+    from plugins.memory.memory_os.crystallized import (
+        compact_candidate_queue,
+        read_candidate_queue,
+    )
+
+    store = _store_with_gate(tmp_path)
+    _stale_owner_eligible_candidate(store, "cand-triage-only", days_old=60)
+
+    archived = compact_candidate_queue(store)
+
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-triage-only" in live_ids
+    assert archived == 0


### PR DESCRIPTION
## 背景

CU(PR #63)部署后手动跑 lane 验证:stale 清扫计数 0,生产 8 条老候选纹丝不动——**它们走的不是饿死洞**:全部 8 条都曾被结晶过。

## 两个叠加的洞

- **B1 驱逐记录挡刀**:run_once 前置过滤按'有无结晶记录'排除 pending,**不查活性**——3 条的 provisional 已被 resolver 驱逐,被驱逐的记录还在替队列行挡刀,任何阶段永远碰不到。修:过滤只认 **active** 记录。
- **B2 compact triage-only 视图盲区**:5 条 effective=crystallized(terminal、已进召回排除)的行因最新 triage 还写着 owner_eligible 而活队列永生。修:`compact_candidate_queue` 增可选 `terminal_candidate_ids`,lane 传入它刚为召回排除投影算好的**同一个**终态集——一个语义一个来源;默认 None 保历史行为(测试钉住)。

## 附带

- lane 完整视图计算提前到 compact 前,失败降级 triage-only 并记 `candidate_effective_view_failed`。
- 年轻候选测试改钉不变量本身(无 stale 降级行),不钉 conftest resolver 桩合成的下游状态。

## 测试

3398/13(+3:驱逐残影重入并被清扫/活跃结晶行被完整视图归档+进排除集/默认参数保持 triage-only 行为)。四门全绿。