### PR TITLE
fix(memory-os): close 20 code-review findings, two Rule-5 sweeps, and the pre-merge review round

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -3930,7 +3930,149 @@ owner 若日后决定静音：把 "Memory State Overlay" 加进
 `SAFE_CASUAL_HEADINGS` 即可。其余 5 WARN 与 CH 部署时相同
 （knob 过期预期告警 + 4 既有家族）。全量 3234 passed / 13 skipped。
 
+## CW — 全项目代码评审 20 项发现的并行修复 + 两轮 Rule-5 扫描（2026-08-15，提交 `85fa2e4`）
+
+`/code-review 整个项目` 产出 20 条发现（15 主 + 5 截断项）。**先逐条对源码复核**，
+再分 15 个文件所有权互不重叠的包并行修复（全部 Sonnet）。复核阶段推翻了子代理
+的 5 处判断，这部分比修复本身更重要——照着错误的触发路径去修会修错东西。
+
+### CW.0 复核阶段的 5 处更正（3 机制 + 2 严重性）
+
+- **router.py:87 的触发路径不成立**：生产传 `live_guard=self._config`（dict，
+  `__init__.py:496`），`_kill_switch_enabled` 走 dict 分支直接返回 bool，checker
+  循环与其 `except` 根本不执行；`config.snapshot_id` 是纯字符串构造。生产接线下
+  `health()` **没有可实现的抛出路径**。降级为"结构不对称值得加固"，仍修。
+- **edge_weight_feedback 游标风险是潜在的**：`metadata_retention.py:145-152` 明写
+  `dry_run: True, executor_wired: False`——"no executor exists anywhere"。今天没有
+  任何东西裁剪那个账本。
+- **candidate_aggregation 的"任何错误→跳过压缩"是既有策略**，不是本次引入：同一个
+  `candidate_error_records` 在 401、454 行已有两个投喂者。真正的新回归窄得多。
+- **#9/#10 entity_index 两条都是潜在缺陷**：`INDEXABLE_ENTITY_CLASSES` 只含
+  `proper_noun`，两个索引写入点都不传 `classes=`，所以现存 entity_index 每行的
+  class/weight 都相同，错源无法显形。（初版报告把 #9 列为"生产上就会咬人"，错。）
+- **cron_group_runner 时区混用是条件性的**：`now` 默认 `datetime.now(timezone.utc)`，
+  只有 `--now`（标注 testing only）传带偏移量的串才成立。
+
+### CW.1 静默失败改为可观测
+
+- **`index._copy_embeddings_from_live` 裸 `pass` 吞掉所有 `sqlite3.Error`**（根因：
+  防止静默清空 embedding 的守卫，自己失败时静默）。无 embedder 重建 + live 库被
+  并发读者短暂锁住 → staging 里 0 行 → 原子替换上线 → 唯一证据是 `status="ok"`、
+  `details={}` 的审计行。现返回封闭 outcome 集（`copied`/`no_live_index`/
+  `live_table_missing`/`copy_failed`）+ live/copied 双向行数，`copy_failed` 另发
+  `component="sqlite"` 的 error_record；`ATTACH DATABASE` 改参数绑定（原来路径含
+  单引号即永久失败），`DETACH` 移入 `finally`（原异常路径泄漏）。
+- **`llm_edge_proposer`**：`float(parsed.get("confidence"))` 无守卫，模型回 `"high"`
+  即抛出 `_call_llm` 并中断整个 pair 循环（部分边已写入、无 summary 无审计）；
+  `batch` 是死旋钮而 docstring 承诺"合并成一次调用（更便宜）"，实际每轮最多 100 次
+  串行 15s 调用；summary 无任何失败计数，"没关系可提"与"连错 100 次"字节相同。
+  现按 `fact_judge` 范式给出 typed failure、删除死旋钮、补齐四类失败计数与
+  `outcome`/`degraded` 状态。
+- **`edge_weight_feedback` 行号游标**：改为"行数 + 旧游标位内容指纹"双判据检测错位；
+  错位时**不重放**（强化 `w += 0.12(1-w)` 非幂等）而是前移并记 `cursor_misaligned`
+  与跳过行数。实测确认修复前纯截断**不会**重复强化，缺陷性质是"静默漏强化"。
+- **解析器契约收敛**：`clearance_cycle` 与 `llm_contradiction_lane` 两处手搓花括号
+  计数器改用 `low_clue_recall._extract_json_object`（CLAUDE.md 指定的解析器）。
+  注意二者**失败模式不同**（计数器怕字符串内未配对花括号，`_extract_json_object`
+  怕结尾散文含 `}`），是交换不是严格更优；同时补 `llm_parse_failed` typed 记录，
+  并加 `isinstance(parsed, dict)` 守卫——`json.loads` 成功但返回列表时
+  `parsed.get()` 会抛 `AttributeError` 杀掉整个 lane。
+
+### CW.2 数据丢失路径
+
+- **provisional-backed 候选被归档后无回流路径**（根因：`read_effective_candidates`
+  把"存在 active 结晶记录"判为 terminal，而 provisional 记录同样带 `candidate_id`
+  且 sweep 前一直是 active）。归档 → provisional TTL 到期失活 → 候选既不在活队列
+  也不在活结晶里；`candidates.archive.jsonl` **全项目无生产读者**。
+  修复：`EffectiveCandidate.provisional_backed` + 归档集与召回排除集**分离**
+  （内容已结晶，仍应排除召回；但不可归档）。**两条通道都堵**：终态分支与按年龄
+  归档的 `elif/else`（后者更易触发，provisional TTL 常长于 7 天保留期）。
+  参数 `provisional_backed_candidate_ids` **必填、无默认值**（规则 4：`None` 会导致
+  数据丢失就不是可选参数）。
+- **压缩跳过语义反转**：初判要求"视图失败仍降级压缩"，缺陷 C 发现后**推翻**——视图
+  不可用时根本不知道谁是 provisional-backed，归档不可逆而队列变长可恢复。三个失败
+  来源（队列解析、聚类阶段、有效视图）现行为一致并记 `compaction_skip_reason`
+  封闭集，接通脚本摘要 → 状态账本 → owner digest 三层读者。
+
+### CW.3 归属覆盖（故意扩大口径）
+
+`"Recent Cross-Session"` 与 `"Recall Facade (unified)"` 都是真实注入 section，却同时
+缺席 `SECTION_SOURCE_CLASS_BY_TITLE` 与 `_budget_keep_priority`，落到 `other` →
+`NON_ATTRIBUTABLE` → 被归属缺口门**永久跳过**。根因是守卫测试的方向：
+`_producer_vocabulary()` 把 map 的 **values** 定义为生产者词汇表，"发射的标题 ⊆ map
+的键"这个方向结构上不可能被测到。现两者都已分类、接 source_ids、给显式预算优先级
+（55 / 58），新增 `recall_facade` 类并同步 `exposure_rollup`，守卫测试改为**用真实
+`build_prefetch` 断言发射标题全部有映射**。facade 侧另发现：原样透传
+`RecallObject.source_ref` 能过宽松检查却挂在 `test_every_attributable_class_has_a_
+recognised_id_prefix`（"填了 ID 但读者认不出"），故做前缀翻译。
+**这会让归属缺口计数上升——是覆盖变对，不是质量变差。**
+
+### CW.4 新增信号接读者（本批出现 4 次的同一形状）
+
+`llm_call_*`、`cursor_*`/`tracked_edge_count`、`edge_provenance.write_failed_count`、
+`compaction_skip_reason` 都被逐键白名单挡在读者之外。全部接通两层并**逐层单独回退**
+证明各自承重；一律 INFO，不新增分级（错位游标不是事故，加 WARN 只会造出没人能处理
+的告警）。审计另发现 `vector_edge_proposer` 压根不产出 `outcome` 与写失败计数——
+生产者缺口，见待办。
+
+### CW.5 execution_gate：保留不变量、只削成本
+
+调查确认 sidecar 的 `completion_count` **不权威**：`complete_execution_gate_envelope`
+先追加日志再单独更新 sidecar，两步非原子，中间被杀会留下"存在但陈旧"的条目（不同于
+缺失条目，不会经 index-miss 自愈）；且 `scripts/memory_os_execution_gate_runner.py::
+_update_sidecar_index` 是**第二个互不协调的写入方**。故 `and not require_unused`
+**保留**并补 30 行"为什么不能删"的注释（点名第二写入方与钉住该不变量的既有测试）。
+只删成功路径上的无条件全量索引重建（改为仅在索引真缺失时重建，保留自愈），
+反测：50 次 resolve 的重建次数 50 → 0。
+
+### CW.6 两轮 Rule-5 时间戳扫描（23 处）
+
+`datetime.fromisoformat("2026-12-31")` 返回 naive，与 aware `now` 比较抛 `TypeError`，
+而 `except ValueError` 接不住。三种破形：只捕 ValueError、try 只包解析而比较在外、
+完全无保护。修 23 处，含**两处每轮 prefetch 热路径**（`_last_session_lines`、
+`_recent_cross_session_lines`）、`audit.py` 完全无保护且喂 CLI 状态、以及
+`scripts/cleanup_expired_working.py`——**它才是真正每日运行的 `working_cleanup`
+cron lane，完全绕开 `WorkingMemoryService`**，不修它则 `working.py` 的修复对生产
+无效。失败方向逐点判定而非统一套用：删除类路径保留条目、decay 类自愈重刷时间戳、
+CLI 参数直接报错。全仓库 **94 个 `fromisoformat` 调用点 / 53 个文件**已全部分类
+（fixed / clean-because-X / 语义警示），无未分类项。
+
+### CW.7 其余
+
+`entity_index.query_related_records` 的 `min(entity_text)` 与 `max(weight)` 是两个
+独立聚合，会把 A 实体的名字配上 B 实体的 class/weight 交给 agent（CTE + `row_number()`
+取唯一获胜行，class 改读权威列，删除浮点带段推导）；`min_weight` 由 HAVING 过滤组
+改为 join 层过滤实体（与 docstring 一致）。`event_stats._build_continuity_selector`
+自称"精确镜像"却漏了 bookkeeping 排除，且三处常量是硬拷贝——改为从 `prefetch` 单源
+导入。`runtime.processed_event_ids_compacted` 被两处硬编码 `False` 致永不可能为真。
+`substrates/router.recall` 的 `health()` 移入 try。脚本侧：`deploy_l3_probe`/
+`l3_probe_helper` 补 `encoding="utf-8"`、`cron_group_runner` 时区归一。
+
+### 反事实覆盖与测试数
+
+每个修复都配 revert→FAIL→restore→PASS **实测**（用 `cp` 备份，禁用
+`git checkout --`/`git stash`——共享工作区有 15 个代理的未提交改动）。两处方法学
+收获：①`event_stats` 的排序修复经 20000 次差分模糊测试证明**当前不可观测**，代理
+拒绝伪造假失败并如实报告；②一次测试追加的 `old_string` 匹配到倒数第二行，把上一个
+测试的末条断言静默并入新测试——**语法合法、测试全绿、全量套件永远抓不到**，只有
+`git diff` 尾部看得见。故整合期增设"测试文件有删除行即人工核对"检查。
+
+**测试数：3408 → 3521 passed（+113），13 skipped，0 failed。** 四道门全绿，
+`git diff --check` 干净，34 源文件 + 24 测试文件，15 个包零越界。
+
 ## 待办
+
+**`vector_edge_proposer` 无 `outcome`、无写失败计数（CW 登记，2026-08-15）。**
+兄弟五个 edge 步骤都产出封闭 `outcome`，只有它没有；写失败也无计数（是生产者缺口，
+不是白名单丢弃，故 CW.4 的接线修不到它）。后果：该 lane 写失败与"没边可提"在任何
+读者处都同貌。需独立立项——加计数要连带决定 `status` 降级语义。
+
+**`timeutil.py` 已存在却几乎无人用（CW 登记，2026-08-15）。**
+仓库里早有 `parse_utc`/`safe_compare`/`age_seconds` 三个正确实现，但仅 3 个文件采用；
+约 25 处（含 CW 本轮新修的若干）各自内联重复同一套归一逻辑。当前状态**正确**，但这
+正是本项目反复付出代价的"同一词汇多份拷贝"漂移形状。收敛需独立评估：批量替换的回归
+面不小，且各点的失败方向**不统一**（删除类保留、decay 类自愈、CLI 报错），不能无脑
+套同一个 helper。
 
 **图谱遗忘潮预期落点：2026-10-06 前后（CJ 登记,2026-08-07）。**
 first_injection_at=2026-08-07 起算 60 天,过密图谱（refines 为主,重归一后
@@ -6204,3 +6346,13 @@ failed**（11:46），四静态门 + `git diff --check` 全绿。
   份副本、compat 探测 resolve 对齐 + 泛化替换 + 单一 spec 源 + 两处虚假
   注释改正、探针去 profile 硬编码、CLAUDE.md 退休键名更新；11 修 2 不动
   1 记录，全量 3408/13。
+
+- `d4bc158..85fa2e4（CW，本节）`：`/code-review 整个项目` 20 项发现逐条复核后
+  15 包并行修复——复核先推翻 5 处判断（router 生产不可复现、retention 无执行器、
+  压缩跳过策略系既有、entity_index 两条皆潜在、cron 时区条件性）；修 embedding
+  静默清空与 ATTACH 注入、llm 判据崩溃与死旋钮、provisional-backed 候选两条归档
+  通道（参数改必填）、压缩跳过语义反转并接三层读者、两个注入 section 的归属黑洞
+  （守卫测试补上"发射标题 ⊆ 映射键"方向）、四类新增信号接读者、execution_gate
+  保留不变量只削成本（50→0 次索引重写）、两轮 Rule-5 时间戳扫描 23 处（含两处
+  prefetch 热路径与真正的 working_cleanup cron lane），94 个 fromisoformat 调用点
+  全部分类；全量 3408→3521 passed（+113）/13 skipped，四门全绿。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4060,6 +4060,77 @@ CLI 参数直接报错。全仓库 **94 个 `fromisoformat` 调用点 / 53 个�
 **测试数：3408 → 3521 passed（+113），13 skipped，0 failed。** 四道门全绿，
 `git diff --check` 干净，34 源文件 + 24 测试文件，15 个包零越界。
 
+## CX — CW 批次的合入前独立评审：10 项发现，8 修 2 拒（2026-08-15）
+
+开 PR 前对分支全量 diff 跑了一轮独立 /code-review（high）。10 项发现全部先对源码
+逐条验证，8 项修复、2 项有据拒绝。**评审抓到了 CW 自己引入或未闭合的真缺陷**，
+证明"修复批次也要被评审"不是仪式。
+
+### 修复的 8 项
+
+- **驱逐转换丢失（最重）**：CW 的 provisional-backed 守卫在**驱逐一 tick 后失效**——
+  `invalidate_provisional_record` 只改 frontmatter 不写 triage 行，effective 冻结在
+  `resolver_approved`，年龄分支照样归档；守卫参数集从当前视图算，驱逐后不再含该
+  候选。修复：retention 分支把 `resolver_approved` 置为 sticky（同 `owner_eligible`）。
+  不朽性已排除：`_demote_aged` 通用清扫 3 天 TTL 会 demote 它 → 正常归档；已确认
+  聚合 lane 三个提升路径只写 `resolver_approved` 一个字面量；terminal 分支先于
+  sticky 检查，确认转正的候选仍归档（回归测试钉住）。
+- **`degraded` 落穿成 `ok`**：CW 给 `run_llm_proposer` 加的 `status="degraded"` 不在
+  `_step_status` 封闭词表，summary 又无 `output`/`reason` 键 → 落到 `return "ok"`——
+  step/cycle 层在"全部调用失败"的运行上恰好报健康，正是该修复要暴露的场景。原测试
+  直调 wrapper 断言内层 dict，绕过了 `_step_status`，故套件抓不到。修复：映射
+  `degraded → warning`（同 `deferred`），原始值仍在透传 dict 里可见。**预期行为
+  变化**：LLM 间歇失败的主机上 `cognitive_loop.last_status` 会开始出现 `warning`
+  （共享 seam 实测 27.5% 空回复率）——之前是假 `ok`，不是回归。监控端
+  `{"ok","warning"}` 均为 presence-pass，不会 FAIL。
+- **指纹分支跳过数恒 0**：`max(0, processed - len(lines))` 在只于
+  `len(lines) >= processed` 时触发的 fingerprint-mismatch 分支里恒为 0，而该分支
+  丢弃整个前向积压——为量化静默丢失而生的字段在它存在的两个场景之一里报 0。
+  改为按分支计算（mismatch → `len(lines) - processed`），两处均注明是界不是精确值。
+- **撕裂读误判**：读方无锁 `read_text()` 可能读到写了一半的尾行，指纹记在残行上 →
+  下轮误报 mismatch → 丢弃两轮之间的全部真实行。已核实写方单次 `write()` 带 `\n`
+  （`append_jsonl_locked`），修复：非换行终止的尾行对本轮不可见，指纹永远算在
+  完整行上。
+- **跨会话同分档最旧优先**：`key=(-score, ts)` 在同分档内 ts 升序，与上一行注释
+  "newer first"直接矛盾，截断时保最旧弃最新。改为只按分数稳定排序（`collected`
+  已是最新优先预序）。反测复现了 6h 前事件排在 1h 前事件之前。
+- **router 静默吞掉 provider 异常**：CW 把 `health()` 移进 try 修了中断问题，但
+  加宽了静默吞噬——异常 provider 与合法 disabled 的 provider 同貌。修复：分阶段
+  try（`stage="health"|"recall"`），报告带 `provider_error_count` + 有界
+  `provider_errors`（cap 8，只记异常类型名，热路径无 I/O）。
+- **接线到读者（CW 形状第 5 次）**：上述计数被两层挡住——
+  `_record_substrate_shadow_recall` 的 `if not facts: return` 让**全 provider 失败
+  的轮次一行都不写**（恰是计数存在的场景），键选择字典与 `cli._hindsight_substrate_
+  monitor` 又各丢一次。修复：无 facts 但有错误也写行（安静轮仍不写）、两层键选
+  补齐、监控端确认对新键惰性。逐层单独回退各自失败。
+- **timeutil 收敛**：CW 三轮扫描手贴了 25 份相同归一化惯用语，而仓库早有
+  `timeutil.py`（docstring 明言应从它导入）。新增 `ensure_utc_aware()`，25 个
+  分支引入点全部收敛（与 diff 逐一对账），解析/异常结构/各点失败方向不动；
+  `cli.diff_report` 有意保留内联（reject-naive 语义不同）。timeutil 仍为叶子，
+  0 环。**这撤销了 CW 待办里"收敛需独立评估"的保留**——该保留把解析回退
+  （逐点不同，保留）与归一化行（统一，可收敛）混为一谈。
+
+另加一个特征测试钉住解析器收敛的已知取舍（`{JSON} 尾随散文含 }` 形状现在会被
+丢弃并记 `llm_parse_failed`）：它开始失败就意味着有人改了解析语义，须重新决策。
+
+### 有据拒绝的 2 项
+
+- **event_stats 排序反测空洞 + 双排序**：评审正确指出 `(ts,id)` tie-break 修复
+  revert 后全套件仍绿。但 CW 已记录该修复经 20000 次差分模糊测试证明**当前
+  不可观测**（所有消费者重排序或序无关聚合）；伪造白盒失败测试违背批次原则。
+  性能主张亦不成立：Timsort 对近乎有序输入 ~O(n)。评审建议的"把复合键上移到
+  runtime 排序"会改变 owner 面向的 `recent_event_summaries` 顺序语义——不该
+  合入前夹带，如需要应独立立项。
+- **（同上一项的后半）** 保持 selector 内显式排序（正确性文档价值），接受
+  反测不可构造为已记录的例外。
+
+### 评审中另获的观察（记录不修）
+
+`host_capability_probe` 与心跳报告无顶层 `status` 键，同样落穿 `_step_status`
+成 `ok`——前者的能力状态经 `capability_contract` 等其他路径可见，后者失败即抛
+（由 `_run_step` 捕获记 error），均非 CW 引入；根因是"缺键"而非"越界值"，
+需要时独立处理。
+
 ## 待办
 
 **`vector_edge_proposer` 无 `outcome`、无写失败计数（CW 登记，2026-08-15）。**
@@ -4067,12 +4138,12 @@ CLI 参数直接报错。全仓库 **94 个 `fromisoformat` 调用点 / 53 个�
 不是白名单丢弃，故 CW.4 的接线修不到它）。后果：该 lane 写失败与"没边可提"在任何
 读者处都同貌。需独立立项——加计数要连带决定 `status` 降级语义。
 
-**`timeutil.py` 已存在却几乎无人用（CW 登记，2026-08-15）。**
-仓库里早有 `parse_utc`/`safe_compare`/`age_seconds` 三个正确实现，但仅 3 个文件采用；
-约 25 处（含 CW 本轮新修的若干）各自内联重复同一套归一逻辑。当前状态**正确**，但这
-正是本项目反复付出代价的"同一词汇多份拷贝"漂移形状。收敛需独立评估：批量替换的回归
-面不小，且各点的失败方向**不统一**（删除类保留、decay 类自愈、CLI 报错），不能无脑
-套同一个 helper。
+**`timeutil.py` 存量内联归一化点的收敛（CW 登记，CX 部分闭合，2026-08-15）。**
+CX 已新增 `ensure_utc_aware()` 并把 CW 分支引入的全部 25 个点收敛完毕（各点解析
+结构与失败方向不动）。剩余的是 `origin/main` 上**既有**的 clean-because-already-
+normalized 内联点（CW.6 分类表里约十余处）——当前正确，收敛只是防漂移。改它们
+会碰未被本批测试覆盖的老代码路径，留待有正当理由触碰那些文件时顺带收敛，不单独
+起批次。
 
 **图谱遗忘潮预期落点：2026-10-06 前后（CJ 登记,2026-08-07）。**
 first_injection_at=2026-08-07 起算 60 天,过密图谱（refines 为主,重归一后
@@ -6356,3 +6427,10 @@ failed**（11:46），四静态门 + `git diff --check` 全绿。
   保留不变量只削成本（50→0 次索引重写）、两轮 Rule-5 时间戳扫描 23 处（含两处
   prefetch 热路径与真正的 working_cleanup cron lane），94 个 fromisoformat 调用点
   全部分类；全量 3408→3521 passed（+113）/13 skipped，四门全绿。
+
+- `85fa2e4..（CX，本节）`：CW 批次合入前独立评审 10 项发现——修 8（驱逐转换
+  丢失 sticky 化、degraded 落穿 `_step_status`、指纹分支跳过数恒 0、撕裂读
+  误判指纹、跨会话同分档最旧优先、router 吞 provider 异常、substrate 错误
+  计数三层接线含 `if not facts` 早退、timeutil 25 点收敛）拒 2（event_stats
+  排序反测经模糊测试证明不可构造、双排序 Timsort 下不成立）；
+  另钉解析器取舍特征测试。

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -51,6 +51,7 @@ from .store import MemoryOSStore
 from .substrates.hindsight import GovernedHindsightConfig, GovernedHindsightSubstrate
 from .substrates.local_artifact import LocalArtifactProvider
 from .substrates.router import SubstrateRouter
+from .timeutil import ensure_utc_aware
 
 
 # ── C2: maximum age (hours) for recovering a cross-session active anchor.
@@ -1560,8 +1561,7 @@ class MemoryOSProvider(MemoryProvider):
             created_at = datetime.fromisoformat(
                 str(record.get("source_at") or "").replace("Z", "+00:00")
             )
-            if created_at.tzinfo is None:
-                created_at = created_at.replace(tzinfo=timezone.utc)
+            created_at = ensure_utc_aware(created_at)
         except (ValueError, TypeError):
             created_at = None
         anchor_session_id = str(record.get("session_id") or "")

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -1560,8 +1560,10 @@ class MemoryOSProvider(MemoryProvider):
             created_at = datetime.fromisoformat(
                 str(record.get("source_at") or "").replace("Z", "+00:00")
             )
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
         except (ValueError, TypeError):
-            pass
+            created_at = None
         anchor_session_id = str(record.get("session_id") or "")
         if anchor_session_id and anchor_session_id != self.session_id:
             if created_at is not None:

--- a/plugins/memory/memory_os/audit.py
+++ b/plugins/memory/memory_os/audit.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .ids import new_audit_id
 from .jsonl_io import append_jsonl_locked
+from .timeutil import ensure_utc_aware
 
 
 def _audit_monthly_path(base_audit_path: Path) -> Path:
@@ -105,8 +106,7 @@ def last_audit_age_seconds(audit_path: Path, *, now: datetime | None = None) -> 
             ts = datetime.fromisoformat(str(entry["ts"]))
         except (ValueError, TypeError):
             continue
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
+        ts = ensure_utc_aware(ts)
         parsed_ts.append(ts)
     if not parsed_ts:
         return None

--- a/plugins/memory/memory_os/audit.py
+++ b/plugins/memory/memory_os/audit.py
@@ -92,6 +92,24 @@ def last_audit_age_seconds(audit_path: Path, *, now: datetime | None = None) -> 
     entries = [entry for entry in read_audit_records(audit_path) if entry.get("ts")]
     if not entries:
         return None
-    latest = max(datetime.fromisoformat(str(entry["ts"])) for entry in entries)
+    # A malformed `ts` string raises ValueError, and a mix of naive and
+    # aware `ts` values across entries raises TypeError inside max() (the
+    # bare comparison between two datetimes of differing awareness). Parse
+    # each entry individually, normalizing a naive value to UTC same as
+    # knob_overrides._is_expired, and skip entries that fail to parse at
+    # all rather than letting one malformed record crash the CLI status
+    # report for every entry.
+    parsed_ts: list[datetime] = []
+    for entry in entries:
+        try:
+            ts = datetime.fromisoformat(str(entry["ts"]))
+        except (ValueError, TypeError):
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        parsed_ts.append(ts)
+    if not parsed_ts:
+        return None
+    latest = max(parsed_ts)
     current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     return max(0.0, (current - latest.astimezone(timezone.utc)).total_seconds())

--- a/plugins/memory/memory_os/clearance_cycle.py
+++ b/plugins/memory/memory_os/clearance_cycle.py
@@ -402,7 +402,11 @@ def _judge_against_permanents(
         return ("unknown", [], checked_entity_set, invalidation_mode, "judge_unavailable")
 
     # ── Prepare LLM config ──────────────────────────────────────────────
-    from .low_clue_recall import _call_hermes_runtime_model, _resolve_hermes_default_runtime
+    from .low_clue_recall import (
+        _call_hermes_runtime_model,
+        _extract_json_object,
+        _resolve_hermes_default_runtime,
+    )
 
     _DEFAULT_LLM_CONFIG: dict[str, Any] = {
         "enabled": True,
@@ -474,28 +478,36 @@ def _judge_against_permanents(
         if not response or not response.strip():
             continue
 
-        # Parse LLM response (robust JSON extraction)
+        # Parse LLM response (robust JSON extraction). Converge on the
+        # project's canonical parser (_extract_json_object) for contract
+        # consistency with fact_judge.py / session_fact_extraction.py — see
+        # CLAUDE.md "LLM Integration - Reuse, Never Rebuild". A hand-rolled
+        # brace-depth counter used to live here; it broke silently whenever
+        # a claim value itself contained an unbalanced "{" (depth never
+        # returned to 0, `end` stayed -1, the pair was dropped with no
+        # signal). _extract_json_object instead takes the outermost
+        # find("{")..rfind("}") span, which does not share that failure
+        # mode. No trailing-prose fallback is added: the prompt instructs
+        # "Return ONLY a JSON object", and fact_judge.py -- the reference
+        # implementation this converges toward -- has no such fallback
+        # either.
         try:
             parsed = _json.loads(response.strip())
         except _json.JSONDecodeError:
-            start = response.find("{")
-            if start == -1:
-                continue
-            depth = 0
-            end = -1
-            for _i in range(start, len(response)):
-                if response[_i] == "{":
-                    depth += 1
-                elif response[_i] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        end = _i
-                        break
-            if end == -1:
-                continue
-            try:
-                parsed = _json.loads(response[start:end + 1])
-            except _json.JSONDecodeError:
+            parsed = None
+
+        if not isinstance(parsed, dict):
+            # Covers two cases with one guard: the first attempt raised
+            # (parsed is None above), or it succeeded but yielded a
+            # non-dict JSON value (a bare list/string/number) -- the same
+            # shape that crashed llm_edge_proposer._call_llm inside
+            # float(parsed.get("confidence")) before its own
+            # `if not isinstance(parsed, dict)` guard was added.
+            # _extract_json_object already returns None for a non-dict
+            # result, so this is a no-op when there is no nested object to
+            # recover.
+            parsed = _extract_json_object(response)
+            if not isinstance(parsed, dict):
                 continue
 
         claim_a = parsed.get("claim_a") if isinstance(parsed.get("claim_a"), dict) else {}

--- a/plugins/memory/memory_os/cli.py
+++ b/plugins/memory/memory_os/cli.py
@@ -950,17 +950,53 @@ def trace_record(store: MemoryOSStore, record_id: str, *, include_private: bool 
     return trace
 
 
+def _diff_report_parse_record_ts(value: str) -> datetime | None:
+    """Parse a stored event/audit timestamp for the diff report.
+
+    Naive (no-offset) values are treated as UTC. Returns None on
+    genuinely unparseable input so the caller skips the record instead of
+    crashing the report -- ``diff`` is a best-effort diagnostic surface,
+    not a gating or data-deleting path.
+    """
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def diff_report(store: MemoryOSStore, *, since: str, until: str) -> dict[str, Any]:
-    since_dt = datetime.fromisoformat(since)
-    until_dt = datetime.fromisoformat(until)
-    events = [
-        event for event in store.read_events()
-        if since_dt <= datetime.fromisoformat(event.ts) <= until_dt
-    ]
-    audit_entries = [
-        entry for entry in read_audit_entries(store.roots.audit_path)
-        if entry.get("ts") and since_dt <= datetime.fromisoformat(str(entry["ts"])) <= until_dt
-    ]
+    # since/until are raw --since/--until CLI arguments. A parse failure or
+    # a bare (offset-less) date/time is ambiguous user input, not a stored
+    # record we can safely normalize -- fail with a clear CLI message
+    # rather than silently guessing the caller meant UTC.
+    try:
+        since_dt = datetime.fromisoformat(since)
+        until_dt = datetime.fromisoformat(until)
+    except (ValueError, TypeError) as exc:
+        raise SystemExit(
+            f"diff: invalid --since/--until timestamp ({exc}); expected an "
+            f"ISO-8601 timestamp, e.g. 2026-08-01T00:00:00+00:00"
+        ) from exc
+    if since_dt.tzinfo is None or until_dt.tzinfo is None:
+        raise SystemExit(
+            "diff: --since and --until must include a UTC offset "
+            "(e.g. 2026-08-01T00:00:00+00:00) -- a bare date/time is ambiguous"
+        )
+    events = []
+    for event in store.read_events():
+        event_ts = _diff_report_parse_record_ts(event.ts)
+        if event_ts is not None and since_dt <= event_ts <= until_dt:
+            events.append(event)
+    audit_entries = []
+    for entry in read_audit_entries(store.roots.audit_path):
+        if not entry.get("ts"):
+            continue
+        entry_ts = _diff_report_parse_record_ts(str(entry["ts"]))
+        if entry_ts is not None and since_dt <= entry_ts <= until_dt:
+            audit_entries.append(entry)
     return {
         "schema_version": "memory-os.diff.v0",
         "since": since,

--- a/plugins/memory/memory_os/cli.py
+++ b/plugins/memory/memory_os/cli.py
@@ -683,6 +683,8 @@ def _hindsight_substrate_monitor(store: MemoryOSStore) -> dict[str, Any]:
         **projection_fields,
         "local_first_authority_preserved": shadow.get("local_first_authority_preserved") if shadow else None,
         "external_authoritative_count": int(shadow.get("external_authoritative_count") or 0) if shadow else 0,
+        "provider_error_count": int(shadow.get("provider_error_count") or 0) if shadow else 0,
+        "provider_errors": shadow.get("provider_errors") if shadow and isinstance(shadow.get("provider_errors"), list) else [],
     }
 
 

--- a/plugins/memory/memory_os/cognitive_loop.py
+++ b/plugins/memory/memory_os/cognitive_loop.py
@@ -1036,6 +1036,16 @@ class CognitiveLoopRunner:
             "proposed_count": result.get("proposed_count", 0),
             "auto_active_count": result.get("auto_active_count", 0),
             "dedup_skipped": result.get("dedup_skipped", 0),
+            # D2b: outcome + llm_call_* — distinguishes "the judge genuinely
+            # found no relationships" (no_relationships_found, all calls ok)
+            # from "every LLM call failed" (llm_degraded) without re-running
+            # or reading source. See llm_edge_proposer.run_llm_proposer
+            # docstring; same 两层白名单 hazard as edge_weight_feedback above.
+            "outcome": result.get("outcome", ""),
+            "llm_call_count": result.get("llm_call_count", 0),
+            "llm_call_ok_count": result.get("llm_call_ok_count", 0),
+            "llm_call_failure_count": result.get("llm_call_failure_count", 0),
+            "llm_call_failure_reasons": result.get("llm_call_failure_reasons", {}),
             "duration_ms": result.get("duration_ms", 0),
             "error": result.get("error", ""),
         }
@@ -1110,6 +1120,11 @@ class CognitiveLoopRunner:
             "scanned_ref_count": result.get("scanned_ref_count", 0),
             "proposed_count": result.get("proposed_count", 0),
             "dedup_skipped": result.get("dedup_skipped", 0),
+            # write_failed_count is the counter that distinguishes "nothing
+            # to write" from "tried and failed" — Completion Is Not Output.
+            # The monitor's _edge_fields already whitelists it; this key was
+            # the missing half (dropped at this layer only).
+            "write_failed_count": result.get("write_failed_count", 0),
             "duration_ms": result.get("duration_ms", 0),
             "error": result.get("error", ""),
         }
@@ -1168,6 +1183,19 @@ class CognitiveLoopRunner:
             "forget_eligible_backlog": result.get("forget_eligible_backlog", 0),
             "unresolved_hit_count": result.get("unresolved_hit_count", 0),
             "failed_count": result.get("failed_count", 0),
+            "tracked_edge_count": result.get("tracked_edge_count", 0),
+            # Cursor-alignment visibility: the outcome branch gives
+            # reinforced/forgotten/saturated precedence over
+            # "cursor_misaligned", so a misalignment on an otherwise-busy
+            # run is invisible unless these survive independently of
+            # outcome. A future graph_layer_shadow.jsonl compaction
+            # (metadata_retention.py — dry-run only today, no executor
+            # yet) is exactly the event these detect.
+            "cursor_misaligned": result.get("cursor_misaligned", False),
+            "cursor_misalignment_reason": result.get("cursor_misalignment_reason", ""),
+            "cursor_previous_line_count": result.get("cursor_previous_line_count", 0),
+            "cursor_realigned_line_count": result.get("cursor_realigned_line_count", 0),
+            "cursor_skipped_row_count": result.get("cursor_skipped_row_count", 0),
             "duration_ms": result.get("duration_ms", 0),
             "error": result.get("error", ""),
         }

--- a/plugins/memory/memory_os/cognitive_loop.py
+++ b/plugins/memory/memory_os/cognitive_loop.py
@@ -1506,8 +1506,12 @@ class CognitiveLoopRunner:
 
 def _step_status(result: dict[str, Any]) -> str:
     status = str(result.get("status", "") or "").lower()
-    if status in {"ok", "warning", "error", "deferred", "skipped", "skipped_dependency_failed", "blocked"}:
-        return "warning" if status == "deferred" else status
+    if status in {"ok", "warning", "error", "deferred", "degraded", "skipped", "skipped_dependency_failed", "blocked"}:
+        # "degraded" (e.g. llm_edge_proposer: at least one pair's LLM call
+        # failed this run) must not fall through to "ok" — the raw
+        # "degraded" value stays visible in the step's passthrough result
+        # dict; only the step-level classification maps it to "warning".
+        return "warning" if status in {"deferred", "degraded"} else status
     if result.get("output") == "[SILENT]" or result.get("reason"):
         return "warning"
     return "ok"

--- a/plugins/memory/memory_os/crystallized.py
+++ b/plugins/memory/memory_os/crystallized.py
@@ -1803,16 +1803,32 @@ def compact_candidate_queue(
     below resolves state from triage rows alone
     (``resolve_candidate_effective_state``), which has no idea a candidate
     is provisional-backed. A resolver-approved provisional candidate whose
-    triage state is ``resolver_approved`` (not ``owner_eligible``) ages out
-    through that branch once its row passes ``retention_days`` —
-    independent of ``terminal_candidate_ids`` — with the same loss shape as
-    the 2026-08-14 hole: once the provisional is later invalidated (TTL/cap
-    eviction, owner reject), the candidate is in neither the live queue nor
-    active crystallized memory, and ``candidates.archive.jsonl`` has no
-    production reader. Any id in this set is kept active UNCONDITIONALLY —
-    checked first, ahead of every other branch including
-    ``terminal_candidate_ids`` itself, so the guarantee does not depend on
-    every caller constructing ``terminal_candidate_ids`` correctly.
+    triage state is ``resolver_approved`` (not ``owner_eligible``) — once
+    its row passes ``retention_days`` and its provisional anchor is later
+    invalidated (TTL/cap eviction, owner reject) — is no longer in
+    ``provisional_backed_candidate_ids`` (the record is inactive) and has
+    the same loss shape as the 2026-08-14 hole: ``invalidate_provisional_
+    record`` mutates only the crystallized record's frontmatter and appends
+    no triage row, so ``resolve_candidate_effective_state`` still returns
+    the frozen ``resolver_approved`` written at promotion time, and without
+    a further exemption the candidate would be in neither the live queue
+    nor active crystallized memory (``candidates.archive.jsonl`` has no
+    production reader). Pre-merge fix (2026-08-15): the retention-window
+    ``elif`` below now treats ``resolver_approved`` as sticky, exactly like
+    ``owner_eligible`` — a resolver-approved row is never archived by the
+    AGE branch regardless of how long ago its anchor was evicted. This does
+    NOT make the row immortal: once the general aged-demote sweep
+    (``candidate_aggregation._demote_aged``, unaffected by this parameter)
+    eventually writes a ``demoted`` triage row for it, ``resolve_candidate_
+    effective_state`` returns ``demoted`` and the row archives normally on
+    the next tick — either through ``terminal_candidate_ids`` (when the
+    caller supplies the full effective view) or through the ``else`` branch
+    here. Any id in ``provisional_backed_candidate_ids`` is kept active
+    UNCONDITIONALLY — checked first, ahead of every other branch including
+    ``terminal_candidate_ids`` itself, so that guarantee does not depend on
+    every caller constructing ``terminal_candidate_ids`` correctly; the
+    ``resolver_approved`` stickiness below is the narrower, second guarantee
+    that covers the gap between eviction and the next demote sweep.
 
     Invariant enforced by requiring this argument: a candidate can be
     archived ONLY if the caller has affirmatively said it is not
@@ -1832,6 +1848,10 @@ def compact_candidate_queue(
       - it is provisional-backed (see above) -- unconditionally, regardless
         of triage state or age
       - effective state resolves to owner_eligible (owner needs to see it)
+      - effective state resolves to resolver_approved (sticky, same as
+        owner_eligible -- see above; survives an evicted provisional anchor
+        until the general aged-demote sweep writes a demoted/absorbed/
+        fleeting triage row for it)
       - effective state is NOT demoted/absorbed AND created_age < retention_days
 
     Demoted/absorbed candidates are resolved outcomes and are ALWAYS archived
@@ -1890,11 +1910,18 @@ def compact_candidate_queue(
             age = _candidate_age_seconds(cand.created_at, now)
 
             # Active (stays in main file) if the owner still needs to see it,
-            # OR it is within the retention window AND not a resolved outcome.
-            # Demoted/fleeting/absorbed are resolved — always archive them so
-            # they stop cluttering the live queue (previously only archived
-            # once aged past retention_days, leaving young demoted/fleeting/
-            # absorbed in active).
+            # OR the row's latest triage is a resolver-approve that has not
+            # been overwritten by a newer triage action (sticky like
+            # owner_eligible — see the docstring's "resolver_approved is
+            # sticky" note: this is the retention-branch half of the
+            # provisional_backed_candidate_ids reversibility guarantee, for
+            # the window between provisional eviction and the general
+            # aged-demote sweep actually writing a demoted/absorbed/fleeting
+            # triage row), OR it is within the retention window AND not a
+            # resolved outcome. Demoted/fleeting/absorbed are resolved —
+            # always archive them so they stop cluttering the live queue
+            # (previously only archived once aged past retention_days,
+            # leaving young demoted/fleeting/absorbed in active).
             if cand.candidate_id in provisional_backed_candidate_ids:
                 # Reversibility guarantee, checked first and unconditionally:
                 # a provisional-backed candidate's only crystallized anchor
@@ -1910,7 +1937,7 @@ def compact_candidate_queue(
                 # latest triage row does not — archive it now.
                 archived.append(line_stripped)
                 archived_count += 1
-            elif effective == "owner_eligible" or (
+            elif effective in ("owner_eligible", "resolver_approved") or (
                 effective not in ("demoted", "fleeting", "absorbed") and age < retention_days * 86400
             ):
                 active.append(line_stripped)

--- a/plugins/memory/memory_os/crystallized.py
+++ b/plugins/memory/memory_os/crystallized.py
@@ -128,6 +128,16 @@ class EffectiveCandidate:
     owner_review_eligible: bool
     terminal: bool
     exclusion_reason: str
+    # True when this candidate's terminality (state == "crystallized") comes
+    # ONLY from active provisional crystallized record(s) -- no active
+    # PERMANENT record backs it. Provisional is reversible by design
+    # (resolver TTL/cap eviction, owner reject via invalidate_provisional_
+    # record); a candidate whose only anchor is provisional must stay
+    # reachable in the live queue so it can resurface once that anchor is
+    # invalidated. Always False for non-"crystallized" states and for a
+    # candidate that also has an active permanent record (permanent wins:
+    # archival is correct there, same as before this field existed).
+    provisional_backed: bool = False
 
 
 @dataclass(frozen=True)
@@ -1448,6 +1458,12 @@ def write_candidate_aggregation_status(
         "demoted_count": int(summary.get("demoted_count", 0)),
         "fleeting_count": int(summary.get("fleeting_count", 0)),
         "compacted_count": int(summary.get("compacted_count", 0)),
+        # Closed set: "" (compaction ran), "effective_view_unavailable", or
+        # "upstream_error" -- see run_candidate_aggregation_lane. Lets a
+        # reader tell "compacted_count is 0 because there was nothing to
+        # archive" from "compaction did not run", which the counter alone
+        # cannot distinguish.
+        "compaction_skip_reason": str(summary.get("compaction_skip_reason") or ""),
         "execution_gate_envelope_id": str(execution_gate_envelope_id or ""),
         "created_at": _timestamp(now),
     }
@@ -1661,6 +1677,12 @@ def read_effective_candidates(store: MemoryOSStore) -> list[EffectiveCandidate]:
             latest_triage[candidate_id] = dict(record)
 
     canonical_candidate_ids: set[str] = set()
+    # Tracks candidate_ids backed by at least one active PERMANENT (non-
+    # provisional) crystallized record -- separate from canonical_candidate_
+    # ids (any active record, provisional or not) so provisional_backed
+    # below can tell "only provisional anchors this" from "a permanent
+    # record already anchors this too" (permanent always wins).
+    permanent_active_candidate_ids: set[str] = set()
     service = CrystallizedMemoryService(store)
     if store.roots.crystallized_root.exists():
         for path in sorted(store.roots.crystallized_root.glob("*.md")):
@@ -1668,6 +1690,8 @@ def read_effective_candidates(store: MemoryOSStore) -> list[EffectiveCandidate]:
                 candidate_id = str(record.frontmatter.get("candidate_id") or "")
                 if candidate_id and is_active_crystallized_frontmatter(record.frontmatter):
                     canonical_candidate_ids.add(candidate_id)
+                    if record.frontmatter.get("provisional") is not True:
+                        permanent_active_candidate_ids.add(candidate_id)
 
     owner_closed_ids: set[str] = set()
     owner_actions_path = store.roots.memory_os_root / "system" / "owner_actions.jsonl"
@@ -1733,6 +1757,10 @@ def read_effective_candidates(store: MemoryOSStore) -> list[EffectiveCandidate]:
                 owner_review_eligible=owner_review_eligible,
                 terminal=terminal,
                 exclusion_reason=exclusion_reason,
+                provisional_backed=(
+                    candidate.candidate_id in canonical_candidate_ids
+                    and candidate.candidate_id not in permanent_active_candidate_ids
+                ),
             )
         )
     return projected
@@ -1744,13 +1772,20 @@ def compact_candidate_queue(
     archive_path: Path | None = None,
     retention_days: int = 7,
     terminal_candidate_ids: set[str] | None = None,
+    provisional_backed_candidate_ids: set[str],
 ) -> int:
     """Archive-and-compact: move stale candidates to archive file.
 
-    ``terminal_candidate_ids`` (optional) lets the caller pass the FULL
-    terminal view from ``read_effective_candidates`` — which also sees the
+    ``terminal_candidate_ids`` (optional) lets the caller pass a terminal-id
+    set derived from ``read_effective_candidates`` — which also sees the
     crystallized-record and owner-action overlays this function's own
-    triage-only resolution cannot. Measured hole (2026-08-14, production):
+    triage-only resolution cannot. The caller (candidate_aggregation) passes
+    only the ARCHIVABLE subset of the full terminal view: it excludes
+    candidates whose only active crystallized record is provisional
+    (``EffectiveCandidate.provisional_backed``), because archival here is
+    one-way while a provisional anchor is reversible by design. This
+    function has no opinion on that distinction — it archives exactly the
+    ids it is given. Measured hole (2026-08-14, production):
     five queue rows whose candidates had been crystallized long ago resolved
     ``crystallized``/terminal in the full view (and were recall-excluded),
     but their latest *triage* row still said owner_eligible, so this
@@ -1759,14 +1794,51 @@ def compact_candidate_queue(
     projection — one semantics, one source. ``None`` keeps the historical
     triage-only behavior.
 
+    ``provisional_backed_candidate_ids`` is a REQUIRED keyword argument (no
+    default) — it is the enforcement half of the same reversibility
+    guarantee, for the branches below that ``terminal_candidate_ids`` alone
+    does not reach. Excluding a provisional-backed id from
+    ``terminal_candidate_ids`` (as the aggregation lane already does) only
+    protects it from the FIRST branch; the retention-window ``elif``/``else``
+    below resolves state from triage rows alone
+    (``resolve_candidate_effective_state``), which has no idea a candidate
+    is provisional-backed. A resolver-approved provisional candidate whose
+    triage state is ``resolver_approved`` (not ``owner_eligible``) ages out
+    through that branch once its row passes ``retention_days`` —
+    independent of ``terminal_candidate_ids`` — with the same loss shape as
+    the 2026-08-14 hole: once the provisional is later invalidated (TTL/cap
+    eviction, owner reject), the candidate is in neither the live queue nor
+    active crystallized memory, and ``candidates.archive.jsonl`` has no
+    production reader. Any id in this set is kept active UNCONDITIONALLY —
+    checked first, ahead of every other branch including
+    ``terminal_candidate_ids`` itself, so the guarantee does not depend on
+    every caller constructing ``terminal_candidate_ids`` correctly.
+
+    Invariant enforced by requiring this argument: a candidate can be
+    archived ONLY if the caller has affirmatively said it is not
+    provisional-backed. There is no ``None``/omitted spelling of "I don't
+    know" — unlike ``terminal_candidate_ids``, where ``None`` is a safe,
+    documented, strictly-more-conservative fallback (archives less, never
+    more), a ``None`` here would have to mean either "archive
+    provisional-backed rows anyway" (the exact data loss this parameter
+    exists to prevent) or "abort compaction" decided from inside a function
+    that has no visibility into why the caller doesn't have the set. Both
+    are worse than making the caller compute it. Pass ``set()`` only when
+    you have genuinely confirmed (e.g. via ``read_effective_candidates``)
+    that no candidate in this run is provisional-backed — never as a
+    reflexive default to satisfy the signature.
+
     A candidate is 'active' (stays in main file) if:
+      - it is provisional-backed (see above) -- unconditionally, regardless
+        of triage state or age
       - effective state resolves to owner_eligible (owner needs to see it)
       - effective state is NOT demoted/absorbed AND created_age < retention_days
 
     Demoted/absorbed candidates are resolved outcomes and are ALWAYS archived
     (even when newer than retention_days) so they stop cluttering the live
-    candidate queue. Other non-owner-eligible, non-terminal candidates within
-    the retention window stay active for observation.
+    candidate queue -- UNLESS provisional-backed, per above. Other
+    non-owner-eligible, non-terminal candidates within the retention window
+    stay active for observation.
 
     Others are appended to archive and excluded from the main file.
     Returns count of archived candidates.
@@ -1778,7 +1850,9 @@ def compact_candidate_queue(
 
     Holds a shared sidecar lock with append_candidate_queue so concurrent
     appends cannot be lost during the read→replace window (§3.3).
-    A conservation assertion catches silent write-loss (§3.4A fail-closed).
+    A conservation assertion catches silent write-loss (§3.4A fail-closed):
+    unaffected by this parameter, since every row still lands in exactly
+    one of ``active``/``archived``.
     """
     if archive_path is None:
         archive_path = store.roots.crystallized_root / "candidates.archive.jsonl"
@@ -1821,7 +1895,16 @@ def compact_candidate_queue(
             # they stop cluttering the live queue (previously only archived
             # once aged past retention_days, leaving young demoted/fleeting/
             # absorbed in active).
-            if terminal_candidate_ids is not None and cand.candidate_id in terminal_candidate_ids:
+            if cand.candidate_id in provisional_backed_candidate_ids:
+                # Reversibility guarantee, checked first and unconditionally:
+                # a provisional-backed candidate's only crystallized anchor
+                # can be invalidated later (TTL/cap eviction, owner reject),
+                # and archival here has no way back. Never let triage state
+                # (resolver_approved, demoted, ...) or age override this —
+                # see the docstring for the retention-window hole this
+                # closes.
+                active.append(line_stripped)
+            elif terminal_candidate_ids is not None and cand.candidate_id in terminal_candidate_ids:
                 # The full effective view says this candidate is closed
                 # (crystallized / owner_closed / demoted / ...) even if its
                 # latest triage row does not — archive it now.

--- a/plugins/memory/memory_os/edge_weight_feedback.py
+++ b/plugins/memory/memory_os/edge_weight_feedback.py
@@ -27,6 +27,7 @@ Runs as a cognitive-loop step.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
@@ -55,6 +56,17 @@ def _load_state(path) -> dict[str, Any]:
     return {}
 
 
+def _line_fingerprint(line: str) -> str:
+    """Content fingerprint for the last-consumed shadow-ledger line.
+
+    Used to detect cursor misalignment (e.g. a future compaction that
+    trims/rewrites the head of ``graph_layer_shadow.jsonl``) even in the
+    edge case where the post-compaction line count happens to still be
+    >= the old cursor — a bare line-count comparison alone would miss that.
+    """
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()[:16]
+
+
 def run_edge_weight_feedback(
     index_path: str,
     *,
@@ -77,6 +89,7 @@ def run_edge_weight_feedback(
     state_path = roots.memory_os_root / "system" / STATE_FILENAME
     state = _load_state(state_path)
     processed = int(state.get("processed_line_count") or 0)
+    expected_fingerprint = state.get("processed_line_fingerprint")
     last_hit: dict[str, str] = dict(state.get("edge_last_hit") or {})
     first_run_at = str(state.get("first_run_at") or "") or current.isoformat()
     # v0→v1 state 迁移:v0 只有 first_run_at(闭环首跑)。生产的 shadow 自
@@ -104,7 +117,52 @@ def run_edge_weight_feedback(
         except OSError:
             lines = []
 
-    new_lines = lines[processed:] if len(lines) > processed else []
+    # ── Cursor alignment check ──────────────────────────────────────────
+    # `processed` is a LINE-COUNT cursor into a ledger the write side
+    # (prefetch._record_graph_layer_shadow) appends to without bound and
+    # metadata_retention.py registers for future compaction planning (that
+    # planner is dry-run only today — nothing removes rows yet — but the
+    # cursor must not silently assume it never will). If the ledger is ever
+    # compacted (head rows removed/renumbered), a bare `lines[processed:]`
+    # either replays already-reinforced rows (non-idempotent: HIT_LEARNING_RATE
+    # over-reinforces on replay) or — the branch already guarded by
+    # `len(lines) > processed` — silently drops the entire unconsumed
+    # backlog and rewrites the cursor as if it had been consumed. Detect
+    # misalignment via (a) the ledger having fewer lines than the old
+    # cursor expected, or (b) the content at the old cursor position no
+    # longer matching what was last consumed (guards a same-or-larger
+    # line count after a compaction+append that coincidentally lands on
+    # the old cursor value). A missing/empty stored fingerprint (state
+    # written before this fix, or processed == 0) never triggers (b) —
+    # only (a) can fire against pre-fix state.
+    cursor_misaligned = False
+    cursor_misalignment_reason: str | None = None
+    cursor_previous_line_count = processed
+    if processed > 0:
+        if len(lines) < processed:
+            cursor_misaligned = True
+            cursor_misalignment_reason = "ledger_shorter_than_cursor"
+        elif expected_fingerprint and _line_fingerprint(lines[processed - 1]) != expected_fingerprint:
+            cursor_misaligned = True
+            cursor_misalignment_reason = "ledger_fingerprint_mismatch"
+
+    if cursor_misaligned:
+        # Do NOT reprocess from zero (non-idempotent reinforcement would
+        # over-weight already-seen edges) and do NOT trust `lines[processed:]`
+        # (those indices no longer mean what they used to). Realign the
+        # cursor to the current file and process nothing this run; the gap
+        # is reported below instead of silently disappearing into a clean
+        # "no_new_hits" outcome. `last_hit` / `first_injection_at` are left
+        # untouched — they are independent of the shadow-ledger cursor.
+        new_lines: list[str] = []
+        # Best-effort, count-based lower bound on how many previously-tracked
+        # ledger positions vanished out from under the cursor. It is a bound,
+        # not a claim about how many real injection hits were lost — some or
+        # all of that gap may have already been reinforced in a prior run.
+        cursor_skipped_row_count = max(0, processed - len(lines))
+    else:
+        new_lines = lines[processed:] if len(lines) > processed else []
+        cursor_skipped_row_count = 0
 
     try:
         conn = sqlite3.connect(index_path)
@@ -228,9 +286,22 @@ def run_edge_weight_feedback(
         "first_run_at": first_run_at,
         "first_injection_at": first_injection_at,
         "processed_line_count": len(lines),
+        "processed_line_fingerprint": _line_fingerprint(lines[-1]) if lines else None,
         "edge_last_hit": last_hit,
         "updated_at": current.isoformat(),
     }
+    if cursor_misaligned:
+        state_out["last_cursor_misalignment"] = {
+            "detected_at": current.isoformat(),
+            "reason": cursor_misalignment_reason,
+            "previous_line_count": cursor_previous_line_count,
+            "realigned_line_count": len(lines),
+            "skipped_row_count": cursor_skipped_row_count,
+        }
+    elif "last_cursor_misalignment" in state:
+        # Preserve the most recent misalignment record across aligned runs
+        # so it stays visible until the next misalignment overwrites it.
+        state_out["last_cursor_misalignment"] = state["last_cursor_misalignment"]
     try:
         _atomic_write_json(state_path, state_out)
     except Exception:
@@ -238,6 +309,10 @@ def run_edge_weight_feedback(
 
     if reinforced or forgotten or already_saturated:
         outcome = "reinforced"
+    elif cursor_misaligned:
+        # Distinct from "no_new_hits": we did NOT verify there was nothing
+        # new — the cursor could no longer be trusted, so nothing was read.
+        outcome = "cursor_misaligned"
     elif not shadow_exists:
         outcome = "no_shadow_ledger"
     elif not first_injection_at:
@@ -259,6 +334,15 @@ def run_edge_weight_feedback(
         "unresolved_hit_count": unresolved_hits,
         "failed_count": failed,
         "tracked_edge_count": len(last_hit),
+        # Cursor-alignment fields are unconditional (0/None when aligned) so
+        # monitors get a stable schema; they can be non-zero even when
+        # `outcome == "reinforced"` (forgetting still runs on a misaligned
+        # run — only the shadow-hit reinforcement stream is affected).
+        "cursor_misaligned": cursor_misaligned,
+        "cursor_misalignment_reason": cursor_misalignment_reason,
+        "cursor_previous_line_count": cursor_previous_line_count,
+        "cursor_realigned_line_count": len(lines),
+        "cursor_skipped_row_count": cursor_skipped_row_count,
         "duration_ms": elapsed_ms,
         "begin_at": start_time.isoformat(),
     }

--- a/plugins/memory/memory_os/edge_weight_feedback.py
+++ b/plugins/memory/memory_os/edge_weight_feedback.py
@@ -113,9 +113,25 @@ def run_edge_weight_feedback(
     lines: list[str] = []
     if shadow_exists:
         try:
-            lines = shadow_path.read_text(encoding="utf-8").splitlines()
+            raw_text = shadow_path.read_text(encoding="utf-8")
         except OSError:
-            lines = []
+            raw_text = ""
+        lines = raw_text.splitlines()
+        # The per-turn prefetch writer (_record_graph_layer_shadow ->
+        # jsonl_io.append_jsonl_locked) appends one full line + "\n" in a
+        # single handle.write() under a sidecar lock, so every DURABLE
+        # ledger line always ends with "\n". This reader takes no lock on
+        # the hot ledger, so it can race a write in progress and observe a
+        # torn (partially-written) last line with no trailing newline.
+        # Treat only newline-terminated lines as durable: drop a
+        # non-terminated tail element before it is counted, sliced, or
+        # fingerprinted. A partial line is simply invisible to this run and
+        # will be consumed next run once the writer finishes it -- this is
+        # what keeps the fingerprint always computed over a complete line
+        # and prevents a torn read from producing a false
+        # `ledger_fingerprint_mismatch` next run.
+        if raw_text and not raw_text.endswith("\n"):
+            lines = lines[:-1]
 
     # ── Cursor alignment check ──────────────────────────────────────────
     # `processed` is a LINE-COUNT cursor into a ledger the write side
@@ -155,11 +171,25 @@ def run_edge_weight_feedback(
         # "no_new_hits" outcome. `last_hit` / `first_injection_at` are left
         # untouched — they are independent of the shadow-ledger cursor.
         new_lines: list[str] = []
-        # Best-effort, count-based lower bound on how many previously-tracked
-        # ledger positions vanished out from under the cursor. It is a bound,
-        # not a claim about how many real injection hits were lost — some or
-        # all of that gap may have already been reinforced in a prior run.
-        cursor_skipped_row_count = max(0, processed - len(lines))
+        if cursor_misalignment_reason == "ledger_shorter_than_cursor":
+            # Best-effort, count-based lower bound on how many
+            # previously-tracked ledger positions vanished out from under
+            # the cursor. It is a bound, not a claim about how many real
+            # injection hits were lost — some or all of that gap may have
+            # already been reinforced in a prior run.
+            cursor_skipped_row_count = max(0, processed - len(lines))
+        else:
+            # "ledger_fingerprint_mismatch": the ledger is same-or-larger
+            # than the old cursor but its content diverged (a
+            # compaction+append that coincidentally lands the new length at
+            # or past the old cursor value). `new_lines` above was dropped
+            # in full, so the unconsumed forward backlog is everything from
+            # `len(lines) - processed` onward. This is also only a bound,
+            # not an exact count: how much of the renumbered prefix
+            # (positions [0, processed)) was truly already-consumed content
+            # versus newly-shifted content is unknowable from a line count
+            # alone.
+            cursor_skipped_row_count = max(0, len(lines) - processed)
     else:
         new_lines = lines[processed:] if len(lines) > processed else []
         cursor_skipped_row_count = 0

--- a/plugins/memory/memory_os/entity_index.py
+++ b/plugins/memory/memory_os/entity_index.py
@@ -141,17 +141,34 @@ def query_related_records(
         placeholders = ",".join("?" for _ in record_ids)
         rows = conn.execute(
             f"""
-            select ei2.record_id,
-                   min(ei2.entity_text) as shared_entity,
-                   max(ei2.weight) as max_weight,
-                   count(*) as overlap_count
-            from entity_index ei1
-            join entity_index ei2
-              on ei1.entity_id = ei2.entity_id
-             and ei1.record_id != ei2.record_id
-            where ei1.record_id in ({placeholders})
-            group by ei2.record_id
-            having max(ei2.weight) >= ?
+            with matches as (
+                select ei2.record_id as record_id,
+                       ei2.entity_text as entity_text,
+                       ei2.entity_class as entity_class,
+                       ei2.weight as weight
+                from entity_index ei1
+                join entity_index ei2
+                  on ei1.entity_id = ei2.entity_id
+                 and ei1.record_id != ei2.record_id
+                where ei1.record_id in ({placeholders})
+                  and ei2.weight >= ?
+            ),
+            ranked as (
+                select record_id, entity_text, entity_class, weight,
+                       row_number() over (
+                           partition by record_id
+                           order by weight desc, entity_text asc
+                       ) as rn,
+                       count(*) over (partition by record_id) as overlap_count
+                from matches
+            )
+            select record_id,
+                   entity_text as shared_entity,
+                   entity_class,
+                   weight,
+                   overlap_count
+            from ranked
+            where rn = 1
             order by overlap_count desc
             limit ?
             """,
@@ -172,20 +189,11 @@ def query_related_records(
     results: list[dict[str, Any]] = []
     for row in rows:
         shared_entity = row["shared_entity"]
-        weight = float(row["max_weight"])
-        # Derive entity_class from weight for display (match _ENTITY_CLASS_RULES bands)
-        if weight >= 0.9:
-            entity_class = "proper_noun"
-        elif weight >= 0.7:
-            entity_class = "identifier"
-        elif weight == 0.6:
-            entity_class = "ip"
-        elif weight == 0.5:
-            entity_class = "url"
-        elif weight == 0.4:
-            entity_class = "path"
-        else:
-            entity_class = "unknown"
+        # entity_class and weight are read from the SAME winning row (highest
+        # weight, entity_text tie-break) — never re-derived from independent
+        # aggregates, which could mix one entity's text with another's class.
+        entity_class = row["entity_class"]
+        weight = float(row["weight"])
         results.append({
             "related_record_id": row["record_id"],
             "shared_entity": shared_entity,

--- a/plugins/memory/memory_os/event_stats.py
+++ b/plugins/memory/memory_os/event_stats.py
@@ -14,19 +14,17 @@ from pathlib import Path
 from uuid import uuid4
 
 from .jsonl_io import locked_jsonl_file
+from .prefetch import (
+    _BOOKKEEPING_FILL_KIND_MARKERS,
+    _BRIDGE_SEED_SLOTS as _CONTINUITY_SEED_SLOTS,
+    _MAX_CONTINUITY_RECORDS,
+)
 
 EVENT_STATS_SCHEMA_VERSION = "memory-os.event_stats.v0"
 
-# Continuity selector constants — mirrors prefetch._BRIDGE_SEED_SLOTS / _MAX_CONTINUITY_RECORDS
-_CONTINUITY_SEED_SLOTS: dict[str, int] = {
-    "foreground": 2,
-    "cron": 1,
-    "mailbox": 1,
-    "room_family": 1,
-    "state_source": 1,
-    "governance": 1,
-}
-_MAX_CONTINUITY_RECORDS: int = 8
+# Continuity selector constants — imported from prefetch (single source of
+# truth) rather than hand-copied, so seed-slot/marker vocabulary drift
+# between the live selector and this mirror is structurally impossible.
 
 
 class EventStats:
@@ -117,6 +115,20 @@ def _dict_global_sort_key(evt: dict[str, object]) -> tuple[float, str, str]:
     return (_dict_event_importance(evt), str(evt.get("ts", "")), str(evt.get("id", "")))
 
 
+def _dict_is_bookkeeping_event_kind(evt: dict[str, object]) -> bool:
+    """Dict-based mirror of prefetch._is_bookkeeping_event_kind.
+
+    Uses the same _BOOKKEEPING_FILL_KIND_MARKERS imported from prefetch
+    (one source of truth for the marker vocabulary) applied to a dict's
+    "kind" field instead of getattr(event, "kind", "").
+    """
+    kind = str(evt.get("kind", "") or "").lower()
+    return any(
+        kind == marker or kind.startswith(marker)
+        for marker in _BOOKKEEPING_FILL_KIND_MARKERS
+    )
+
+
 def _build_continuity_selector(events: list[dict[str, object]]) -> dict[str, object]:
     """Compute continuity selector summary from sorted event dicts.
 
@@ -139,8 +151,16 @@ def _build_continuity_selector(events: list[dict[str, object]]) -> dict[str, obj
             "max_records": _MAX_CONTINUITY_RECORDS,
         }
 
-    # newest-first for seed slot selection (mirrors reverse ts sort in original)
-    events_rev: list[dict[str, object]] = list(reversed(events))
+    # newest-first for seed slot selection — mirrors prefetch's explicit
+    # sorted(source, key=lambda e: (e.ts, e.id), reverse=True). A plain
+    # list(reversed(events)) only matches that when every ts is unique;
+    # ties in ts must break the same way on both sides or the two
+    # selectors can disagree on which of two same-instant events wins.
+    events_rev: list[dict[str, object]] = sorted(
+        events,
+        key=lambda evt: (str(evt.get("ts", "")), str(evt.get("id", ""))),
+        reverse=True,
+    )
     buckets: dict[str, list[dict[str, object]]] = {sc: [] for sc in _CONTINUITY_SEED_SLOTS}
     for evt in events_rev:
         sc = _dict_source_class(evt)
@@ -161,7 +181,17 @@ def _build_continuity_selector(events: list[dict[str, object]]) -> dict[str, obj
 
     # Phase 2: fill remaining slots by (_global_sort_key, reverse=True)
     # (mirrors: sorted(remaining, key=_global_sort_key, reverse=True))
-    remaining = [evt for evt in events_rev if str(evt.get("id", "")) not in selected_ids]
+    # Bookkeeping-kind events (governance_*, state_source_*, session_fact_
+    # extracted, session_observed — see _BOOKKEEPING_FILL_KIND_MARKERS) are
+    # excluded from this global recency fill ONLY, matching
+    # prefetch._select_continuity_events line 3074-3078. The seed slots
+    # above are untouched by this exclusion — that asymmetry is a pinned
+    # design decision, not an oversight.
+    remaining = [
+        evt for evt in events_rev
+        if str(evt.get("id", "")) not in selected_ids
+        and not _dict_is_bookkeeping_event_kind(evt)
+    ]
     for evt in sorted(remaining, key=_dict_global_sort_key, reverse=True):
         if len(selected_ids) >= _MAX_CONTINUITY_RECORDS:
             break
@@ -252,8 +282,11 @@ def read_event_stats(roots: object) -> tuple[EventStats | None, str]:
     updated_at = data.get("updated_at")
     if isinstance(updated_at, str) and updated_at:
         try:
-            age = (datetime.now(timezone.utc) - datetime.fromisoformat(updated_at)).total_seconds()
-        except ValueError:
+            parsed_updated_at = datetime.fromisoformat(updated_at)
+            if parsed_updated_at.tzinfo is None:
+                parsed_updated_at = parsed_updated_at.replace(tzinfo=timezone.utc)
+            age = (datetime.now(timezone.utc) - parsed_updated_at).total_seconds()
+        except (ValueError, TypeError):
             age = float("inf")
         if age < 900:
             freshness = "fresh"

--- a/plugins/memory/memory_os/event_stats.py
+++ b/plugins/memory/memory_os/event_stats.py
@@ -19,6 +19,7 @@ from .prefetch import (
     _BRIDGE_SEED_SLOTS as _CONTINUITY_SEED_SLOTS,
     _MAX_CONTINUITY_RECORDS,
 )
+from .timeutil import ensure_utc_aware
 
 EVENT_STATS_SCHEMA_VERSION = "memory-os.event_stats.v0"
 
@@ -283,8 +284,7 @@ def read_event_stats(roots: object) -> tuple[EventStats | None, str]:
     if isinstance(updated_at, str) and updated_at:
         try:
             parsed_updated_at = datetime.fromisoformat(updated_at)
-            if parsed_updated_at.tzinfo is None:
-                parsed_updated_at = parsed_updated_at.replace(tzinfo=timezone.utc)
+            parsed_updated_at = ensure_utc_aware(parsed_updated_at)
             age = (datetime.now(timezone.utc) - parsed_updated_at).total_seconds()
         except (ValueError, TypeError):
             age = float("inf")

--- a/plugins/memory/memory_os/execution_gate.py
+++ b/plugins/memory/memory_os/execution_gate.py
@@ -316,14 +316,42 @@ def resolve_execution_gate_permit(
             risk_class=risk_class,
         )
 
-    # Fast path: O(1) index lookup
+    # Fast path: O(1) index lookup.
+    #
+    # DELIBERATELY disabled whenever require_unused=True -- do not "fix" this
+    # by dropping the `and not require_unused` clause below. The sidecar
+    # index's completion_count is NOT authoritative for that check:
+    #
+    #  1. It is written by a write that is separate from (and not atomic
+    #     with) the journal append it derives from. complete_execution_gate_
+    #     envelope() appends the canonical "completion" record to the
+    #     journal, then -- as a second, later step -- calls
+    #     _update_gate_index() to bump the sidecar's completion_count. A
+    #     process kill between those two steps leaves the journal correctly
+    #     showing "completed" while the sidecar entry stays PRESENT but
+    #     STALE (completion_count still 0). Unlike a genuinely missing
+    #     index entry, this does not self-heal via the "index miss" full
+    #     scan below, because the entry exists and looks fine.
+    #  2. A second, independent writer of this exact sidecar file exists:
+    #     scripts/memory_os_execution_gate_runner.py::_update_sidecar_index
+    #     (the cron-wrapper permit path). It does not import or share code
+    #     with this module, so any freshness/watermark scheme added here
+    #     alone would not be honored by that writer either.
+    #
+    # tests/plugins/memory/test_memory_os_execution_gate.py::
+    # test_resolve_require_unused_rejects_canonical_completion_missing_from_sidecar
+    # pins this: a completion appended straight to the journal (bypassing
+    # the sidecar entirely) must still be caught when require_unused=True.
+    # That only holds because require_unused=True always falls through to
+    # the full-journal scan below, which reads the canonical journal
+    # directly instead of trusting the sidecar. A slow-but-correct gate
+    # beats a fast-but-weak one here (see CLAUDE.md "No Silent Failures").
     idx = _read_gate_index(roots)
     index_entry = idx.get(target)
-    if (
-        index_entry is not None
-        and index_entry.get("permit_decision") is not None
-        and not require_unused
-    ):
+    index_entry_fresh = (
+        index_entry is not None and index_entry.get("permit_decision") is not None
+    )
+    if index_entry_fresh and not require_unused:
         failed = _validate_index_entry(
             index_entry, target, lane_id, risk_class,
             require_fresh, require_unused, expected_scope, expected_scope_hash, now,
@@ -346,7 +374,15 @@ def resolve_execution_gate_permit(
             scope_match=True if expected_hash else None,
         )
 
-    # Index miss — fall back to full scan (limit=0 = no window)
+    # Index miss (or require_unused=True bypass) — fall back to full scan.
+    # limit=0 is deliberate, not an oversight: a permit or its completion
+    # record can be arbitrarily far back in the journal relative to when it
+    # is resolved (see test_old_permit_beyond_2000_window_still_resolvable /
+    # spec B.1), so windowing this read would let an old-but-valid permit
+    # read as "not found", or -- far worse -- let an old completion record
+    # fall outside the window and an already-used permit read as unused.
+    # A documented O(journal length) read here is intentional; do not
+    # "optimize" it into a windowed read.
     records = read_execution_gate_records(roots, limit=0)
     permits = [
         record
@@ -410,7 +446,21 @@ def resolve_execution_gate_permit(
         scope_match=True if expected_hash else None,
         require_fresh=require_fresh,
     )
-    _rebuild_gate_index_from_records(roots, records)
+    if not index_entry_fresh:
+        # The sidecar had no usable entry for this envelope (missing file,
+        # deleted entry, or an entry without permit_decision -- see
+        # test_index_miss_falls_back_to_full_scan). Populate it now so
+        # future resolves can use the O(1) fast path.
+        #
+        # When index_entry_fresh is True, we only reached this full scan
+        # because require_unused=True forced the bypass above (the sidecar
+        # itself was fine) -- so there is nothing stale to repair, and
+        # rebuilding the whole index here on every call is exactly the
+        # perf defect this fix removes: a lane appending N governed
+        # records under one envelope no longer rewrites
+        # execution_gate_index.json N times (see
+        # test_require_unused_success_does_not_rewrite_index).
+        _rebuild_gate_index_from_records(roots, records)
     return result
 
 

--- a/plugins/memory/memory_os/exposure_rollup.py
+++ b/plugins/memory/memory_os/exposure_rollup.py
@@ -67,6 +67,7 @@ ATTRIBUTABLE_SOURCE_CLASSES = frozenset({
     "event",          # event:<event_id>
     "indexed",        # <record_type>:<record_id> from the FTS index
     "graph_layer",    # <record_type>:<record_id> reached by graph traversal
+    "recall_facade",  # composite retriever-facade recall; each object's own source_ref
 })
 
 # Deliberately NOT attributable, one reason per class. These are derived or

--- a/plugins/memory/memory_os/index.py
+++ b/plugins/memory/memory_os/index.py
@@ -79,8 +79,15 @@ class MemoryOSIndex:
             )
             if _embedder_available:
                 _index_embeddings(conn, self.roots.crystallized_root, self._embedder)
+                _embedding_preservation: dict[str, Any] = {"outcome": "embedder_available"}
             elif self.roots.index_path.exists():
-                _copy_embeddings_from_live(conn, self.roots.index_path)
+                _embedding_preservation = _copy_embeddings_from_live(conn, self.roots.index_path)
+            else:
+                _embedding_preservation = {
+                    "outcome": "no_live_index",
+                    "live_row_count": 0,
+                    "copied_row_count": 0,
+                }
             _index_audit_entries(conn, self.roots.audit_path)
             _index_edges(conn, self.roots)
             if _entity_index_enabled(store):
@@ -102,8 +109,36 @@ class MemoryOSIndex:
             action="index_rebuild",
             status="ok",
             target=str(self.roots.index_path),
-            details={},
+            details={"embedding_preservation": _embedding_preservation},
         )
+        if _embedding_preservation.get("outcome") == "copy_failed":
+            # Fail-open by design (see _copy_embeddings_from_live): the
+            # rebuild above already completed and shipped. This is the
+            # loud record that a silent embedding wipe would otherwise be
+            # indistinguishable from a healthy rebuild — the "No Silent
+            # Failures" bounded error record, same shape as the
+            # entity_index knob-resolution failure above.
+            from .jsonl_io import build_error_record as _build_error_record
+
+            _error_record = _build_error_record(
+                component="sqlite",
+                operation="copy_embeddings_from_live",
+                error_code="EMBEDDINGS_COPY_FROM_LIVE_FAILED",
+                severity="warning",
+                recoverable=True,
+                details={
+                    "error": str(_embedding_preservation.get("error", "")),
+                    "live_row_count": _embedding_preservation.get("live_row_count", 0),
+                    "copied_row_count": _embedding_preservation.get("copied_row_count", 0),
+                },
+            )
+            append_audit(
+                self.roots.audit_path,
+                action="index_rebuild_embeddings_copy_failed",
+                status="warning",
+                target=str(self.roots.index_path),
+                details={"error_record": _error_record},
+            )
 
     def try_rebuild_from_store(self, store: MemoryOSStore) -> bool:
         try:
@@ -735,22 +770,108 @@ def _clear_table(conn: sqlite3.Connection, table: str) -> None:
     conn.execute(f"delete from {table}")
 
 
-def _copy_embeddings_from_live(staging_conn: sqlite3.Connection, live_path: Path) -> None:
+def _copy_embeddings_from_live(staging_conn: sqlite3.Connection, live_path: Path) -> dict[str, Any]:
     """Copy memory_embeddings from the live index into a staging DB.
 
     Used by rebuild_from_store to preserve embeddings across a rebuild
     when the embedder is not available (P0.2-class guard — prevents
     silent embedding wipe).
+
+    Fail-open by design: any sqlite3.Error here (live index locked,
+    corrupt, or missing its table) must never abort the rebuild — the
+    staging DB always ships. What changes with this contract is that the
+    outcome is now reported through a CLOSED set of reason codes instead
+    of a bare `pass`, so a caller can tell "live had rows, staging has
+    zero" (a silent wipe) from "live genuinely had nothing to copy"
+    (idle/healthy) without re-running anything:
+
+      - "no_live_index": live_path does not exist.
+      - "live_table_missing": live DB attached but has no
+        memory_embeddings table (e.g. pre-embeddings schema).
+      - "copy_failed": ATTACH or the copy raised sqlite3.Error (locked,
+        corrupt, etc.) — live_row_count reflects what was readable
+        before the failure, if any.
+      - "copied": copy completed; live_row_count/copied_row_count are
+        counted independently (before/after) so a short copy is visible.
     """
+    if not live_path.exists():
+        return {"outcome": "no_live_index", "live_row_count": 0, "copied_row_count": 0}
+
+    attached = False
+    live_row_count = 0
     try:
-        staging_conn.execute(f"ATTACH DATABASE '{live_path}' AS live")
+        staging_conn.execute("ATTACH DATABASE ? AS live", (str(live_path),))
+        attached = True
+        table_exists = staging_conn.execute(
+            "select 1 from live.sqlite_master where type = 'table' and name = 'memory_embeddings'"
+        ).fetchone()
+        if not table_exists:
+            return {"outcome": "live_table_missing", "live_row_count": 0, "copied_row_count": 0}
+        live_row_count = staging_conn.execute(
+            "select count(*) from live.memory_embeddings"
+        ).fetchone()[0]
         staging_conn.execute(
             "INSERT INTO main.memory_embeddings "
             "SELECT * FROM live.memory_embeddings"
         )
-        staging_conn.execute("DETACH live")
+        copied_row_count = staging_conn.execute(
+            "select count(*) from main.memory_embeddings"
+        ).fetchone()[0]
+        return {
+            "outcome": "copied",
+            "live_row_count": live_row_count,
+            "copied_row_count": copied_row_count,
+        }
+    except sqlite3.Error as exc:
+        # fail-open: live index may be locked or corrupt — the rebuild
+        # must still complete; the loss is reported, not swallowed.
+        # live_row_count may still be 0 here if ATTACH itself raised
+        # before the in-transaction count could run — fall back to an
+        # independent direct connection so a wipe (live had rows) stays
+        # distinguishable from an idle rebuild (live had none) even when
+        # the ATTACH-based path never got far enough to count anything.
+        if live_row_count == 0:
+            live_row_count = _best_effort_live_embedding_count(live_path)
+        return {
+            "outcome": "copy_failed",
+            "live_row_count": live_row_count,
+            "copied_row_count": 0,
+            "error": str(exc),
+        }
+    finally:
+        if attached:
+            try:
+                staging_conn.execute("DETACH live")
+            except sqlite3.Error:
+                pass
+
+
+def _best_effort_live_embedding_count(live_path: Path) -> int:
+    """Independently probe how many rows live.memory_embeddings has.
+
+    Used only on the copy_failed path in _copy_embeddings_from_live, via a
+    fresh direct connection (not the staging conn's failed ATTACH), so the
+    audit can still report a nonzero live_row_count when the ATTACH-based
+    copy itself is what failed (e.g. a lock held only against ATTACH).
+    Best-effort: if this probe also fails, 0 is returned rather than
+    raising — the caller already has a copy_failed outcome to report.
+    """
+    try:
+        probe_conn = sqlite3.connect(str(live_path))
     except sqlite3.Error:
-        pass  # fail-open: live index may not exist, be locked, or be corrupt
+        return 0
+    try:
+        table_exists = probe_conn.execute(
+            "select 1 from sqlite_master where type = 'table' and name = 'memory_embeddings'"
+        ).fetchone()
+        if not table_exists:
+            return 0
+        row = probe_conn.execute("select count(*) from memory_embeddings").fetchone()
+        return int(row[0]) if row else 0
+    except sqlite3.Error:
+        return 0
+    finally:
+        probe_conn.close()
 
 
 def _index_events(conn: sqlite3.Connection, store: MemoryOSStore) -> None:

--- a/plugins/memory/memory_os/knob_overrides.py
+++ b/plugins/memory/memory_os/knob_overrides.py
@@ -19,6 +19,7 @@ from typing import Any
 from uuid import uuid4
 
 from .roots import MemoryOSRoots
+from .timeutil import ensure_utc_aware
 
 # ── Dedup sentinel — must be a unique object that cannot appear in JSON ──
 _SENTINEL = object()
@@ -940,8 +941,7 @@ def _is_expired(expires_str: str, now: datetime) -> bool:
     """
     try:
         expires_at = datetime.fromisoformat(expires_str)
-        if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        expires_at = ensure_utc_aware(expires_at)
         return expires_at <= now
     except (ValueError, TypeError):
         return False

--- a/plugins/memory/memory_os/knob_overrides.py
+++ b/plugins/memory/memory_os/knob_overrides.py
@@ -672,6 +672,21 @@ def register_override(
             f"Knob '{name}' is meta=True — self-tuning of governance knobs is blocked"
         )
 
+    # expires_at: "" is the documented "no expiry" sentinel and stays valid.
+    # Anything else must be a parseable ISO-8601 timestamp -- reject a
+    # malformed value at this write boundary rather than letting it reach
+    # the store, where _is_expired's fail-open contract would silently
+    # treat it as never-expiring. Naive (no-offset) timestamps DO parse
+    # here and are accepted -- _is_expired treats them as UTC.
+    if expires_at:
+        try:
+            datetime.fromisoformat(expires_at)
+        except ValueError as exc:
+            raise ValueError(
+                f"expires_at {expires_at!r} for knob '{name}' is not a valid "
+                f"ISO-8601 timestamp"
+            ) from exc
+
     # Allowed-list knobs: validate against allowed list
     allowed = spec.get("allowed")
     if allowed is not None:
@@ -907,11 +922,28 @@ def _is_provisional_state(record: dict[str, Any]) -> bool:
 
 
 def _is_expired(expires_str: str, now: datetime) -> bool:
-    """Check if an ISO-format expiry string is in the past."""
+    """Check if an ISO-format expiry string is in the past.
+
+    ``now`` is always timezone-aware (``datetime.now(timezone.utc)`` or an
+    aware ``_now`` override). A timezone-*naive* ``expires_str`` (e.g.
+    ``"2026-12-31"`` or ``"2026-12-31T00:00:00"``) parses without error via
+    ``fromisoformat`` but then raises ``TypeError`` on comparison against an
+    aware datetime -- this store's own writers (register_override /
+    revert_override / confirm_override) always stamp aware UTC timestamps,
+    so a naive value only reaches here via a hand-edited record on this
+    owner-facing JSONL surface, or a future caller that doesn't. Treat a
+    naive timestamp as UTC rather than letting the comparison raise. Genuine
+    parse failures keep the original fail-open contract: an override whose
+    expiry cannot be understood at all is treated as not-expired (still
+    active) rather than crashing the hot-path callers (resolve_knob /
+    resolve_knobs / list_active_overrides).
+    """
     try:
         expires_at = datetime.fromisoformat(expires_str)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
         return expires_at <= now
-    except ValueError:
+    except (ValueError, TypeError):
         return False
 
 

--- a/plugins/memory/memory_os/llm_contradiction_lane.py
+++ b/plugins/memory/memory_os/llm_contradiction_lane.py
@@ -656,7 +656,11 @@ def run_contradiction_lane(
         }
 
     # ── 2. LLM claim extraction + contradiction judgment ──────────────
-    from .low_clue_recall import _call_hermes_runtime_model, _resolve_hermes_default_runtime
+    from .low_clue_recall import (
+        _call_hermes_runtime_model,
+        _extract_json_object,
+        _resolve_hermes_default_runtime,
+    )
 
     # Reuse the same LLM config pattern as llm_edge_proposer
     _DEFAULT_LLM_CONFIG: dict[str, Any] = {
@@ -719,30 +723,60 @@ def run_contradiction_lane(
             ))
             continue
 
-        # Parse LLM response
+        # Parse LLM response. Converge on the project's canonical parser
+        # (_extract_json_object) for contract consistency with
+        # fact_judge.py / session_fact_extraction.py — see CLAUDE.md "LLM
+        # Integration - Reuse, Never Rebuild". A hand-rolled brace-depth
+        # counter used to live here; it broke silently whenever a claim
+        # value itself contained an unbalanced "{" (depth never returned to
+        # 0, `end` stayed -1, the pair was dropped with no signal).
+        # _extract_json_object instead takes the outermost
+        # find("{")..rfind("}") span, which does not share that failure
+        # mode. No trailing-prose fallback is added: the prompt instructs
+        # "Return ONLY a JSON object", and fact_judge.py -- the reference
+        # implementation this converges toward -- has no such fallback
+        # either.
         try:
             parsed = json.loads(response.strip())
         except json.JSONDecodeError:
-            # Extract outermost JSON object (handles nested braces in claim values)
-            start = response.find("{")
-            if start == -1:
-                continue
-            # Find matching close brace
-            depth = 0
-            end = -1
-            for _i in range(start, len(response)):
-                if response[_i] == "{":
-                    depth += 1
-                elif response[_i] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        end = _i
-                        break
-            if end == -1:
-                continue
-            try:
-                parsed = json.loads(response[start:end + 1])
-            except json.JSONDecodeError:
+            parsed = None
+
+        if not isinstance(parsed, dict):
+            # Covers two cases with one guard: the first attempt raised
+            # (parsed is None above), or it succeeded but yielded a
+            # non-dict JSON value (a bare list/string/number) -- the same
+            # shape that crashed llm_edge_proposer._call_llm inside
+            # float(parsed.get("confidence")) before its own
+            # `if not isinstance(parsed, dict)` guard was added. Left
+            # unguarded here, the following parsed.get("claim_a") would
+            # raise AttributeError uncaught, killing this whole
+            # run_contradiction_lane call mid-loop after some pairs were
+            # already processed. _extract_json_object already returns None
+            # for a non-dict result, so this second attempt is a no-op
+            # when there is no nested object to recover.
+            parsed = _extract_json_object(response)
+            if not isinstance(parsed, dict):
+                # Backlog 14 (Completion Is Not Output), same family as the
+                # llm_empty_content case just above: a reply came back but
+                # could not be parsed as a JSON object. A bare `continue`
+                # here made a run where every reply was garbage (or
+                # validly-parsed-but-wrong-shape) indistinguishable from
+                # "genuinely no contradictions" -- give it the same typed
+                # error-record treatment as the empty-reply path. Reusing
+                # llm_parse_failed rather than a sibling code: from the
+                # monitor's perspective both are "the reply could not be
+                # turned into a claim pair," and the existing counterfactual
+                # test for the extraction-failure case already covers this
+                # error_code, so no test/monitor vocabulary drift is
+                # introduced by folding this case into it.
+                error_records.append(_build_error_record(
+                    component="llm_contradiction_lane",
+                    operation="hermes_runtime_call",
+                    error_code="llm_parse_failed",
+                    severity="warning",
+                    recoverable=True,
+                    details={"record_a": pair["a"]["id"], "record_b": pair["b"]["id"]},
+                ))
                 continue
 
         claim_a = parsed.get("claim_a") if isinstance(parsed.get("claim_a"), dict) else {}

--- a/plugins/memory/memory_os/llm_edge_proposer.py
+++ b/plugins/memory/memory_os/llm_edge_proposer.py
@@ -81,8 +81,13 @@ If "none", still respond with valid JSON showing relation_type "none"."""
 def _call_llm(record_a: dict[str, Any], record_b: dict[str, Any]) -> dict[str, Any]:
     """Call the configured Hermes LLM to determine relationship between two records.
 
-    Returns a dict with keys: relation_type, confidence, reasoning.
-    Returns {"relation_type": "none", "confidence": 0.0, "reasoning": "llm_unavailable"} on failure.
+    Returns a dict with keys: relation_type, confidence, reasoning, outcome.
+    ``outcome`` is a closed-set typed failure value ("ok" on success) mirroring
+    fact_judge.py's failure_reason typing — llm_call_exception / empty_llm_response
+    / parse_failed / not_a_dict / invalid_confidence. Never raises: every failure
+    path (including a non-numeric or null "confidence" field, which previously
+    propagated a bare ValueError/TypeError out of this function) returns a typed
+    failure dict with relation_type "none" and confidence 0.0 instead.
     """
     kind_a = str(record_a.get("kind", ""))
     kind_b = str(record_b.get("kind", ""))
@@ -103,10 +108,16 @@ def _call_llm(record_a: dict[str, Any], record_b: dict[str, Any]) -> dict[str, A
     try:
         response = _call_hermes_runtime_model(prompt, _DEFAULT_LLM_CONFIG)
     except Exception:
-        return {"relation_type": "none", "confidence": 0.0, "reasoning": "llm_call_exception"}
+        return {
+            "relation_type": "none", "confidence": 0.0,
+            "reasoning": "llm_call_exception", "outcome": "llm_call_exception",
+        }
 
     if not response or not response.strip():
-        return {"relation_type": "none", "confidence": 0.0, "reasoning": "empty_llm_response"}
+        return {
+            "relation_type": "none", "confidence": 0.0,
+            "reasoning": "empty_llm_response", "outcome": "empty_llm_response",
+        }
 
     # Parse JSON from response (handle wrapping markdown code fences)
     json_str = response.strip()
@@ -118,22 +129,41 @@ def _call_llm(record_a: dict[str, Any], record_b: dict[str, Any]) -> dict[str, A
     try:
         parsed = json.loads(json_str)
     except (json.JSONDecodeError, TypeError):
-        return {"relation_type": "none", "confidence": 0.0, "reasoning": "parse_failed"}
+        return {
+            "relation_type": "none", "confidence": 0.0,
+            "reasoning": "parse_failed", "outcome": "parse_failed",
+        }
 
     if not isinstance(parsed, dict):
-        return {"relation_type": "none", "confidence": 0.0, "reasoning": "not_a_dict"}
+        return {
+            "relation_type": "none", "confidence": 0.0,
+            "reasoning": "not_a_dict", "outcome": "not_a_dict",
+        }
 
     rtype = str(parsed.get("relation_type", "none")).strip().lower()
     if rtype not in ("refines", "contradicts", "depends_on", "co_occurs", "none"):
         rtype = "none"
 
-    confidence = float(parsed.get("confidence", 0.0))
+    # D1 fix: the model reply's "confidence" field is untrusted input — a
+    # non-numeric string (e.g. "high") raises ValueError, null raises
+    # TypeError. Both used to propagate out of this function (and out of
+    # run_llm_proposer's pair loop) with no failure typing, ending the run
+    # after partial writes. Type it the way fact_judge.py types LLM-reply
+    # failures: a typed failure dict, never a raised exception.
+    try:
+        confidence = float(parsed.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        return {
+            "relation_type": "none", "confidence": 0.0,
+            "reasoning": "invalid_confidence", "outcome": "invalid_confidence",
+        }
     reasoning = str(parsed.get("reasoning", ""))
 
     return {
         "relation_type": rtype,
         "confidence": min(max(confidence, 0.0), 1.0),
         "reasoning": reasoning,
+        "outcome": "ok",
     }
 
 
@@ -172,7 +202,6 @@ def run_llm_proposer(
     *,
     index: object | None = None,
     audit_path: str | None = None,
-    batch: bool = True,
 ) -> dict[str, Any]:
     """Run the LLM-class edge proposer across all crystallized record pairs.
 
@@ -183,10 +212,22 @@ def run_llm_proposer(
         index_path: Path to the index DB.
         index: MemoryOSIndex instance (needed for edge writing).
         audit_path: Optional audit path.
-        batch: If True, batches all pairs into a single LLM call (cheaper).
-               If False, calls LLM per pair (more accurate).
 
-    Returns a summary dict.
+    Every eligible pair makes its own sequential LLM round-trip (up to
+    _MAX_PAIRS=100, each bounded by _DEFAULT_LLM_CONFIG["timeout_ms"]).
+    D2: this function used to accept a dead ``batch`` parameter, documented
+    as "batches all pairs into a single LLM call (cheaper)" but never read
+    anywhere in the body — no caller ever passed it (grepped repo-wide), so
+    it was removed rather than wired up. There is no batched call path;
+    real batching would be a behavior change beyond this fix.
+
+    Returns a summary dict. ``status`` is "ok" unless at least one pair's
+    LLM call failed this run, in which case it is "degraded" — see
+    ``llm_call_failure_count`` / ``llm_call_failure_reasons`` for the typed
+    breakdown and ``outcome`` for a closed-set characterization of what the
+    run produced (no_eligible_pairs / llm_degraded / no_relationships_found
+    / produced), so "the judge found nothing" is distinguishable from "the
+    judge could not be reached" without re-running or reading source.
     """
     start_time = datetime.now(timezone.utc)
 
@@ -272,6 +313,14 @@ def run_llm_proposer(
     proposed = 0
     auto_active = 0
     dedup_skipped = 0
+    # D2b: per-run _call_llm outcome tally. "Completion Is Not Output" —
+    # pair_count=100/proposed_count=0 was byte-identical whether the judge
+    # legitimately found no relationships or every call failed; these
+    # counters (surfaced in the summary below) make that distinguishable
+    # from the summary alone, without re-running or reading source.
+    llm_call_count = 0
+    llm_ok_count = 0
+    llm_failure_reasons: dict[str, int] = {}
 
     for i in range(len(records)):
         if pairs >= _MAX_PAIRS:
@@ -293,6 +342,12 @@ def run_llm_proposer(
 
             # Call LLM for this pair
             llm_result = _call_llm(records[i], records[j])
+            llm_call_count += 1
+            call_outcome = str(llm_result.get("outcome", "ok"))
+            if call_outcome == "ok":
+                llm_ok_count += 1
+            else:
+                llm_failure_reasons[call_outcome] = llm_failure_reasons.get(call_outcome, 0) + 1
             rtype = llm_result.get("relation_type", "none")
             confidence = llm_result.get("confidence", 0.0)
 
@@ -334,13 +389,36 @@ def run_llm_proposer(
                         auto_active += 1
 
     elapsed_ms = int((datetime.now(timezone.utc) - start_time).total_seconds() * 1000)
+    llm_failure_count = sum(llm_failure_reasons.values())
+
+    # D2b closed outcome set — what this run actually produced, distinct
+    # from "status" (whether calls degraded). See docstring above.
+    if llm_call_count == 0:
+        run_outcome = "no_eligible_pairs"
+    elif llm_ok_count == 0:
+        run_outcome = "llm_degraded"
+    elif proposed:
+        run_outcome = "produced"
+    else:
+        run_outcome = "no_relationships_found"
+
+    # D2b: status must not lie "ok" through call failures — any typed
+    # _call_llm failure this run marks the lane degraded, even if other
+    # pairs succeeded and produced edges.
+    run_status = "degraded" if llm_failure_count > 0 else "ok"
+
     summary = {
-        "status": "ok",
+        "status": run_status,
+        "outcome": run_outcome,
         "record_count": len(records),
         "pair_count": pairs,
         "proposed_count": proposed,
         "auto_active_count": auto_active,
         "dedup_skipped": dedup_skipped,
+        "llm_call_count": llm_call_count,
+        "llm_call_ok_count": llm_ok_count,
+        "llm_call_failure_count": llm_failure_count,
+        "llm_call_failure_reasons": llm_failure_reasons,
         "duration_ms": elapsed_ms,
         "begin_at": start_time.isoformat(),
         "llm_model": _resolve_runtime().get("model", "unknown"),
@@ -351,7 +429,7 @@ def run_llm_proposer(
         append_audit(
             Path(audit_path),
             action="llm_edge_proposer_run",
-            status="ok",
+            status=run_status,
             target=str(index_path),
             details=summary,
         )

--- a/plugins/memory/memory_os/loop_health_view.py
+++ b/plugins/memory/memory_os/loop_health_view.py
@@ -35,6 +35,7 @@ from typing import Any
 
 from .cron_registry import LANE_LAST_RUN_EVIDENCE, MEMORY_OS_CRON_LANES
 from .lane_last_run import read_lane_last_run
+from .timeutil import ensure_utc_aware
 
 LOOP_HEALTH_VIEW_SCHEMA_VERSION = "memory-os.loop_health_view.v0"
 
@@ -93,9 +94,7 @@ def _parse_recorded_at(value: str) -> datetime | None:
         parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return ensure_utc_aware(parsed)
 
 
 def build_loop_health_view(

--- a/plugins/memory/memory_os/loop_health_view.py
+++ b/plugins/memory/memory_os/loop_health_view.py
@@ -90,9 +90,12 @@ _FRESHNESS_CADENCE_MULTIPLIER = 3
 
 def _parse_recorded_at(value: str) -> datetime | None:
     try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def build_loop_health_view(

--- a/plugins/memory/memory_os/memory_sources.py
+++ b/plugins/memory/memory_os/memory_sources.py
@@ -596,10 +596,12 @@ def _records_since(records: list[dict[str, Any]], *, hours: int) -> list[dict[st
     for record in records:
         try:
             created_at = datetime.fromisoformat(str(record.get("created_at", "")).replace("Z", "+00:00"))
-        except ValueError:
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            if created_at >= cutoff:
+                result.append(record)
+        except (ValueError, TypeError):
             continue
-        if created_at >= cutoff:
-            result.append(record)
     return result
 
 

--- a/plugins/memory/memory_os/memory_sources.py
+++ b/plugins/memory/memory_os/memory_sources.py
@@ -14,6 +14,7 @@ from .audit import append_audit
 from .context_router import ContextSection
 from .roots import MemoryOSRoots
 from .source_ids import filter_safe_source_id_values
+from .timeutil import ensure_utc_aware
 
 
 SCHEMA_VERSION = "memory-os.memory_sources.v0"
@@ -596,8 +597,7 @@ def _records_since(records: list[dict[str, Any]], *, hours: int) -> list[dict[st
     for record in records:
         try:
             created_at = datetime.fromisoformat(str(record.get("created_at", "")).replace("Z", "+00:00"))
-            if created_at.tzinfo is None:
-                created_at = created_at.replace(tzinfo=timezone.utc)
+            created_at = ensure_utc_aware(created_at)
             if created_at >= cutoff:
                 result.append(record)
         except (ValueError, TypeError):

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -53,6 +53,7 @@ from .jsonl_io import (
     locked_jsonl_file,
 )
 from .store import MemoryOSStore
+from .timeutil import ensure_utc_aware
 from .review_content_safety import (
     contains_transcript_marker as _shared_contains_transcript_marker,
     looks_like_raw_review_content as _shared_looks_like_raw_review_content,
@@ -5311,8 +5312,7 @@ def _provisional_crystallized_review_items(store: MemoryOSStore, closed: set[str
                 # owner digest. Normalize before subtracting, same as
                 # knob_overrides._is_expired. Genuinely unparseable input
                 # keeps the existing fail-open default (999 / "fyi").
-                if expires_at.tzinfo is None:
-                    expires_at = expires_at.replace(tzinfo=timezone.utc)
+                expires_at = ensure_utc_aware(expires_at)
                 remaining_seconds = (expires_at - now).total_seconds()
                 remaining_days = max(0, int(remaining_seconds / 86400))
             except (ValueError, TypeError):
@@ -5396,8 +5396,7 @@ def _provisional_knob_override_review_items(store: MemoryOSStore, closed: set[st
         if expires_str:
             try:
                 expires_dt = datetime.fromisoformat(expires_str)
-                if expires_dt.tzinfo is None:
-                    expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+                expires_dt = ensure_utc_aware(expires_dt)
                 remaining = expires_dt - datetime.now(timezone.utc)
                 days_left = f"{max(0, remaining.days)}d"
             except (ValueError, TypeError):

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -450,6 +450,7 @@ def _candidate_aggregation_status_block(store: MemoryOSStore) -> dict[str, Any]:
             "demoted_count": 0,
             "fleeting_count": 0,
             "compacted_count": 0,
+            "compaction_skip_reason": "",
         }
     return {
         "available": True,
@@ -462,6 +463,7 @@ def _candidate_aggregation_status_block(store: MemoryOSStore) -> dict[str, Any]:
         "demoted_count": int(latest.get("demoted_count", 0)),
         "fleeting_count": int(latest.get("fleeting_count", 0)),
         "compacted_count": int(latest.get("compacted_count", 0)),
+        "compaction_skip_reason": str(latest.get("compaction_skip_reason") or ""),
     }
 
 
@@ -5300,6 +5302,17 @@ def _provisional_crystallized_review_items(store: MemoryOSStore, closed: set[str
         if expires_str:
             try:
                 expires_at = datetime.fromisoformat(expires_str)
+                # Naive (no-offset) expires_str parses without error but
+                # raises TypeError on the aware subtraction below -- not a
+                # ValueError, so the bare `except ValueError` would not
+                # catch it, and previously the naive-input path fell through
+                # to the remaining_days=999 default, silently mis-priming
+                # this item to "fyi" instead of its real urgency in the
+                # owner digest. Normalize before subtracting, same as
+                # knob_overrides._is_expired. Genuinely unparseable input
+                # keeps the existing fail-open default (999 / "fyi").
+                if expires_at.tzinfo is None:
+                    expires_at = expires_at.replace(tzinfo=timezone.utc)
                 remaining_seconds = (expires_at - now).total_seconds()
                 remaining_days = max(0, int(remaining_seconds / 86400))
             except (ValueError, TypeError):
@@ -5383,9 +5396,11 @@ def _provisional_knob_override_review_items(store: MemoryOSStore, closed: set[st
         if expires_str:
             try:
                 expires_dt = datetime.fromisoformat(expires_str)
+                if expires_dt.tzinfo is None:
+                    expires_dt = expires_dt.replace(tzinfo=timezone.utc)
                 remaining = expires_dt - datetime.now(timezone.utc)
                 days_left = f"{max(0, remaining.days)}d"
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
         summary = (
@@ -5810,6 +5825,19 @@ def _fyi_items(status: dict[str, Any], *, limit: int, start: int = 1) -> list[di
     raw_aggr = status.get("candidate_aggregation")
     aggr: dict[str, Any] = raw_aggr if isinstance(raw_aggr, dict) else {}
     if aggr.get("available"):
+        aggr_summary = (
+            f"聚合上次运行: promoted={aggr.get('promoted_count')}; "
+            f"rejected_demoted={aggr.get('rejected_demoted_count')}; "
+            f"demoted={aggr.get('demoted_count')}; "
+            f"fleeting={aggr.get('fleeting_count')}; "
+            f"compacted={aggr.get('compacted_count')}"
+        )
+        # Only appended when set, so a healthy tick's digest line is
+        # byte-identical to before this field existed -- compacted_count
+        # alone cannot tell "0, nothing to archive" from "0, not attempted".
+        skip_reason = aggr.get("compaction_skip_reason")
+        if skip_reason:
+            aggr_summary += f"; compaction_skipped={skip_reason}"
         fyi.append(
             {
                 "anchor": f"F{start + 2}",
@@ -5817,13 +5845,7 @@ def _fyi_items(status: dict[str, Any], *, limit: int, start: int = 1) -> list[di
                 "target_type": "digest_status",
                 "target_id": "candidate_aggregation",
                 "source_module": "candidate_aggregation",
-                "summary": (
-                    f"聚合上次运行: promoted={aggr.get('promoted_count')}; "
-                    f"rejected_demoted={aggr.get('rejected_demoted_count')}; "
-                    f"demoted={aggr.get('demoted_count')}; "
-                    f"fleeting={aggr.get('fleeting_count')}; "
-                    f"compacted={aggr.get('compacted_count')}"
-                ),
+                "summary": aggr_summary,
                 "raw_body_included": False,
             }
         )

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -617,6 +617,7 @@ def _build_prefetch_sections(
     events_cache = list(store.read_events())
     _append_section(sections, "Continuity Bridge", _continuity_bridge_lines(store, session_id=session_id, seen=seen, events=events_cache))
     _append_section(sections, "Last Session", _last_session_lines(store, session_id=session_id, seen=seen))
+    cross_session_ids: list[str] = []
     _append_section(
         sections,
         "Recent Cross-Session",
@@ -627,8 +628,11 @@ def _build_prefetch_sections(
             seen=seen,
             query=query,
             events=events_cache,
+            source_ids=cross_session_ids,
         ),
     )
+    if cross_session_ids:
+        section_source_ids["Recent Cross-Session"] = cross_session_ids
     _append_section(sections, "Conversation Carryover", _deep_reflection_lines(store))
     # Attribution (item 16a): every section class the disclosure audit treats as
     # attributable must record the canonical records it drew from, or the
@@ -727,6 +731,9 @@ def _build_prefetch_sections(
                 facade_text = facade.format_context(results, budget=800)
                 if facade_text.strip():
                     sections.append(("Recall Facade (unified)", [facade_text]))
+                    facade_ids = _recall_facade_source_ids(results)
+                    if facade_ids:
+                        section_source_ids["Recall Facade (unified)"] = facade_ids
         except Exception as exc:
             # fail-open: facade failure must not block prefetch,
             # but record bounded error for monitor visibility
@@ -743,6 +750,73 @@ def _build_prefetch_sections(
     return sections, section_source_ids
 
 
+def _recall_facade_source_ids(results: Any) -> list[str]:
+    """Per-record attribution for the Recall Facade section.
+
+    ``results`` is ``dict[str, list[RecallObject]]`` (recall_type -> objects),
+    the same shape ``facade.format_context`` renders from. Defensive against
+    non-RecallObject values on purpose: the caller is a stub-friendly facade
+    contract (see the ApplyCanaryFacade test doubles), so a malformed/partial
+    result must degrade to an empty id list rather than raise -- the
+    surrounding try/except already treats any raise here as a facade failure
+    that drops the whole section, which would be worse than merely missing
+    attribution.
+    """
+    ids: list[str] = []
+    if not isinstance(results, dict):
+        return ids
+    for objects in results.values():
+        if not isinstance(objects, list):
+            continue
+        for obj in objects:
+            ids.extend(_recall_object_canonical_ids(obj))
+    return ids
+
+
+def _recall_object_canonical_ids(obj: Any) -> list[str]:
+    """Best-effort canonical record id(s) for one facade RecallObject.
+
+    ``RecallObject.source_ref`` is stamped by the owning retriever with a
+    lane-specific prefix (``retrievers/*.py``, e.g. ``"entity_graph:<id>"``,
+    ``"fts5:<id>"``) rather than the underlying record's own canonical type --
+    passing those through verbatim would be "populated but unrecognisable" to
+    any downstream reader keyed on the canonical id vocabulary. Where the
+    retriever's own metadata identifies the underlying record, translate
+    through the same record_type -> canonical prefix table
+    ``_canonical_source_id`` already uses for the "Related Memory"
+    (graph_layer) section, so the two sections emit the same vocabulary for
+    the same underlying records:
+
+    - ``crystallized`` retrieval already stamps a canonical ``source_ref``
+      directly ("crystallized:<id>").
+    - ``entity_graph`` always resolves within ``crystallized_root``
+      (retrievers/entity_graph.py), so its ``related_record_id`` is a
+      crystallized record id.
+    - ``indexed_fts`` carries the FTS row's own ``record_type``/``record_id``
+      in metadata, already one of the canonical record types.
+
+    Lanes with no 1:1 canonical record at this layer -- state_overlay's
+    aggregate projection, temporal's synthetic markers ("temporal:current_
+    task" etc. name no JSONL record at all) -- are left unattributed here
+    rather than fabricated; a facade result drawn only from those lanes is a
+    genuine attribution gap, not a bug in this function.
+    """
+    recall_type = str(getattr(obj, "recall_type", "") or "")
+    metadata = getattr(obj, "metadata", None)
+    metadata = metadata if isinstance(metadata, dict) else {}
+    if recall_type == "crystallized":
+        ref = str(getattr(obj, "source_ref", "") or "").strip()
+        return [ref] if ref else []
+    if recall_type == "entity_graph":
+        rid = str(metadata.get("related_record_id") or "").strip()
+        return [_canonical_source_id("crystallized_record", rid)] if rid else []
+    if recall_type == "indexed_fts":
+        record_id = str(metadata.get("record_id") or "").strip()
+        kind = str(metadata.get("kind") or "").strip()
+        return [_canonical_source_id(kind, record_id)] if record_id and kind else []
+    return []
+
+
 # Module-level so the attribution contract can be validated against it: the
 # vocabulary a checker gates on must be provable against what the producer
 # actually emits. Keeping this inside the function is what allowed the audit
@@ -755,6 +829,10 @@ SECTION_SOURCE_CLASS_BY_TITLE: dict[str, str] = {
     "Memory State Overlay": "state_overlay",
     "Continuity Bridge": "bridge",
     "Last Session": "last_session",
+    # Same class as "Recent Event Summaries": this section injects
+    # event-derived content (source-gate-passed events from other sessions),
+    # just filtered/windowed differently.
+    "Recent Cross-Session": "event",
     "Conversation Carryover": "carryover",
     "Working Memory": "working",
     "Relationship Memory": "relationship",
@@ -765,6 +843,12 @@ SECTION_SOURCE_CLASS_BY_TITLE: dict[str, str] = {
     "Recent Event Summaries": "event",
     "Related Memory": "graph_layer",
     "Diagnostic Grounding": "diagnostic",
+    # Composite across retriever lanes (crystallized/working/indexed/entity-graph/
+    # etc.), NOT a single producer's vocabulary -- distinct from every class
+    # above for the same reason "graph_layer" is distinct from "crystallized":
+    # each RecallObject already carries its own canonical source_ref (see
+    # retrievers/*.py), so per-record attribution is a direct field read.
+    "Recall Facade": "recall_facade",
 }
 
 # Returned for any title absent from the mapping above.
@@ -955,8 +1039,24 @@ def _last_continuity_freshness_signature(path: Path) -> str | None:
     try:
         from .continuity import continuity_freshness_signature
         # Tail-capped: this file is bounded by transitions, but a pre-existing
-        # long file must not turn a per-turn read into an unbounded one.
-        lines = path.read_text(encoding="utf-8").splitlines()[-20:]
+        # long file must not turn a per-turn read into an unbounded one. Seek
+        # to a bounded window from the end of the file so the READ itself
+        # (not just the line count kept after parsing) stays fixed-size
+        # regardless of total file length.
+        _TAIL_WINDOW_BYTES = 16384
+        with path.open("rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            start = max(0, size - _TAIL_WINDOW_BYTES)
+            fh.seek(start)
+            chunk = fh.read()
+        text = chunk.decode("utf-8", errors="ignore")
+        lines = text.splitlines()
+        if start > 0 and lines:
+            # The window may begin mid-line (or mid-codepoint); the leading
+            # fragment is neither a complete line nor reliably decodable.
+            lines = lines[1:]
+        lines = lines[-20:]
         for line in reversed(lines):
             if not line.strip():
                 continue
@@ -1765,6 +1865,17 @@ def _crystallized_lines(
                 if expires_str:
                     try:
                         expires_dt = datetime.fromisoformat(expires_str)
+                        # Naive (no-offset) expires_str parses without error
+                        # but raises TypeError on the aware subtraction below
+                        # -- normalize before subtracting, same as
+                        # knob_overrides._is_expired. Without this, a naive
+                        # value both under-counts days_remaining (silently
+                        # wrong owner-facing countdown) AND leaves expires_dt
+                        # naive in provisional_entries, crashing the sort at
+                        # `provisional_entries.sort(key=lambda e: e[0])` below
+                        # when compared against aware sentinel/parsed values.
+                        if expires_dt.tzinfo is None:
+                            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
                         sec = (expires_dt - now).total_seconds()
                         days_remaining = max(0, int(sec / 86400))
                     except (ValueError, TypeError):
@@ -1928,8 +2039,22 @@ def _candidate_lines(
     # Same-lane publication also bounds the correction latency: an owner reject
     # stops surfacing within one candidate_aggregation cycle (<=6h).
     excluded_ids = read_candidate_recall_exclusions(store.roots)
+    # Dedup to the latest row per candidate_id -- same pattern as
+    # crystallized.read_effective_candidates: a candidate can have multiple
+    # queue rows (re-triage, updates), and without this a single candidate
+    # is scored and emitted once per row instead of once overall.
+    # excluded_ids filters terminal candidates only; it does not dedup.
+    raw_candidates = read_candidate_queue(store.roots)
+    latest_candidates_reversed: list[Any] = []
+    seen_candidate_ids: set[str] = set()
+    for candidate in reversed(raw_candidates):
+        if candidate.candidate_id in seen_candidate_ids:
+            continue
+        seen_candidate_ids.add(candidate.candidate_id)
+        latest_candidates_reversed.append(candidate)
+    latest_candidates = list(reversed(latest_candidates_reversed))
     scored: list[tuple[int, Any]] = []
-    for candidate in read_candidate_queue(store.roots):
+    for candidate in latest_candidates:
         if candidate.candidate_id in excluded_ids:
             continue
         if magic_word_match:
@@ -2749,6 +2874,12 @@ def _last_session_lines(
             continue
         try:
             ended_at = datetime.fromisoformat(str(record.get("ended_at", "")))
+            # Naive (no-offset) timestamps parse without error but raise
+            # TypeError on the aware comparison/subtraction below -- not a
+            # ValueError, so a bare `except ValueError` would not catch it.
+            # Normalize before comparing, same as knob_overrides._is_expired.
+            if ended_at.tzinfo is None:
+                ended_at = ended_at.replace(tzinfo=timezone.utc)
         except (ValueError, TypeError):
             continue
         if best is None or ended_at > best[0]:
@@ -2779,6 +2910,7 @@ def _recent_cross_session_lines(
     seen: set[tuple[str, str]] | None = None,
     query: str = "",
     events: list[Any] | None = None,
+    source_ids: list[str] | None = None,
 ) -> list[str]:
     """Source-gate-passed events from recent sessions (not current).
 
@@ -2793,6 +2925,11 @@ def _recent_cross_session_lines(
 
     Each line carries a "[跨会话·待结晶]" marker so the agent knows this
     is not yet owner-confirmed memory.
+
+    ``source_ids`` is an optional out-parameter (same idiom as ``seen`` and
+    ``_working_lines``' own ``source_ids``): when provided it is filled with
+    the canonical ``event:<event_id>`` reference for every emitted line, so
+    the disclosure record can name what it drew from.
     """
     if not session_id:
         return []
@@ -2866,7 +3003,7 @@ def _recent_cross_session_lines(
     # Read events, filter to cross-session + source-gate-passed + recent
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=age_hours)
-    collected: list[tuple[datetime, str]] = []
+    collected: list[tuple[datetime, str, str]] = []
 
     for event in (events if events is not None else store.read_events()):
         eid = str(event.id).strip()
@@ -2880,6 +3017,11 @@ def _recent_cross_session_lines(
             continue
         try:
             ts = datetime.fromisoformat(str(event.ts))
+            # Naive (no-offset) event.ts parses without error but raises
+            # TypeError on the aware `cutoff` comparison below -- normalize
+            # before comparing, same as knob_overrides._is_expired.
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
         except (ValueError, TypeError):
             continue
         if ts < cutoff:
@@ -2889,7 +3031,7 @@ def _recent_cross_session_lines(
             continue
         if seen is not None and eid:
             seen.add(("event", eid))
-        collected.append((ts, summary))
+        collected.append((ts, summary, eid))
 
     if not collected:
         return []
@@ -2904,21 +3046,23 @@ def _recent_cross_session_lines(
     if query and len(collected) > 1:
         query_tokens = _extract_query_tokens(query)
         if query_tokens:
-            scored: list[tuple[int, datetime, str]] = []
-            for ts, summary in collected:
+            scored: list[tuple[int, datetime, str, str]] = []
+            for ts, summary, eid in collected:
                 summary_lower = summary.lower()
                 score = sum(1 for token in query_tokens if token in summary_lower)
-                scored.append((score, ts, summary))
+                scored.append((score, ts, summary, eid))
             # Stable sort: higher score first, then newer first within same score
             scored.sort(key=lambda x: (-x[0], x[1]), reverse=False)
-            collected = [(ts, s) for _, ts, s in scored]
+            collected = [(ts, s, e) for _, ts, s, e in scored]
 
     lines: list[str] = []
-    for ts, summary in collected[:limit]:
+    for ts, summary, eid in collected[:limit]:
         age_h = max(1, int((now - ts).total_seconds() / 3600))
         lines.append(
             f"- [跨会话·待结晶·{age_h}h前] {_redact(summary)}"
         )
+        if source_ids is not None and eid:
+            source_ids.append(f"event:{eid}")
 
     lines.insert(0, "— 近期跨会话 (source gate 通过, 待 owner 结晶) —")
     return lines
@@ -3021,9 +3165,21 @@ def _deep_reflection_card_is_safe(card: dict[str, Any]) -> bool:
     expires_at = str(card.get("expires_at", ""))
     if expires_at:
         try:
-            if datetime.fromisoformat(expires_at) <= datetime.now(timezone.utc):
+            expires_dt = datetime.fromisoformat(expires_at)
+            # A timezone-naive value (e.g. "2026-12-31") parses without error
+            # but raises TypeError when compared against the aware `now`
+            # below -- not a ValueError, so the bare `except ValueError` did
+            # not catch it and the per-turn prefetch path crashed on an
+            # otherwise-valid naive timestamp. Same normalization as
+            # knob_overrides._is_expired: treat a naive value as UTC rather
+            # than raising. Genuinely unparseable input keeps this
+            # function's existing intent unchanged -- treated as expired
+            # (return False), not as fail-open like knob_overrides.
+            if expires_dt.tzinfo is None:
+                expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+            if expires_dt <= datetime.now(timezone.utc):
                 return False
-        except ValueError:
+        except (ValueError, TypeError):
             return False
     return True
 
@@ -3630,6 +3786,8 @@ def _budget_keep_priority(title: str) -> int:
         "Working Memory": 40,
         "Relationship Memory": 45,
         "Crystallized Review Candidates": 50,
+        "Recent Cross-Session": 55,  # between Candidates(50) and Crystallized(60): source-gate-passed but owner-unreviewed, fresher signal than the general review queue
+        "Recall Facade": 58,  # between Recent Cross-Session(55) and Crystallized(60): per-record attributable via source_ref, but still an apply_canary rollout so it must not yet outrank the established single-purpose sections it can duplicate
         "Crystallized Memory": 60,
         "Related Memory": 65,
         "Recent Event Summaries": 80,

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -35,6 +35,7 @@ from .memory_sources import (
     normalize_memory_sources_config,
 )
 from .store import MemoryOSStore
+from .timeutil import ensure_utc_aware
 
 
 HEADER = "## Memory-OS Context"
@@ -899,13 +900,21 @@ def _record_substrate_shadow_recall(
     report: dict[str, Any],
 ) -> None:
     facts = report.get("facts") if isinstance(report.get("facts"), list) else []
-    if not facts:
+    provider_error_count = int(report.get("provider_error_count") or 0)
+    # An all-providers-failed turn produces zero facts but must still leave
+    # evidence -- see SubstrateRouter.recall's provider_error_count /
+    # provider_errors (substrates/router.py). Without this, the exact case
+    # the counters exist for (every provider raised) writes no shadow row at
+    # all. A genuinely quiet turn -- no facts AND no provider errors -- still
+    # returns early: no row.
+    if not facts and not provider_error_count:
         return
     path = store.roots.memory_os_root / "system" / "substrate_recall_shadow.jsonl"
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
     except Exception:
         return  # fail-open: shadow loss must not break prefetch
+    provider_errors = report.get("provider_errors")
     record = {
         "schema_version": "memory-os.substrate_recall_shadow.v0",
         # The field name is load-bearing: metadata_retention._record_created_at
@@ -923,6 +932,10 @@ def _record_substrate_shadow_recall(
         "local_first_authority_preserved": bool(report.get("local_first_authority_preserved")),
         "recall_llm_triggered": bool(report.get("recall_llm_triggered")),
         "fallback_triggered": bool(report.get("fallback_triggered")),
+        "provider_error_count": provider_error_count,
+        # Pass through as-is -- SubstrateRouter.recall already bounds this to
+        # MAX_PROVIDER_ERROR_RECORDS (8) entries.
+        "provider_errors": provider_errors if isinstance(provider_errors, list) else [],
     }
     try:
         from .jsonl_io import append_jsonl_locked
@@ -1874,8 +1887,7 @@ def _crystallized_lines(
                         # naive in provisional_entries, crashing the sort at
                         # `provisional_entries.sort(key=lambda e: e[0])` below
                         # when compared against aware sentinel/parsed values.
-                        if expires_dt.tzinfo is None:
-                            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+                        expires_dt = ensure_utc_aware(expires_dt)
                         sec = (expires_dt - now).total_seconds()
                         days_remaining = max(0, int(sec / 86400))
                     except (ValueError, TypeError):
@@ -2878,8 +2890,7 @@ def _last_session_lines(
             # TypeError on the aware comparison/subtraction below -- not a
             # ValueError, so a bare `except ValueError` would not catch it.
             # Normalize before comparing, same as knob_overrides._is_expired.
-            if ended_at.tzinfo is None:
-                ended_at = ended_at.replace(tzinfo=timezone.utc)
+            ended_at = ensure_utc_aware(ended_at)
         except (ValueError, TypeError):
             continue
         if best is None or ended_at > best[0]:
@@ -3020,8 +3031,7 @@ def _recent_cross_session_lines(
             # Naive (no-offset) event.ts parses without error but raises
             # TypeError on the aware `cutoff` comparison below -- normalize
             # before comparing, same as knob_overrides._is_expired.
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
+            ts = ensure_utc_aware(ts)
         except (ValueError, TypeError):
             continue
         if ts < cutoff:
@@ -3051,8 +3061,13 @@ def _recent_cross_session_lines(
                 summary_lower = summary.lower()
                 score = sum(1 for token in query_tokens if token in summary_lower)
                 scored.append((score, ts, summary, eid))
-            # Stable sort: higher score first, then newer first within same score
-            scored.sort(key=lambda x: (-x[0], x[1]), reverse=False)
+            # Stable sort: higher score first, then newer first within same score.
+            # `collected` is already newest-first (sorted above), and Python's
+            # sort is stable, so sorting by score alone preserves that
+            # newest-first order within each tied score tier -- do not also
+            # sort by timestamp here, which would reverse the tie-break to
+            # oldest-first.
+            scored.sort(key=lambda x: -x[0])
             collected = [(ts, s, e) for _, ts, s, e in scored]
 
     lines: list[str] = []
@@ -3175,8 +3190,7 @@ def _deep_reflection_card_is_safe(card: dict[str, Any]) -> bool:
             # than raising. Genuinely unparseable input keeps this
             # function's existing intent unchanged -- treated as expired
             # (return False), not as fail-open like knob_overrides.
-            if expires_dt.tzinfo is None:
-                expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+            expires_dt = ensure_utc_aware(expires_dt)
             if expires_dt <= datetime.now(timezone.utc):
                 return False
         except (ValueError, TypeError):

--- a/plugins/memory/memory_os/runtime.py
+++ b/plugins/memory/memory_os/runtime.py
@@ -213,7 +213,13 @@ class MemoryOSRuntime:
                     "processed_event_ids": full_processed_ids,
                     "recent_processed_event_ids": recent_processed_ids,
                     "recent_processed_event_ids_limit": RECENT_PROCESSED_EVENT_IDS_LIMIT,
-                    "processed_event_ids_compacted": False,
+                    # Heartbeat itself never compacts/trims the ledger — it only
+                    # appends and writes the full list back out — so it must
+                    # carry forward whatever `_read_state()` reported rather than
+                    # hardcoding False. Hardcoding here made the flag structurally
+                    # incapable of ever surviving a heartbeat cycle: any future
+                    # compactor's True would be overwritten on the very next run.
+                    "processed_event_ids_compacted": bool(state.get("processed_event_ids_compacted", False)),
                 }
             )
             index_counts = MemoryOSIndex(self.store.roots).sync_from_store(self.store)
@@ -231,6 +237,14 @@ class MemoryOSRuntime:
                 "candidate_created_count": candidate_created_count,
                 "already_processed_event_count": len([event for event in events if event.id in already_processed_ids]),
                 "total_event_count": len(events),
+                # Observability for the unbounded dedup ledger written above
+                # (full_processed_ids / "processed_event_ids" in state): its
+                # growth is otherwise only visible by opening the state file
+                # by hand. NOT the same number as processed_event_count_total —
+                # that counter skips events which already had a candidate
+                # (window-overflow dedup) but this ledger still records their
+                # ids for dedup purposes, so ledger size can exceed it.
+                "processed_event_ids_ledger_size": len(full_processed_ids),
                 "working_item_count": _working_item_count(self.store),
                 "candidate_count": len(read_candidate_queue(self.store.roots)),
                 "crystallized_record_count": approved_crystallized_record_count,
@@ -317,6 +331,7 @@ class MemoryOSRuntime:
                 "processed_event_ids": [],
                 "recent_processed_event_ids": [],
                 "processed_event_count_total": 0,
+                "processed_event_ids_compacted": False,
             }
         state = json.loads(self._state_path.read_text(encoding="utf-8"))
         # Legacy migration: if old-format processed_event_ids exists but recent_ doesn't
@@ -334,7 +349,13 @@ class MemoryOSRuntime:
             state["processed_event_ids_compacted"] = False
         state.setdefault("recent_processed_event_ids_limit", RECENT_PROCESSED_EVENT_IDS_LIMIT)
         state.setdefault("processed_event_count_total", state.get("processed_event_count", 0))
-        state["processed_event_ids_compacted"] = False
+        # Reflect reality instead of hardwiring: preserve whatever the reverse
+        # migration branch above just set (False, deliberately — the ledger was
+        # just restored) or whatever was actually persisted (e.g. True from a
+        # future compactor that trimmed processed_event_ids while keeping the
+        # key present). Forcing False here unconditionally made the flag
+        # structurally incapable of ever reporting True.
+        state.setdefault("processed_event_ids_compacted", False)
         return state
 
     def _write_state(self, state: dict[str, Any]) -> None:

--- a/plugins/memory/memory_os/state_overlay.py
+++ b/plugins/memory/memory_os/state_overlay.py
@@ -331,9 +331,11 @@ def _read_open_threads_from_candidates(
             ts_str = str(c.get("last_updated", c.get("ts", "")))
             try:
                 ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < cutoff:
+                    continue
             except (ValueError, TypeError):
-                continue
-            if ts < cutoff:
                 continue
             summary = str(c.get("summary") or c.get("body", "")[:200]).strip()
             if summary:

--- a/plugins/memory/memory_os/state_overlay.py
+++ b/plugins/memory/memory_os/state_overlay.py
@@ -19,6 +19,7 @@ from .state_overlay_schema import (
     STATE_OVERLAY_SCHEMA_VERSION,
 )
 from .store import MemoryOSStore
+from .timeutil import ensure_utc_aware
 
 if TYPE_CHECKING:
     from .roots import MemoryOSRoots
@@ -331,8 +332,7 @@ def _read_open_threads_from_candidates(
             ts_str = str(c.get("last_updated", c.get("ts", "")))
             try:
                 ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
+                ts = ensure_utc_aware(ts)
                 if ts < cutoff:
                     continue
             except (ValueError, TypeError):

--- a/plugins/memory/memory_os/structural_edge_proposer.py
+++ b/plugins/memory/memory_os/structural_edge_proposer.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from .audit import append_audit
 from .edge_weights import birth_weight
+from .timeutil import ensure_utc_aware
 
 
 # Dice coefficient threshold for body-text similarity — above this the pair
@@ -70,9 +71,7 @@ def _parse_iso(ts: str) -> datetime | None:
         parsed = datetime.fromisoformat(ts)
     except (ValueError, TypeError):
         return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return ensure_utc_aware(parsed)
 
 
 def _detect_relation(

--- a/plugins/memory/memory_os/structural_edge_proposer.py
+++ b/plugins/memory/memory_os/structural_edge_proposer.py
@@ -55,13 +55,24 @@ def _contains_record_ref(body: str, record_id: str) -> bool:
 
 
 def _parse_iso(ts: str) -> datetime | None:
-    """Parse an ISO timestamp string, best-effort."""
+    """Parse an ISO timestamp string, best-effort.
+
+    Naive (no-offset) timestamps parse without error but, if left naive,
+    raise TypeError when subtracted from another parsed value of differing
+    awareness in `_detect_relation`'s temporal-proximity check (two
+    crystallized records whose `created_at` differ in naive/aware-ness).
+    Normalize to UTC here, same as knob_overrides._is_expired, so every
+    value this helper returns is safely comparable.
+    """
     if not ts:
         return None
     try:
-        return datetime.fromisoformat(ts)
+        parsed = datetime.fromisoformat(ts)
     except (ValueError, TypeError):
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def _detect_relation(

--- a/plugins/memory/memory_os/substrates/router.py
+++ b/plugins/memory/memory_os/substrates/router.py
@@ -9,6 +9,13 @@ from .base import GroundingFact
 
 LOCAL_AUTHORITY_CLASSES = {"local_canonical", "owner_approved"}
 
+# Bounded cap on report["provider_errors"]: providers is a short, fixed
+# list (LocalArtifact + at most a handful of substrates), so this is far
+# above the realistic count. provider_error_count keeps counting past the
+# cap; only the detail list is capped, per the project's bounded-error-record
+# convention (see CLAUDE.md "No Silent Failures").
+MAX_PROVIDER_ERROR_RECORDS = 8
+
 
 def _health_value(health: Any, key: str, default: Any = None) -> Any:
     if isinstance(health, dict):
@@ -83,21 +90,45 @@ class SubstrateRouter:
     def recall(self, query: str, *, consumer: str) -> dict[str, Any]:
         raw_facts: list[dict[str, Any]] = []
         fallback_triggered = True
+        provider_error_count = 0
+        provider_errors: list[dict[str, Any]] = []
         for provider in self.providers:
-            # health() is inside the same guard as recall(): one provider's
+            provider_name = str(getattr(provider, "name", "") or "unknown")
+            # health() is guarded separately from recall(): one provider's
             # bad health check must only skip that provider, never abort the
             # whole loop -- an uncaught raise here would otherwise propagate
             # out of recall() entirely, discarding facts already collected
             # from providers processed earlier (including LocalArtifact, the
             # architecture's always-primary authority) and never reaching
-            # the return below.
+            # the return below. Splitting the try per stage (rather than one
+            # try around both calls) lets a raise be classified as
+            # stage="health" vs stage="recall" -- see "No Silent Failures" in
+            # CLAUDE.md: a broad except must not silently drop a provider
+            # indistinguishably from one that legitimately reported
+            # status != "ok". No message/traceback is recorded here -- only
+            # the exception type name -- to keep the report bounded and safe
+            # for the per-turn hot path (no I/O, no logging; see INV-5).
             try:
                 health = provider.health()
                 capabilities = set(_health_value(health, "capabilities", []) or [])
-                if _health_value(health, "status") != "ok" or "recall" not in capabilities:
-                    continue
+                is_healthy = _health_value(health, "status") == "ok" and "recall" in capabilities
+            except Exception as exc:
+                provider_error_count += 1
+                if len(provider_errors) < MAX_PROVIDER_ERROR_RECORDS:
+                    provider_errors.append(
+                        {"provider": provider_name, "stage": "health", "error_type": type(exc).__name__}
+                    )
+                continue
+            if not is_healthy:
+                continue
+            try:
                 provider_facts = provider.recall(query, consumer=consumer)
-            except Exception:
+            except Exception as exc:
+                provider_error_count += 1
+                if len(provider_errors) < MAX_PROVIDER_ERROR_RECORDS:
+                    provider_errors.append(
+                        {"provider": provider_name, "stage": "recall", "error_type": type(exc).__name__}
+                    )
                 continue
             if provider_facts:
                 raw_facts.extend(_fact_to_dict(fact) for fact in provider_facts)
@@ -134,4 +165,6 @@ class SubstrateRouter:
             "local_first_authority_preserved": external_authoritative_count == 0,
             "fallback_triggered": fallback_triggered,
             "recall_llm_triggered": any(bool(fact.get("recall_llm_triggered")) for fact in raw_facts),
+            "provider_error_count": provider_error_count,
+            "provider_errors": provider_errors,
         }

--- a/plugins/memory/memory_os/substrates/router.py
+++ b/plugins/memory/memory_os/substrates/router.py
@@ -84,11 +84,18 @@ class SubstrateRouter:
         raw_facts: list[dict[str, Any]] = []
         fallback_triggered = True
         for provider in self.providers:
-            health = provider.health()
-            capabilities = set(_health_value(health, "capabilities", []) or [])
-            if _health_value(health, "status") != "ok" or "recall" not in capabilities:
-                continue
+            # health() is inside the same guard as recall(): one provider's
+            # bad health check must only skip that provider, never abort the
+            # whole loop -- an uncaught raise here would otherwise propagate
+            # out of recall() entirely, discarding facts already collected
+            # from providers processed earlier (including LocalArtifact, the
+            # architecture's always-primary authority) and never reaching
+            # the return below.
             try:
+                health = provider.health()
+                capabilities = set(_health_value(health, "capabilities", []) or [])
+                if _health_value(health, "status") != "ok" or "recall" not in capabilities:
+                    continue
                 provider_facts = provider.recall(query, consumer=consumer)
             except Exception:
                 continue

--- a/plugins/memory/memory_os/timeutil.py
+++ b/plugins/memory/memory_os/timeutil.py
@@ -131,6 +131,11 @@ def is_naive(dt: datetime) -> bool:
     return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None
 
 
+def ensure_utc_aware(dt: datetime) -> datetime:
+    """Interpret a naive datetime as UTC; return aware datetimes unchanged."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
 def safe_compare(a: datetime | None, b: datetime | None) -> int:
     """Compare two datetimes safely.
 

--- a/plugins/memory/memory_os/working.py
+++ b/plugins/memory/memory_os/working.py
@@ -14,6 +14,7 @@ from .ids import new_working_id
 from .jsonl_io import locked_jsonl_file
 from .schema import WORKING_SCHEMA_VERSION, WORKING_SCHEMA_VERSION_V0, WorkingItem
 from .store import MemoryOSStore
+from .timeutil import ensure_utc_aware
 
 
 ALLOWED_WORKING_KINDS = {"lingering", "emotional", "curiosity", "attention"}
@@ -197,8 +198,7 @@ class WorkingMemoryService:
             decay_base_str = item.last_decayed_at or item.updated_at or item.created_at
             try:
                 decay_base = datetime.fromisoformat(decay_base_str)
-                if decay_base.tzinfo is None:
-                    decay_base = decay_base.replace(tzinfo=timezone.utc)
+                decay_base = ensure_utc_aware(decay_base)
             except (ValueError, TypeError):
                 # Malformed/unparseable stored timestamp on the heartbeat decay
                 # path — must not raise. Treat as "decayed just now" (no weight
@@ -285,8 +285,7 @@ class WorkingMemoryService:
             expiry_base_str = item.expired_at or item.updated_at
             try:
                 expiry_dt = datetime.fromisoformat(expiry_base_str)
-                if expiry_dt.tzinfo is None:
-                    expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
+                expiry_dt = ensure_utc_aware(expiry_dt)
             except (ValueError, TypeError):
                 # Malformed timestamp — keep the item rather than risk data loss.
                 kept.append(raw_item)

--- a/plugins/memory/memory_os/working.py
+++ b/plugins/memory/memory_os/working.py
@@ -195,7 +195,26 @@ class WorkingMemoryService:
                 continue
             # ── Decay from last_decayed_at (v1), fallback to updated_at (v0 compat) ──
             decay_base_str = item.last_decayed_at or item.updated_at or item.created_at
-            decay_base = datetime.fromisoformat(decay_base_str)
+            try:
+                decay_base = datetime.fromisoformat(decay_base_str)
+                if decay_base.tzinfo is None:
+                    decay_base = decay_base.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                # Malformed/unparseable stored timestamp on the heartbeat decay
+                # path — must not raise. Treat as "decayed just now" (no weight
+                # change this cycle) rather than skip the item outright: below,
+                # last_decayed_at is unconditionally re-stamped with a fresh
+                # aware value, so the record self-heals starting next cycle
+                # instead of either crashing the heartbeat or becoming
+                # permanently exempt from decay (which a bare "leave unchanged
+                # and continue" would cause, since nothing would ever fix the
+                # stored field). Recorded so a bad record is diagnosable.
+                decay_base = current
+                self._audit(
+                    "working_item_decay_base_invalid",
+                    "warning",
+                    {"item_id": item.id, "kind": kind, "decay_base_str": decay_base_str},
+                )
             elapsed_hours = max(0.0, (current - decay_base).total_seconds() / 3600.0)
             decayed_weight = item.weight * pow(0.5, elapsed_hours / effective_half_life)
             new_status = "expired" if decayed_weight < effective_expire_below else "active"
@@ -266,6 +285,8 @@ class WorkingMemoryService:
             expiry_base_str = item.expired_at or item.updated_at
             try:
                 expiry_dt = datetime.fromisoformat(expiry_base_str)
+                if expiry_dt.tzinfo is None:
+                    expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
             except (ValueError, TypeError):
                 # Malformed timestamp — keep the item rather than risk data loss.
                 kept.append(raw_item)

--- a/plugins/modules/cognition/deep_reflection.py
+++ b/plugins/modules/cognition/deep_reflection.py
@@ -1625,9 +1625,12 @@ def _reject_reason(card: dict[str, Any], *, input_snapshot: dict[str, Any], now:
     if _has_identity_or_delivery_language(str(card.get("text", ""))):
         return "identity_or_delivery_language"
     try:
-        if datetime.fromisoformat(str(card.get("expires_at", ""))) <= now:
+        expires_at = datetime.fromisoformat(str(card.get("expires_at", "")))
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at <= now:
             return "expired"
-    except ValueError:
+    except (ValueError, TypeError):
         return "invalid_expiry"
     if not _source_refs_eligible(source_refs, input_snapshot):
         return "ineligible_source_class"

--- a/plugins/modules/cognition/deep_reflection.py
+++ b/plugins/modules/cognition/deep_reflection.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 from plugins.memory.memory_os.inner_drive import classify_event_for_inner_drive
 from plugins.memory.memory_os.store import MemoryOSStore
+from plugins.memory.memory_os.timeutil import ensure_utc_aware
 from plugins.memory.memory_os.working import WorkingMemoryService
 
 
@@ -1626,8 +1627,7 @@ def _reject_reason(card: dict[str, Any], *, input_snapshot: dict[str, Any], now:
         return "identity_or_delivery_language"
     try:
         expires_at = datetime.fromisoformat(str(card.get("expires_at", "")))
-        if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        expires_at = ensure_utc_aware(expires_at)
         if expires_at <= now:
             return "expired"
     except (ValueError, TypeError):

--- a/plugins/modules/expression/speak_rate_limit.py
+++ b/plugins/modules/expression/speak_rate_limit.py
@@ -48,11 +48,20 @@ def _parse_ts(ts: str) -> datetime:
 
     Returns datetime.min on any parse failure so the delivery is treated
     as ancient and never counted (safe default — avoid false rate-limit).
+    A successfully-parsed but timezone-naive value (no offset) is treated
+    as UTC rather than returned naive: this store's own writer stamps
+    aware UTC timestamps, so a naive value only reaches here via a
+    hand-edited/legacy record, and comparing it as-is against the aware
+    `cutoff` in under_speak_limit would raise TypeError instead of
+    hitting this function's own fail-open contract.
     """
     if not ts:
         return datetime.min.replace(tzinfo=timezone.utc)
     try:
         ts_clean = str(ts).replace("Z", "+00:00")
-        return datetime.fromisoformat(ts_clean)
+        parsed = datetime.fromisoformat(ts_clean)
     except (ValueError, TypeError):
         return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed

--- a/plugins/modules/expression/speak_rate_limit.py
+++ b/plugins/modules/expression/speak_rate_limit.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from plugins.memory.memory_os.timeutil import ensure_utc_aware
+
 MAX_PER_HOUR = 5
 WINDOW_SECONDS = 3600
 
@@ -62,6 +64,4 @@ def _parse_ts(ts: str) -> datetime:
         parsed = datetime.fromisoformat(ts_clean)
     except (ValueError, TypeError):
         return datetime.min.replace(tzinfo=timezone.utc)
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return ensure_utc_aware(parsed)

--- a/plugins/modules/governance/candidate_aggregation.py
+++ b/plugins/modules/governance/candidate_aggregation.py
@@ -468,7 +468,27 @@ def run_candidate_aggregation_lane(
     # production rows, 66–98 days old, recall-excluded yet never archived).
     # read_effective_candidates costs ~61ms on production — affordable here
     # in an offline lane, never on the per-turn prefetch path.
+    #
+    # Errors accumulated BEFORE this point -- malformed candidates.jsonl rows
+    # from read_candidate_queue, or a promote-stage failure recorded by
+    # _cluster_and_promote -- disable compaction entirely; that pre-existing
+    # "any upstream error -> skip compaction" policy for those two feeders
+    # is unchanged (see test_queue_parse_error_still_skips_compaction and
+    # test_promote_stage_error_still_skips_compaction in
+    # test_candidate_aggregation_logic.py). Snapshot the count now, before
+    # the try/except below can append its own error, so the two reasons
+    # stay independently attributable in compaction_skip_reason below even
+    # though, as of 2026-08-15, all three now skip compaction the same way.
+    pre_effective_view_error_count = len(candidate_error_records)
     effective_terminal_ids: set[str] | None = None
+    archivable_terminal_ids: set[str] | None = None
+    # compact_candidate_queue's provisional_backed_candidate_ids is a
+    # REQUIRED (non-Optional) argument. It is only ever passed when
+    # compaction actually runs (see compaction_skip_reason below), so this
+    # initial empty set is never itself handed to a real archival decision
+    # -- it exists purely so the variable is always bound.
+    provisional_backed_ids: set[str] = set()
+    effective_view_failed = False
     effective_count = 0
     try:
         effective = read_effective_candidates(store)
@@ -476,7 +496,37 @@ def run_candidate_aggregation_lane(
         effective_terminal_ids = {
             item.candidate.candidate_id for item in effective if item.terminal
         }
-    except Exception as exc:  # noqa: BLE001 - view failure degrades, never breaks the lane
+        # A provisional-backed terminal candidate (its only active
+        # crystallized record is provisional=True) must NOT be archived out
+        # of the live queue: the provisional is reversible by design
+        # (resolver TTL/cap eviction, owner reject via
+        # invalidate_provisional_record) and archival has no way back. It
+        # still belongs in the FULL terminal set used for the recall-
+        # exclusion projection below -- the content is already in
+        # crystallized memory, so it must not double-surface in recall
+        # while the provisional anchor is active. Only a permanent
+        # (non-provisional) crystallized record, or a demoted/fleeting/
+        # absorbed/owner-closed state, is archivable.
+        archivable_terminal_ids = {
+            item.candidate.candidate_id
+            for item in effective
+            if item.terminal and not item.provisional_backed
+        }
+        # Excluding these ids from archivable_terminal_ids only protects
+        # them from compact_candidate_queue's terminal-ids branch. Its
+        # retention-window elif/else resolves state from triage rows alone
+        # (resolver_approved, not owner_eligible) and does not know a
+        # candidate is provisional-backed, so an aged resolver-approved
+        # provisional row was still archivable through that branch --
+        # same loss shape as the case above, reached a different way, and
+        # arguably more likely to fire since provisional TTLs can exceed
+        # retention_days. Pass the id set explicitly so
+        # compact_candidate_queue enforces the guarantee on every branch.
+        provisional_backed_ids = {
+            item.candidate.candidate_id for item in effective if item.provisional_backed
+        }
+    except Exception as exc:  # noqa: BLE001 - view failure never breaks the lane; compaction is skipped instead
+        effective_view_failed = True
         candidate_error_records.append(
             build_error_record(
                 component="candidate_aggregation",
@@ -488,11 +538,48 @@ def run_candidate_aggregation_lane(
             )
         )
 
-    compact_count = 0 if candidate_error_records else compact_candidate_queue(
+    # Whether and why compaction ran, as an explicit decision -- not a side
+    # effect of candidate_error_records' length, which was the actual defect
+    # here (2026-08-15 finding): the code used to comment that a
+    # read_effective_candidates failure "degrades to terminal_candidate_ids=
+    # None (compact's own triage-only view)", but triage-only compaction is
+    # exactly what archives a provisional-backed candidate irreversibly
+    # (Defect C) -- so degrading to it on the ONE path where we have the
+    # LEAST information about which candidates are provisional-backed was
+    # itself unsafe. When the view fails we do not know which candidates
+    # are provisional-backed; archiving under that uncertainty is
+    # unrecoverable (candidates.archive.jsonl has no production reader), so
+    # a view failure now joins the two pre-existing upstream-error sources
+    # in skipping compaction outright, rather than falling back to a
+    # triage-only view that cannot make the provisional-backed distinction
+    # at all. Not compacting just lets the live queue grow -- visible,
+    # bounded by how long the failure persists, and fully recoverable the
+    # moment the malformed record is fixed.
+    #
+    # compaction_skip_reason is the durable, closed-set answer to "why did
+    # compaction not run this tick", surfaced in the returned summary so a
+    # reader can distinguish it from "compaction ran and archived nothing"
+    # (compaction_skip_reason is None, compacted_count is a real count)
+    # without re-running anything or reading source:
+    #   None                       -- compaction ran normally.
+    #   "effective_view_unavailable" -- read_effective_candidates raised;
+    #       see candidate_effective_view_failed in error_records.
+    #   "upstream_error"           -- read_candidate_queue or
+    #       _cluster_and_promote recorded an error before the effective-view
+    #       attempt; see recent_error_codes / error_records for which.
+    if effective_view_failed:
+        compaction_skip_reason: str | None = "effective_view_unavailable"
+    elif pre_effective_view_error_count:
+        compaction_skip_reason = "upstream_error"
+    else:
+        compaction_skip_reason = None
+
+    compact_count = 0 if compaction_skip_reason else compact_candidate_queue(
         store,
         archive_path=archive,
         retention_days=7,
-        terminal_candidate_ids=effective_terminal_ids,
+        terminal_candidate_ids=archivable_terminal_ids,
+        provisional_backed_candidate_ids=provisional_backed_ids,
     )
 
     # Publish the hot-path recall exclusion projection (owner ruling
@@ -541,6 +628,12 @@ def run_candidate_aggregation_lane(
         "stale_owner_eligible_demoted_count": stale_results["demoted_count"],
         "fleeting_count": fleeting_results["fleeting_count"],
         "compacted_count": compact_count,
+        # Closed set: None (ran normally), "effective_view_unavailable"
+        # (read_effective_candidates raised), "upstream_error"
+        # (read_candidate_queue or _cluster_and_promote recorded an error
+        # first). See the comment above compaction_skip_reason's assignment
+        # for why a view failure must not fall back to compacting anyway.
+        "compaction_skip_reason": compaction_skip_reason,
         "action": "candidate_aggregation_tick",
         "status": "warning" if candidate_error_records else "ok",
         "suppressed_error_count": len(candidate_error_records),

--- a/plugins/modules/governance/override_sweep.py
+++ b/plugins/modules/governance/override_sweep.py
@@ -16,6 +16,7 @@ from plugins.memory.memory_os.knob_overrides import (
     list_active_overrides,
     revert_override,
 )
+from plugins.memory.memory_os.timeutil import ensure_utc_aware
 
 MAX_OVERRIDES = 30
 
@@ -112,8 +113,7 @@ class OverrideSweepModule:
                     continue
                 try:
                     expires_at = datetime.fromisoformat(expires_str)
-                    if expires_at.tzinfo is None:
-                        expires_at = expires_at.replace(tzinfo=timezone.utc)
+                    expires_at = ensure_utc_aware(expires_at)
                 except (ValueError, TypeError):
                     continue
                 if expires_at <= now and override.get("state") == "active":
@@ -260,8 +260,7 @@ def _days_until_expiry(expires_at: str) -> float:
         # record from near_expiry_count. Normalize before subtracting,
         # same as knob_overrides._is_expired. Genuinely unparseable input
         # keeps the existing fail-open fallback.
-        if expires_dt.tzinfo is None:
-            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+        expires_dt = ensure_utc_aware(expires_dt)
         remaining = expires_dt - datetime.now(timezone.utc)
         return remaining.total_seconds() / 86400.0
     except (ValueError, TypeError):

--- a/plugins/modules/governance/override_sweep.py
+++ b/plugins/modules/governance/override_sweep.py
@@ -112,7 +112,9 @@ class OverrideSweepModule:
                     continue
                 try:
                     expires_at = datetime.fromisoformat(expires_str)
-                except ValueError:
+                    if expires_at.tzinfo is None:
+                        expires_at = expires_at.replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
                     continue
                 if expires_at <= now and override.get("state") == "active":
                     try:
@@ -250,6 +252,16 @@ def _days_until_expiry(expires_at: str) -> float:
         return float("inf")
     try:
         expires_dt = datetime.fromisoformat(expires_at)
+        # Naive (no-offset) expires_at parses without error but raises
+        # TypeError on the aware subtraction below -- not a ValueError, so
+        # the bare `except ValueError` would not catch it, and previously
+        # the naive-input path fell through to the genuinely-unparseable
+        # fallback (float("inf")), silently hiding a real near-expiry
+        # record from near_expiry_count. Normalize before subtracting,
+        # same as knob_overrides._is_expired. Genuinely unparseable input
+        # keeps the existing fail-open fallback.
+        if expires_dt.tzinfo is None:
+            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
         remaining = expires_dt - datetime.now(timezone.utc)
         return remaining.total_seconds() / 86400.0
     except (ValueError, TypeError):

--- a/plugins/modules/governance/provisional_sweep.py
+++ b/plugins/modules/governance/provisional_sweep.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from plugins.memory.memory_os.crystallized import CrystallizedMemoryService
 from plugins.memory.memory_os.store import MemoryOSStore
+from plugins.memory.memory_os.timeutil import ensure_utc_aware
 
 
 def provisional_sweep_manifest() -> dict[str, Any]:
@@ -92,8 +93,7 @@ class ProvisionalSweepModule:
                 continue
             try:
                 expires_at = datetime.fromisoformat(expires_str)
-                if expires_at.tzinfo is None:
-                    expires_at = expires_at.replace(tzinfo=timezone.utc)
+                expires_at = ensure_utc_aware(expires_at)
             except (ValueError, TypeError):
                 continue
             if expires_at <= now:
@@ -268,8 +268,7 @@ def _days_until_expiry(expires_at: str) -> float:
         # record from near_expiry_count. Normalize before subtracting,
         # same as knob_overrides._is_expired. Genuinely unparseable input
         # keeps the existing fail-open fallback.
-        if expires_dt.tzinfo is None:
-            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+        expires_dt = ensure_utc_aware(expires_dt)
         remaining = expires_dt - datetime.now(timezone.utc)
         return remaining.total_seconds() / 86400.0
     except (ValueError, TypeError):
@@ -299,8 +298,7 @@ def find_expiring_provisional(
             continue
         try:
             expires_at = datetime.fromisoformat(expires_str)
-            if expires_at.tzinfo is None:
-                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            expires_at = ensure_utc_aware(expires_at)
         except (ValueError, TypeError):
             continue
         if expires_at <= threshold and expires_at > now:

--- a/plugins/modules/governance/provisional_sweep.py
+++ b/plugins/modules/governance/provisional_sweep.py
@@ -92,7 +92,9 @@ class ProvisionalSweepModule:
                 continue
             try:
                 expires_at = datetime.fromisoformat(expires_str)
-            except ValueError:
+                if expires_at.tzinfo is None:
+                    expires_at = expires_at.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
                 continue
             if expires_at <= now:
                 try:
@@ -258,6 +260,16 @@ def _days_until_expiry(expires_at: str) -> float:
         return float("inf")
     try:
         expires_dt = datetime.fromisoformat(expires_at)
+        # Naive (no-offset) expires_at parses without error but raises
+        # TypeError on the aware subtraction below -- not a ValueError, so
+        # the bare `except ValueError` would not catch it, and previously
+        # the naive-input path fell through to the genuinely-unparseable
+        # fallback (float("inf")), silently hiding a real near-expiry
+        # record from near_expiry_count. Normalize before subtracting,
+        # same as knob_overrides._is_expired. Genuinely unparseable input
+        # keeps the existing fail-open fallback.
+        if expires_dt.tzinfo is None:
+            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
         remaining = expires_dt - datetime.now(timezone.utc)
         return remaining.total_seconds() / 86400.0
     except (ValueError, TypeError):
@@ -287,7 +299,9 @@ def find_expiring_provisional(
             continue
         try:
             expires_at = datetime.fromisoformat(expires_str)
-        except ValueError:
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
             continue
         if expires_at <= threshold and expires_at > now:
             recurrence = 0

--- a/scripts/cleanup_expired_working.py
+++ b/scripts/cleanup_expired_working.py
@@ -28,10 +28,14 @@ else:
 
 try:
     from plugins.memory.memory_os.lane_last_run import record_lane_last_run
+    from plugins.memory.memory_os.timeutil import ensure_utc_aware
 except ModuleNotFoundError:  # pragma: no cover - plugin tree unavailable
     def record_lane_last_run(*_args, **_kwargs) -> bool:  # type: ignore[misc]
         sys.stderr.write("lane_last_run unavailable: plugin tree not importable\n")
         return False
+
+    def ensure_utc_aware(dt: datetime) -> datetime:  # type: ignore[misc]
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 RETENTION_DAYS = 7
 _LANE_ID = "working_cleanup"
@@ -73,8 +77,7 @@ def main(hermes_home: str | None = None) -> int:
             continue
         try:
             ts = datetime.fromisoformat(ts_str)
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
+            ts = ensure_utc_aware(ts)
             age_days = (now - ts).total_seconds() / 86400
         except (ValueError, TypeError):
             # Malformed/unparseable stored timestamp -- this lane DELETES

--- a/scripts/cleanup_expired_working.py
+++ b/scripts/cleanup_expired_working.py
@@ -61,6 +61,7 @@ def main(hermes_home: str | None = None) -> int:
     surviving = []
     removed_count = 0
     removed_chars = 0
+    malformed_ts_count = 0
 
     for item in items:
         if not isinstance(item, dict) or item.get("status") != "expired":
@@ -72,10 +73,19 @@ def main(hermes_home: str | None = None) -> int:
             continue
         try:
             ts = datetime.fromisoformat(ts_str)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            age_days = (now - ts).total_seconds() / 86400
         except (ValueError, TypeError):
+            # Malformed/unparseable stored timestamp -- this lane DELETES
+            # expired items, so a wrong answer here is data loss. Keep the
+            # item rather than risk deleting something that was not
+            # actually expired (matches working.py::prune_expired_items'
+            # conservative direction), and record the bad input so it is
+            # diagnosable rather than silently swallowed.
             surviving.append(item)
+            malformed_ts_count += 1
             continue
-        age_days = (now - ts).total_seconds() / 86400
         if age_days > RETENTION_DAYS:
             removed_count += 1
             removed_chars += len(str(item.get("text", "")))
@@ -83,12 +93,15 @@ def main(hermes_home: str | None = None) -> int:
         surviving.append(item)
 
     if removed_count == 0:
+        counters = {"items_scanned": before, "items_removed": 0}
+        if malformed_ts_count:
+            counters["items_malformed_timestamp"] = malformed_ts_count
         record_lane_last_run(
             home,
             _LANE_ID,
             status="ok",
             reason="no_expired_items",
-            counters={"items_scanned": before, "items_removed": 0},
+            counters=counters,
         )
         return 0
 
@@ -102,16 +115,19 @@ def main(hermes_home: str | None = None) -> int:
         sys.stderr.write(f"working_cleanup: cannot write {working_path}: {exc}\n")
         return 1
 
+    counters = {
+        "items_scanned": before,
+        "items_removed": removed_count,
+        "chars_freed": removed_chars,
+    }
+    if malformed_ts_count:
+        counters["items_malformed_timestamp"] = malformed_ts_count
     record_lane_last_run(
         home,
         _LANE_ID,
         status="ok",
         reason="removed_expired_items",
-        counters={
-            "items_scanned": before,
-            "items_removed": removed_count,
-            "chars_freed": removed_chars,
-        },
+        counters=counters,
     )
     print(
         f"🧹 Working Memory Cleanup: removed {removed_count} expired items "

--- a/scripts/deploy_l3_probe.py
+++ b/scripts/deploy_l3_probe.py
@@ -118,7 +118,7 @@ def run_plan(hermes_home: Path) -> dict[str, Any]:
     helper_current = (
         helper_installed
         and SOURCE_HELPER.is_file()
-        and DEPLOY_HELPER.read_text() == SOURCE_HELPER.read_text()
+        and DEPLOY_HELPER.read_text(encoding="utf-8") == SOURCE_HELPER.read_text(encoding="utf-8")
     ) if SOURCE_HELPER.is_file() else helper_installed
     report["helper_installed"] = helper_installed
     report["helper_current"] = helper_current

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -1989,6 +1989,7 @@ def _run_expired_working_migration(
 ) -> dict[str, object]:
     """One-time migration: remove expired working items older than 7 days."""
     from datetime import datetime, timezone
+    from plugins.memory.memory_os.timeutil import ensure_utc_aware
     working_path = hermes_home / "memory-os" / "working" / "lingering.json"
     if not working_path.exists():
         return {"status": "no_working_file", "reason": "lingering.json not found"}
@@ -2012,8 +2013,7 @@ def _run_expired_working_migration(
             continue
         try:
             ts = datetime.fromisoformat(ts_str)
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
+            ts = ensure_utc_aware(ts)
             age_days = (now - ts).total_seconds() / 86400
         except (ValueError, TypeError):
             # Malformed/unparseable timestamp -- this migration deletes

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -2012,10 +2012,16 @@ def _run_expired_working_migration(
             continue
         try:
             ts = datetime.fromisoformat(ts_str)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            age_days = (now - ts).total_seconds() / 86400
         except (ValueError, TypeError):
+            # Malformed/unparseable timestamp -- this migration deletes
+            # expired items, so keep the item rather than risk deleting
+            # something that was not actually expired (same conservative
+            # direction as cleanup_expired_working.py / prune_expired_items).
             surviving.append(item)
             continue
-        age_days = (now - ts).total_seconds() / 86400
         if age_days > 7:
             removed += 1
             continue

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -7305,6 +7305,18 @@ def cognitive_loop_step_evidence():
       "already_saturated_count", "skipped_not_injected_count",
       "invalidated_never_hit_count", "forget_eligible_backlog",
       "unresolved_hit_count", "duration_ms", "error",
+      # D2b: llm_edge_proposer per-run call tally — distinguishes "judge
+      # found no relationships" from "every LLM call failed" (see outcome
+      # above, already generic across edge steps).
+      "llm_call_count", "llm_call_ok_count", "llm_call_failure_count",
+      "llm_call_failure_reasons",
+      # edge_weight_feedback cursor-alignment visibility: a ledger-cursor
+      # desync (future graph_layer_shadow.jsonl compaction) goes dark in
+      # `outcome` whenever the run also reinforced/forgot edges that same
+      # cycle (outcome gives those precedence) — these survive that case.
+      "tracked_edge_count", "cursor_misaligned", "cursor_misalignment_reason",
+      "cursor_previous_line_count", "cursor_realigned_line_count",
+      "cursor_skipped_row_count",
     )
     edge_step_results = {}
     for step in steps:

--- a/scripts/memory_os_candidate_aggregation_lane.py
+++ b/scripts/memory_os_candidate_aggregation_lane.py
@@ -116,6 +116,7 @@ def main() -> int:
         "demoted_count": result["demoted_count"],
         "fleeting_count": result["fleeting_count"],
         "compacted_count": result["compacted_count"],
+        "compaction_skip_reason": result["compaction_skip_reason"],
         "actual_crystallized_approval": result["actual_crystallized_approval"],
         "status": "ok" if not result.get("error") else "error",
     }
@@ -126,8 +127,22 @@ def main() -> int:
         int(result.get(key) or 0)
         for key in ("promoted_count", "demoted_count", "fleeting_count", "compacted_count")
     )
+    compaction_skip_reason = str(result.get("compaction_skip_reason") or "")
     if result.get("error"):
         run_status, reason = "error", "lane_failed"
+    elif compaction_skip_reason == "effective_view_unavailable":
+        # Visibility, not alerting: status stays "ok" -- a view failure
+        # already emits its own error record, and the live queue merely
+        # growing is recoverable. But compacted_count is 0 here exactly
+        # like a healthy tick with nothing to archive, so the counter-only
+        # branches below (no_candidates/nothing_pending/no_triage_actions/
+        # triaged) cannot tell them apart -- "compaction ran and archived
+        # nothing" is a materially different fact from "compaction was not
+        # attempted", so this reason is checked before those regardless of
+        # whether other triage happened this tick.
+        run_status, reason = "ok", "compaction_skipped_effective_view_unavailable"
+    elif compaction_skip_reason == "upstream_error":
+        run_status, reason = "ok", "compaction_skipped_upstream_error"
     elif int(result.get("candidates_read") or 0) == 0:
         run_status, reason = "ok", "no_candidates"
     elif int(result.get("pending") or 0) == 0:

--- a/scripts/memory_os_cron_group_runner.py
+++ b/scripts/memory_os_cron_group_runner.py
@@ -246,9 +246,19 @@ def _is_due(spec: dict[str, Any], entry: dict[str, Any], *, now: datetime, force
     policy = str(spec.get("due_policy") or "interval")
     if policy == "calendar":
         anchor_minutes = _anchor_minutes(str(spec.get("calendar_anchor") or "00:00"))
-        if last_started.astimezone(timezone.utc).date() >= now.astimezone(timezone.utc).date():
+        # Normalize `now` to UTC once and reuse it for both the date and the
+        # anchor-minutes comparison. Production always calls this with a
+        # UTC `now` (datetime.now(timezone.utc) at both call sites), but a
+        # non-UTC-aware `now` (only reachable via the documented
+        # testing-only --now override) previously compared its raw
+        # wall-clock hour/minute against a UTC anchor while the date check
+        # two lines above was already UTC-normalized -- a mixed-timezone
+        # comparison that could report "before_calendar_anchor" past the
+        # anchor, or vice versa.
+        now_utc = now.astimezone(timezone.utc)
+        if last_started.astimezone(timezone.utc).date() >= now_utc.date():
             return False, "already_ran_today"
-        if (now.hour * 60 + now.minute) < anchor_minutes:
+        if (now_utc.hour * 60 + now_utc.minute) < anchor_minutes:
             return False, "before_calendar_anchor"
         return True, "calendar_day_due"
     try:

--- a/scripts/memory_os_l3_probe_helper.py
+++ b/scripts/memory_os_l3_probe_helper.py
@@ -175,14 +175,19 @@ def main(smoke: bool = False) -> int:
     stderr = (result.stderr or "").strip()
     details = _parse_probe_output(stdout)
 
-    # Save last result for diagnostics
+    # Save last result for diagnostics. stderr_truncated carries captured
+    # subprocess output, which can contain non-ASCII bytes -- omitting
+    # encoding= here left this write_text() at the mercy of the locale's
+    # preferred encoding, raising UnicodeEncodeError on a non-UTF-8 locale
+    # instead of writing the diagnostic (same defect class as Defect 3's
+    # deploy_l3_probe.py fix, write side rather than read side).
     LAST_RUN_FILE.parent.mkdir(parents=True, exist_ok=True)
     LAST_RUN_FILE.write_text(json.dumps({
         "returncode": result.returncode,
         "details": details,
         "stderr_truncated": stderr[-500:] if stderr else "",
         "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    }, indent=2))
+    }, indent=2), encoding="utf-8")
 
     # Smoke mode: always print result regardless of pass/fail
     if smoke:

--- a/tests/plugins/memory/test_candidate_aggregation_logic.py
+++ b/tests/plugins/memory/test_candidate_aggregation_logic.py
@@ -840,6 +840,129 @@ class TestA1Boundary:
             "error_type": "OSError",
         }
 
+    # ── Defect A: read_effective_candidates failure must not widen the
+    # pre-existing "any upstream error -> skip compaction" policy that the
+    # two feeders below (read_candidate_queue, _cluster_and_promote) rely
+    # on. These two tests pin that the policy is UNCHANGED for those
+    # feeders; the counterpart (a read_effective_candidates failure alone
+    # must still let compaction run with terminal_candidate_ids=None) lives
+    # in test_candidate_aggregation_pipeline.py, next to the fixtures
+    # (_stale_owner_eligible_candidate / _crystallize_candidate) needed to
+    # prove which terminal view actually reached compact_candidate_queue.
+
+    def test_queue_parse_error_still_skips_compaction(self, tmp_path):
+        """Counterfactual for Defect A's narrow scope: a malformed
+        candidates.jsonl row (read_candidate_queue's error_records feed at
+        run_candidate_aggregation_lane's line ~401) must still disable
+        compaction entirely. This policy predates the Defect A fix and must
+        stay unchanged -- without pinning it, a future refactor could widen
+        the read_effective_candidates exemption to cover this feeder too.
+
+        Extra teeth: compact_candidate_queue re-reads candidates.jsonl under
+        its own lock and does a raw json.loads per line with no try/except,
+        and run_candidate_aggregation_lane has no try around the compact
+        call. If this feeder's skip-compaction exemption were silently
+        widened, running compact against the still-malformed queue would not
+        just archive the wrong rows -- it would crash the lane unhandled on
+        the corrupted line.
+        """
+        from plugins.memory.memory_os.crystallized import (
+            append_candidate_queue,
+            append_candidate_triage,
+            read_candidate_queue,
+        )
+        from plugins.modules.governance.candidate_aggregation import run_candidate_aggregation_lane
+
+        store = _store_with_gate(tmp_path)
+        archivable = _cand("cand-archivable-demoted", body="记住：这是一条已裁决的候选")
+        append_candidate_queue(store, archivable)
+        append_candidate_triage(
+            store,
+            candidate_id=archivable.candidate_id,
+            action="demote",
+            target_state="demoted",
+            reason="pre-seeded terminal fixture",
+            execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        )
+        queue_path = store.roots.crystallized_root / "candidates.jsonl"
+        with queue_path.open("a", encoding="utf-8") as handle:
+            handle.write("{BROKEN\n")
+
+        result = run_candidate_aggregation_lane(
+            store,
+            execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        )
+
+        assert result["status"] == "warning"
+        assert "jsonl_malformed_line" in result["recent_error_codes"]
+        assert result["compacted_count"] == 0, (
+            "line-401 (read_candidate_queue) error must still disable "
+            f"compaction entirely, got {result}"
+        )
+        live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+        assert "cand-archivable-demoted" in live_ids, (
+            "demoted row was archived despite an upstream queue-parse error "
+            "-- the pre-existing skip-compaction policy for this feeder was "
+            "silently widened"
+        )
+
+    def test_promote_stage_error_still_skips_compaction(self, tmp_path, monkeypatch):
+        """Counterfactual for Defect A's narrow scope: a promote-stage
+        failure recorded by _cluster_and_promote (provisional_write_failed,
+        run_candidate_aggregation_lane's line ~454 feeder) must still
+        disable compaction entirely -- unchanged pre-existing policy, pinned
+        the same way as test_queue_parse_error_still_skips_compaction for
+        the other feeder."""
+        from plugins.memory.memory_os.crystallized import (
+            CrystallizedMemoryService,
+            append_candidate_queue,
+            append_candidate_triage,
+            read_candidate_queue,
+        )
+        from plugins.modules.governance.candidate_aggregation import run_candidate_aggregation_lane
+
+        store = _store_with_gate(tmp_path)
+        append_candidate_queue(
+            store,
+            _cand("cand-promote-fails-2", body="记住：每次启动必须检查失败回执二号"),
+        )
+        archivable = _cand("cand-archivable-demoted-2", body="记住：这是另一条已裁决的候选")
+        append_candidate_queue(store, archivable)
+        append_candidate_triage(
+            store,
+            candidate_id=archivable.candidate_id,
+            action="demote",
+            target_state="demoted",
+            reason="pre-seeded terminal fixture",
+            execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        )
+
+        def fail_write(*args, **kwargs):
+            raise OSError("synthetic canonical write failure")
+
+        monkeypatch.setattr(CrystallizedMemoryService, "write_approved_record", fail_write)
+
+        result = run_candidate_aggregation_lane(
+            store,
+            execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        )
+
+        assert result["status"] == "warning"
+        assert any(
+            record.get("error_code") == "provisional_write_failed"
+            for record in result["error_records"]
+        )
+        assert result["compacted_count"] == 0, (
+            "line-454 (_cluster_and_promote) error must still disable "
+            f"compaction entirely, got {result}"
+        )
+        live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+        assert "cand-archivable-demoted-2" in live_ids, (
+            "demoted row was archived despite a promote-stage write failure "
+            "-- the pre-existing skip-compaction policy for this feeder was "
+            "silently widened"
+        )
+
     def test_promote_writes_triage_not_crystallized(self, tmp_path):
         """Non-resolver-eligible candidates still write triage not crystallized.
 

--- a/tests/plugins/memory/test_candidate_aggregation_pipeline.py
+++ b/tests/plugins/memory/test_candidate_aggregation_pipeline.py
@@ -463,8 +463,350 @@ def test_compact_without_terminal_view_keeps_triage_only_behavior(tmp_path):
     store = _store_with_gate(tmp_path)
     _stale_owner_eligible_candidate(store, "cand-triage-only", days_old=60)
 
-    archived = compact_candidate_queue(store)
+    archived = compact_candidate_queue(store, provisional_backed_candidate_ids=set())
 
     live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
     assert "cand-triage-only" in live_ids
     assert archived == 0
+
+
+# ── Defect A counterpart, REVISED 2026-08-15: a read_effective_candidates
+# failure must NOT run compaction. Reversed from the original Defect A fix,
+# which degraded to terminal_candidate_ids=None (compact's own triage-only
+# view) on a view failure. Defect C then established that triage-only
+# compaction is exactly what archives a provisional-backed candidate
+# irreversibly -- so degrading to it on the one path where we have the
+# LEAST information about which candidates are provisional-backed was
+# itself unsafe. A view failure now joins the two pre-existing
+# upstream-error sources (read_candidate_queue, _cluster_and_promote,
+# pinned separately in test_candidate_aggregation_logic.py) in skipping
+# compaction outright: not compacting just lets the live queue grow --
+# visible, bounded, and fully recoverable once the malformed record is
+# fixed -- versus archiving under uncertainty, which is not recoverable
+# (candidates.archive.jsonl has no production reader).
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_effective_view_failure_skips_compaction_and_records_the_reason(tmp_path, monkeypatch):
+    """Counterfactual for the 2026-08-15 reversal: a read_effective_candidates
+    failure must skip compact_candidate_queue entirely -- not run it with
+    terminal_candidate_ids=None -- and the lane must record WHY via the
+    closed-set compaction_skip_reason field, distinguishable from both "ran
+    and archived nothing" (compaction_skip_reason is None) and the two
+    pre-existing upstream-error sources.
+
+    Two fixtures make the "compaction did not run at all" proof precise:
+
+      - a pre-seeded `demoted` triage row -- would be archived by compact's
+        own triage-only view if compaction ran (as it does in
+        test_compact_without_terminal_view_keeps_triage_only_behavior's
+        sibling case), so its survival here proves compaction did not run,
+        not merely that it archived nothing for some other reason.
+      - a crystallized ghost (permanently crystallized, stale owner_eligible
+        triage, same shape as test_actively_crystallized_row_is_archived_by_
+        the_full_terminal_view above) -- would ALSO be archived if
+        compaction ran (via the full terminal view), so it must survive too.
+
+    Patches aggregation.read_effective_candidates (the name bound inside the
+    candidate_aggregation module at import time), not
+    crystallized.read_effective_candidates -- the lane imports the symbol by
+    name, so patching the source module would not reach it.
+    """
+    import plugins.modules.governance.candidate_aggregation as aggregation
+    from plugins.memory.memory_os.crystallized import (
+        append_candidate_queue,
+        append_candidate_triage,
+        read_candidate_queue,
+    )
+
+    store = _store_with_gate(tmp_path)
+
+    demoted = _candidate("cand-demoted-fixture", body="记住：这是一条已裁决的候选")
+    append_candidate_queue(store, demoted)
+    append_candidate_triage(
+        store,
+        candidate_id="cand-demoted-fixture",
+        action="demote",
+        target_state="demoted",
+        reason="pre-seeded terminal fixture",
+        execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    ghost = _stale_owner_eligible_candidate(store, "cand-ghost-view-fail", days_old=60)
+    _crystallize_candidate(store, ghost, provisional=False)
+
+    def _raise_view_failure(_store):
+        raise RuntimeError("synthetic effective-view failure")
+
+    monkeypatch.setattr(aggregation, "read_effective_candidates", _raise_view_failure)
+
+    result = aggregation.run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    assert result["status"] == "warning"
+    assert "candidate_effective_view_failed" in result["recent_error_codes"]
+    assert result["recall_exclusion_count"] == -1, (
+        "a view failure must not silently republish recall exclusions"
+    )
+    assert result["compacted_count"] == 0, (
+        "compaction must NOT run on a view failure -- archiving under "
+        "uncertainty about which candidates are provisional-backed is "
+        "unrecoverable, unlike a queue that merely grows"
+    )
+    assert result["compaction_skip_reason"] == "effective_view_unavailable", (
+        "the reason must be durable and distinguishable from the two "
+        f"pre-existing upstream-error sources, got {result['compaction_skip_reason']!r}"
+    )
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-demoted-fixture" in live_ids, (
+        "demoted row was archived -- compaction ran despite the view "
+        "failure, which is exactly the unsafe fallback this test guards "
+        "against"
+    )
+    assert "cand-ghost-view-fail" in live_ids, (
+        "crystallized-ghost row was archived -- compaction ran despite the "
+        "view failure"
+    )
+
+
+# ── Defect B: provisional-backed terminality must not be archivable ────────
+#
+# Verified chain: any active crystallized record (provisional included)
+# marks a candidate terminal in read_effective_candidates. Before this fix,
+# candidate_aggregation passed that FULL terminal set straight to
+# compact_candidate_queue, so a resolver-approved provisional candidate got
+# archived out of the live queue on the same or a later tick. Once
+# provisional_sweep later invalidates the provisional (TTL/cap eviction),
+# the candidate is in NEITHER the live queue NOR active crystallized memory
+# -- candidates.archive.jsonl has no production reader, so there is no
+# automatic path back. The fix: EffectiveCandidate.provisional_backed marks
+# "terminal only because of an active provisional record, no active
+# permanent record backs it", and the lane excludes those ids from the set
+# it hands to compact_candidate_queue while still including them in the
+# FULL set it publishes to write_candidate_recall_exclusions (the content is
+# already in crystallized memory, so it must not double-surface in recall).
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_provisional_backed_terminal_row_is_not_archived(tmp_path):
+    """Counterfactual for Defect B: a provisional-backed terminal candidate
+    must stay in the live queue -- archival is one-way, and the provisional
+    anchor is reversible by design (resolver TTL/cap eviction, owner
+    reject). It IS excluded from recall (content already crystallized).
+
+    Deliberately the provisional=True mirror of
+    test_actively_crystallized_row_is_archived_by_the_full_terminal_view
+    above (same _stale_owner_eligible_candidate baseline, same days_old=60,
+    same owner_eligible triage state) so the only variable is the
+    provisional flag -- isolating exactly what changed."""
+    from plugins.memory.memory_os.crystallized import (
+        read_candidate_queue,
+        read_candidate_recall_exclusions,
+    )
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _stale_owner_eligible_candidate(store, "cand-prov-backed", days_old=60)
+    _crystallize_candidate(store, candidate, provisional=True)
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    # Not re-promoted, not stale-swept (shielded by the active provisional
+    # record, same pre-filter as the permanent case):
+    assert result["stale_owner_eligible_demoted_count"] == 0, result
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-prov-backed" in live_ids, (
+        "provisional-backed row was archived -- the provisional anchor is "
+        "reversible, archival is not"
+    )
+    assert "cand-prov-backed" in read_candidate_recall_exclusions(store.roots), (
+        "a provisional-backed candidate must still be excluded from recall "
+        "-- its content is already in crystallized memory"
+    )
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_invalidated_provisional_lets_the_pipeline_reach_the_candidate_again(tmp_path):
+    """Counterfactual for Defect B's reversal half: once the provisional
+    anchor is invalidated through the REAL API
+    (invalidate_provisional_record with resolver_ttl_expired -- the same
+    call provisional_sweep makes), the candidate must resurface as
+    non-terminal so the pipeline can reach it again. Mirrors
+    test_evicted_provisional_no_longer_shields_the_queue_row above (which
+    uses revoke_record with resolver_cap_evicted); this uses the TTL-expiry
+    path the acceptance criteria calls out explicitly."""
+    from plugins.memory.memory_os.crystallized import (
+        read_candidate_queue,
+        read_effective_candidates,
+    )
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _stale_owner_eligible_candidate(store, "cand-prov-expires", days_old=20)
+    service, record_id = _crystallize_candidate(store, candidate, provisional=True)
+
+    # While the provisional is active, the row stays but is terminal.
+    pre_effective = {
+        item.candidate.candidate_id: item for item in read_effective_candidates(store)
+    }
+    assert pre_effective["cand-prov-expires"].terminal is True
+    assert pre_effective["cand-prov-expires"].provisional_backed is True
+
+    service.invalidate_provisional_record(
+        record_id, reason="resolver_ttl_expired", invalidated_by="provisional_sweep",
+    )
+
+    post_effective = {
+        item.candidate.candidate_id: item for item in read_effective_candidates(store)
+    }
+    assert post_effective["cand-prov-expires"].terminal is False, (
+        "candidate must resurface as non-terminal once its only anchor is "
+        "invalidated"
+    )
+
+    # The pipeline can now act on it again (stale sweep reaches it, since
+    # it is no longer shielded by an active crystallized record).
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+    assert result["stale_owner_eligible_demoted_count"] == 1, result
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-prov-expires" not in live_ids, (
+        "resurfaced candidate should now be reachable and demoted/compacted "
+        "by the stale sweep, not stuck"
+    )
+
+
+# ── Defect C (coordinator follow-up, 2026-08-15): the retention-window
+# elif/else branch inside compact_candidate_queue resolves state from triage
+# rows alone (resolve_candidate_effective_state) and has no idea a candidate
+# is provisional-backed. Excluding a provisional-backed id from
+# archivable_terminal_ids (Defect B's fix) only protects it from the FIRST
+# branch of compact_candidate_queue; a resolver-approved provisional
+# candidate whose triage state is "resolver_approved" (not "owner_eligible")
+# still ages out through the retention-window branch once its row passes
+# retention_days -- the same loss shape as Defect B, reached a different
+# way, and arguably more likely since provisional TTLs can exceed
+# retention_days. The fix: compact_candidate_queue takes an explicit
+# provisional_backed_candidate_ids set and keeps those rows active
+# UNCONDITIONALLY, checked first, ahead of every other branch.
+#
+# Deliberately uses "resolver_approved" triage (not the "owner_eligible"
+# baseline every earlier fixture in this file used) -- owner_eligible's
+# first-clause exemption already made it immune to the age branch, which is
+# exactly what left this branch untested.
+
+
+def _resolver_approved_aged_candidate(store, candidate_id, *, days_old):
+    """Real-producer setup mirroring _cluster_and_promote's own
+    resolver-approve triage write (target_state='resolver_approved'), aged
+    past retention_days. bridge_state is set to a non-default value so the
+    raw-bridge_state filter in _cluster_and_promote's candidates_for_promote
+    (c.bridge_state in ("", "inner_drive_candidate")) excludes it from being
+    re-clustered on a later lane run -- isolating the retention/demote
+    branches this test targets from an unrelated promote-stage race."""
+    from datetime import timedelta
+
+    from plugins.memory.memory_os.crystallized import (
+        append_candidate_queue,
+        append_candidate_triage,
+    )
+
+    now = datetime.now(timezone.utc)
+    created = (now - timedelta(days=days_old)).isoformat().replace("+00:00", "Z")
+    candidate = _candidate(
+        candidate_id,
+        body="记住：Memory-OS 的部署配置讨论,关键词富集必然成簇的建造期元讨论。",
+        bridge_state="resolver_approved",
+        created_at=created,
+    )
+    append_candidate_queue(store, candidate)
+    append_candidate_triage(
+        store,
+        candidate_id=candidate_id,
+        action="promote",
+        target_state="resolver_approved",
+        reason="cluster match (test fixture, resolver approved)",
+        cluster_key="moment:记住",
+        cluster_size=2,
+        execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+        now=now - timedelta(days=days_old),
+    )
+    return candidate
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_provisional_backed_resolver_approved_row_survives_retention_window_archival(tmp_path):
+    """Counterfactual for Defect C: a provisional-backed candidate whose
+    triage state is resolver_approved (not owner_eligible) and whose row is
+    aged past retention_days must still survive compaction. Without
+    provisional_backed_candidate_ids reaching compact_candidate_queue, this
+    row falls through the terminal-ids branch (correctly excluded by Defect
+    B) straight into the retention-window elif/else, which does not know it
+    is provisional-backed and archives it once age >= retention_days.
+
+    Then invalidates the provisional through the REAL API
+    (invalidate_provisional_record, resolver_ttl_expired) and shows the
+    pipeline can still reach and act on the candidate afterward."""
+    from plugins.memory.memory_os.crystallized import (
+        read_candidate_queue,
+        read_candidate_recall_exclusions,
+        read_effective_candidates,
+    )
+    from plugins.modules.governance.candidate_aggregation import (
+        run_candidate_aggregation_lane,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _resolver_approved_aged_candidate(
+        store, "cand-resolver-approved-aged", days_old=20,
+    )
+    service, record_id = _crystallize_candidate(store, candidate, provisional=True)
+
+    result = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-resolver-approved-aged" in live_ids, (
+        "provisional-backed row with resolver_approved triage, aged past "
+        "retention_days, was archived through the retention-window branch "
+        "-- the reversibility guarantee was not enforced on every branch "
+        f"of compact_candidate_queue. result={result}"
+    )
+    assert "cand-resolver-approved-aged" in read_candidate_recall_exclusions(store.roots), (
+        "a provisional-backed candidate must still be excluded from recall"
+    )
+
+    # Reversal half: once the provisional anchor is invalidated through the
+    # real API, the candidate must resurface as non-terminal...
+    service.invalidate_provisional_record(
+        record_id, reason="resolver_ttl_expired", invalidated_by="provisional_sweep",
+    )
+    post_effective = {
+        item.candidate.candidate_id: item for item in read_effective_candidates(store)
+    }
+    assert post_effective["cand-resolver-approved-aged"].terminal is False, (
+        "candidate must resurface as non-terminal once its only anchor is "
+        "invalidated"
+    )
+
+    # ...and the pipeline must be able to reach and act on it again (no
+    # longer shielded by an active crystallized record, it is now old
+    # enough for the general aged-demote sweep to close it).
+    result2 = run_candidate_aggregation_lane(
+        store, execution_gate_envelope_id=_VALID_ENVELOPE_ID,
+    )
+    assert result2["demoted_count"] >= 1, result2
+    live_ids_after = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-resolver-approved-aged" not in live_ids_after, (
+        "resurfaced candidate should now be reachable and demoted/compacted "
+        "by the general aged sweep, not stuck"
+    )

--- a/tests/plugins/memory/test_candidate_aggregation_pipeline.py
+++ b/tests/plugins/memory/test_candidate_aggregation_pipeline.py
@@ -810,3 +810,105 @@ def test_provisional_backed_resolver_approved_row_survives_retention_window_arch
         "resurfaced candidate should now be reachable and demoted/compacted "
         "by the general aged sweep, not stuck"
     )
+
+
+# ── Defect D (coordinator pre-merge review, 2026-08-15): Defect C's fix
+# protects a resolver_approved row from the retention-window branch only
+# while the caller passes an accurate provisional_backed_candidate_ids set.
+# invalidate_provisional_record (called by provisional_sweep on TTL/cap
+# eviction) mutates ONLY the crystallized record's frontmatter -- it appends
+# NO triage row. So the tick immediately after eviction: the candidate is no
+# longer provisional_backed (record inactive) AND its latest triage row still
+# says "resolver_approved" (not "owner_eligible", frozen from promotion
+# time) -- neither exemption clause in the retention-window elif applied,
+# and the row fell into the else branch and archived once aged past
+# retention_days. Same loss shape as Defect C, at the eviction transition
+# the guard exists to close. Fix: the retention-window elif treats
+# resolver_approved as sticky, exactly like owner_eligible.
+#
+# The decisive counterfactual below calls compact_candidate_queue directly
+# (not through run_candidate_aggregation_lane) with
+# provisional_backed_candidate_ids=set() -- exactly what candidate_aggregation
+# itself would compute post-invalidation -- to isolate the retention-window
+# elif/else branch this fix targets from _demote_aged's general aged-demote
+# sweep, which (depending on whether the candidate's bridge_state still
+# qualifies it for re-clustering) may or may not get a turn before compact
+# runs in the full pipeline. The function-level contract must hold on its
+# own regardless of what the current sole caller's stage ordering happens to
+# paper over.
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_resolver_approved_row_survives_compact_after_provisional_invalidated(tmp_path):
+    """DECISIVE counterfactual for Defect D: once invalidate_provisional_record
+    evicts the ONLY crystallized anchor for a resolver_approved candidate,
+    compact_candidate_queue's retention-window elif -- which resolves
+    effective state from triage rows alone and has no idea the candidate WAS
+    provisional-backed -- must not archive the row purely because it aged
+    past retention_days with a frozen resolver_approved triage state."""
+    from plugins.memory.memory_os.crystallized import (
+        compact_candidate_queue,
+        read_candidate_queue,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _resolver_approved_aged_candidate(
+        store, "cand-sticky-resolver-approved", days_old=20,
+    )
+    service, record_id = _crystallize_candidate(store, candidate, provisional=True)
+
+    service.invalidate_provisional_record(
+        record_id, reason="resolver_ttl_expired", invalidated_by="provisional_sweep",
+    )
+
+    archived_count = compact_candidate_queue(
+        store, retention_days=7, provisional_backed_candidate_ids=set(),
+    )
+
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-sticky-resolver-approved" in live_ids, (
+        "resolver_approved row was archived one tick after its provisional "
+        f"anchor was evicted -- archived_count={archived_count}"
+    )
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+def test_resolver_approved_confirmed_permanent_still_archived_by_terminal_branch(tmp_path):
+    """Regression guard for Defect D's fix: the new resolver_approved
+    stickiness must NOT resurrect a candidate whose provisional was
+    confirmed to a PERMANENT crystallized record. terminal_candidate_ids
+    (checked before the retention-window elif) must still win."""
+    from plugins.memory.memory_os.crystallized import (
+        compact_candidate_queue,
+        read_candidate_queue,
+        read_effective_candidates,
+    )
+
+    store = _store_with_gate(tmp_path)
+    candidate = _resolver_approved_aged_candidate(
+        store, "cand-confirmed-permanent", days_old=20,
+    )
+    _crystallize_candidate(store, candidate, provisional=False)
+
+    effective = read_effective_candidates(store)
+    terminal_ids = {
+        item.candidate.candidate_id for item in effective
+        if item.terminal and not item.provisional_backed
+    }
+    assert "cand-confirmed-permanent" in terminal_ids, (
+        "test setup: a permanently-crystallized candidate must resolve "
+        "terminal and not provisional_backed"
+    )
+
+    archived_count = compact_candidate_queue(
+        store,
+        retention_days=7,
+        terminal_candidate_ids=terminal_ids,
+        provisional_backed_candidate_ids=set(),
+    )
+
+    live_ids = {c.candidate_id for c in read_candidate_queue(store.roots)}
+    assert "cand-confirmed-permanent" not in live_ids, (
+        "sticky resolver_approved must not override the terminal branch for "
+        f"a permanently-confirmed candidate -- archived_count={archived_count}"
+    )

--- a/tests/plugins/memory/test_candidate_compact_atomic.py
+++ b/tests/plugins/memory/test_candidate_compact_atomic.py
@@ -77,7 +77,7 @@ def test_compact_archive_append_failure_keeps_main_candidates(tmp_path, monkeypa
     )
 
     with pytest.raises(RuntimeError, match="simulated archive write failure"):
-        compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+        compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     assert candidates_path.read_text() == original_content
     assert not archive_path.exists() or archive_path.stat().st_size == 0
@@ -96,7 +96,7 @@ def test_compact_writes_conservation_ok_audit(tmp_path):
     append_candidate_queue(store, stale)
 
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
-    archived_count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    archived_count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     assert archived_count >= 1
 
@@ -140,7 +140,7 @@ def test_compact_malformed_line_does_not_replace(tmp_path):
 
     # compact should raise (JSONDecodeError) on the malformed line
     with pytest.raises((json.JSONDecodeError, Exception)):
-        compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+        compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     # Original content is still present in the file
     current = candidates_path.read_text()
@@ -157,7 +157,7 @@ def test_concurrent_append_waits_for_compact_lock(tmp_path):
     append_candidate_queue(store, stale)
 
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
-    count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     assert count >= 1
 
@@ -182,7 +182,7 @@ def test_compact_skips_duplicate_candidate_ids_in_archive(tmp_path):
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
 
     # First compact: stale goes to archive, active stays empty
-    count1 = compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    count1 = compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
     assert count1 == 1
 
     # Re-add the same stale candidate (simulating it re-entered queue)
@@ -190,7 +190,7 @@ def test_compact_skips_duplicate_candidate_ids_in_archive(tmp_path):
     append_candidate_queue(store, stale2)
 
     # Second compact: should compact the stale candidate but dedup in archive
-    count2 = compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    count2 = compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
     assert count2 == 1  # still archived from active
 
     # Archive should have exactly 1 entry (dedup kicked in)
@@ -217,12 +217,12 @@ def test_compact_dedup_writes_audit_record(tmp_path):
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
 
     # First compact
-    compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     # Re-add and compact again
     stale2 = _make_candidate(candidate_id="stale-dedup-audit", age_days=14, bridge_state="fleeting")
     append_candidate_queue(store, stale2)
-    compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     audit_records = read_audit_records(store.roots.audit_path)
     dedup_audits = [
@@ -241,7 +241,7 @@ def test_compact_no_dedup_audit_when_no_duplicates(tmp_path):
     append_candidate_queue(store, stale)
 
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
-    compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     audit_records = read_audit_records(store.roots.audit_path)
     dedup_audits = [
@@ -262,7 +262,7 @@ def test_compact_dedup_different_candidates_not_affected(tmp_path):
     append_candidate_queue(store, stale_b)
 
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
-    count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     assert count == 2
     archive_records = [
@@ -283,7 +283,7 @@ def test_compact_dedup_malformed_archive_lines_ignored(tmp_path):
     stale = _make_candidate(candidate_id="stale-after-malformed", age_days=14, bridge_state="fleeting")
     append_candidate_queue(store, stale)
 
-    count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    count = compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
     assert count == 1  # should succeed despite malformed archive line
 
     # Parse archive lines individually — skip malformed (as production dedup does)
@@ -309,12 +309,12 @@ def test_counterfactual_compact_without_dedup_would_duplicate(tmp_path):
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
 
     # First compact
-    compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     # Re-add and compact again
     stale2 = _make_candidate(candidate_id="stale-cf", age_days=14, bridge_state="fleeting")
     append_candidate_queue(store, stale2)
-    compact_candidate_queue(store, archive_path=archive_path, retention_days=1)
+    compact_candidate_queue(store, archive_path=archive_path, retention_days=1, provisional_backed_candidate_ids=set())
 
     # With dedup, archive should have exactly 1 entry for stale-cf
     archive_records = [
@@ -338,7 +338,9 @@ def test_compact_without_archive_path_uses_default_and_preserves_stale(tmp_path)
     append_candidate_queue(store, active)
 
     # Call WITHOUT archive_path — must use safe default, not drop stale
-    count = compact_candidate_queue(store, retention_days=1)
+    count = compact_candidate_queue(
+        store, retention_days=1, provisional_backed_candidate_ids=set(),
+    )
     assert count == 1  # stale-default-path archived
 
     # Main file should only have the active candidate
@@ -367,7 +369,9 @@ def test_counterfactual_archive_path_none_drops_data(tmp_path):
 
     # Explicit None must still get a safe default (not drop data)
     # Note: after Fix 2, None → derived default, so this is safe
-    count = compact_candidate_queue(store, archive_path=None, retention_days=1)
+    count = compact_candidate_queue(
+        store, archive_path=None, retention_days=1, provisional_backed_candidate_ids=set(),
+    )
     assert count == 1
 
     # Verify stale was archived, not lost
@@ -404,7 +408,7 @@ def test_compact_archives_young_demoted_candidate(tmp_path):
     append_candidate_queue(store, young_absorbed)
 
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
-    archived_count = compact_candidate_queue(store, archive_path=archive_path, retention_days=7)
+    archived_count = compact_candidate_queue(store, archive_path=archive_path, retention_days=7, provisional_backed_candidate_ids=set())
 
     assert archived_count == 2
     remaining = read_candidate_queue(store)
@@ -428,7 +432,7 @@ def test_compact_keeps_young_owner_eligible_archives_young_fleeting(tmp_path):
     append_candidate_queue(store, young_fleeting)
 
     archive_path = store.roots.crystallized_root / "candidates_archive.jsonl"
-    archived_count = compact_candidate_queue(store, archive_path=archive_path, retention_days=7)
+    archived_count = compact_candidate_queue(store, archive_path=archive_path, retention_days=7, provisional_backed_candidate_ids=set())
 
     # fleeting is now terminal, so 1 gets archived
     assert archived_count == 1

--- a/tests/plugins/memory/test_event_stats.py
+++ b/tests/plugins/memory/test_event_stats.py
@@ -465,3 +465,119 @@ def test_continuity_selector_parity_with_live_selector(tmp_path):
     assert cached["seed_slots"] == live["seed_slots"]
     assert cached["max_records"] == live["max_records"]
     assert cached["schema_version"] == live["schema_version"]
+
+
+def test_continuity_selector_parity_with_bookkeeping_burst_and_tied_ts(tmp_path):
+    """Decisive parity test for the verified mirror-drift defect.
+
+    Builds ONE synthetic event set containing:
+      - one seed-eligible event per _CONTINUITY_SEED_SLOTS bucket (7 events,
+        filling all 7 seed slots and leaving exactly 1 global-fill slot open
+        under _MAX_CONTINUITY_RECORDS=8),
+      - a bookkeeping burst of 5 governance_* events (high importance, recent
+        ts, two of them sharing the exact same ts to exercise the (ts, id)
+        sort tie-break) that must be excluded from the global recency FILL
+        (but not from governance's own seed slot — that asymmetry is pinned),
+      - one ordinary lower-importance foreground conversation_turn event that
+        should win the single remaining fill slot once the burst is excluded.
+
+    Feeds the SAME events through both real producers:
+      - live: EventEnvelope objects via MemoryOSStore + continuity_selector_report
+      - mirror: the same events' .to_dict() via build_event_stats
+
+    Before the fix, the live selector excludes the governance_* burst from
+    its fill (prefetch._select_continuity_events line 3074-3078) while the
+    mirror's `remaining` had no such exclusion, so cached selected_by_source_class
+    reported governance=2/foreground=2 while live reported governance=1/
+    foreground=3 for this exact input — the disagreement this test pins.
+    """
+    from plugins.memory.memory_os.prefetch import continuity_selector_report
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.schema import EventEnvelope
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    now = datetime.now(timezone.utc)
+
+    def _ts(minutes_ago: float) -> str:
+        return (now - timedelta(minutes=minutes_ago)).isoformat()
+
+    events_data = [
+        # -- 7 seed-eligible events, one per bucket (age_minutes chosen so
+        #    each is the top-ranked candidate in its own source-class bucket) --
+        # (id_suffix, age_minutes, source, kind, safe_ref, importance)
+        ("seed-foreground-a", 1, "foreground", "conversation_turn", {}, 0.9),
+        ("seed-foreground-b", 2, "foreground", "conversation_turn", {}, 0.8),
+        ("seed-cron", 3, "cron_src", "cron_job",
+         {"source_module": "cron_mirror"}, 0.5),
+        ("seed-mailbox", 4, "mailbox_src", "mailbox_item",
+         {"platform": "mailbox"}, 0.5),
+        ("seed-room-family", 5, "family", "room_update", {}, 0.5),
+        ("seed-state-source", 6, "state_src", "state_change",
+         {"source_module": "state_source_mirror"}, 0.5),
+        ("seed-governance", 0.2, "governance", "proposal_review", {}, 1.0),
+        # -- bookkeeping burst: must be excluded from the global FILL only --
+        # Two share the exact same ts to exercise the (ts, id) sort tie-break.
+        ("burst-1", 0.5, "governance", "governance_resolver_approved", {}, 1.0),
+        ("burst-2-tied", 0.6, "governance", "governance_resolver_invalidated", {}, 1.0),
+        ("burst-3-tied", 0.6, "governance", "governance_resolver_approved", {}, 1.0),
+        ("burst-4", 0.7, "governance", "governance_resolver_invalidated", {}, 1.0),
+        ("burst-5", 0.8, "governance", "governance_resolver_approved", {}, 1.0),
+        # -- ordinary event that should win the single remaining fill slot
+        #    once the burst above is correctly excluded --
+        ("extra-foreground", 9, "foreground", "conversation_turn", {}, 0.4),
+    ]
+
+    # burst-2-tied and burst-3-tied share an identical ts string.
+    tied_ts = _ts(0.6)
+
+    for id_suffix, age_min, source, kind, safe_ref_extra, importance in events_data:
+        ts = tied_ts if id_suffix in ("burst-2-tied", "burst-3-tied") else _ts(age_min)
+        safe_ref = {"importance": importance, **safe_ref_extra}
+        event = EventEnvelope(
+            schema_version="memory-os.event.v0",
+            id=f"evt-{id_suffix}",
+            ts=ts,
+            profile="test",
+            source=source,
+            kind=kind,
+            summary=f"summary-{id_suffix}",
+            tags=[],
+            safe_ref=safe_ref,
+        )
+        store.append_event(event)
+
+    # Live selector (EventEnvelope path).
+    live = continuity_selector_report(store)
+
+    # Cached selector (dict path — same data, same real producer chain).
+    sorted_events = sorted(store.read_events(), key=lambda e: e.ts)
+    event_dicts = [e.to_dict() for e in sorted_events]
+    cached = build_event_stats(event_dicts).continuity_selector
+
+    assert cached["selected_total"] == live["selected_total"], (
+        f"selected_total: cached={cached['selected_total']} live={live['selected_total']}"
+    )
+    assert cached["dropped_total"] == live["dropped_total"], (
+        f"dropped_total: cached={cached['dropped_total']} live={live['dropped_total']}"
+    )
+    for field in ("selected_by_source_class", "dropped_by_source_class"):
+        cached_val = cached[field]
+        live_val = live[field]
+        for sc in set(list(cached_val) + list(live_val)):
+            c = cached_val.get(sc, 0)
+            l = live_val.get(sc, 0)
+            assert c == l, f"{field}[{sc}]: cached={c} live={l}"
+
+    # Pin the actual live-correct values so a future change to either side
+    # that breaks parity is caught even if both sides drift together.
+    assert live["selected_by_source_class"] == {
+        "foreground": 3, "cron": 1, "mailbox": 1,
+        "room_family": 1, "state_source": 1, "governance": 1,
+    }
+    assert live["dropped_by_source_class"] == {"governance": 5}
+    assert live["selected_total"] == 8
+    assert live["dropped_total"] == 5

--- a/tests/plugins/memory/test_memory_os_attribution_contract.py
+++ b/tests/plugins/memory/test_memory_os_attribution_contract.py
@@ -82,8 +82,13 @@ def test_every_attributable_class_has_a_recognised_id_prefix():
     # crystallized/candidate/working/event own a literal prefix; indexed and
     # graph_layer emit "<record_type>:<record_id>" where record_type is itself
     # one of those canonical types, so they are covered transitively.
+    # recall_facade is the same shape: prefetch._recall_object_canonical_ids
+    # translates each RecallObject's lane-specific source_ref (e.g.
+    # "entity_graph:<id>") through the same record_type -> canonical prefix
+    # table _canonical_source_id uses for graph_layer, rather than passing
+    # the retriever's own ad hoc prefix through verbatim.
     direct = {prefix.rstrip(":") for prefix in CANONICAL_SOURCE_ID_PREFIXES}
-    transitive = {"indexed", "graph_layer"}
+    transitive = {"indexed", "graph_layer", "recall_facade"}
     uncovered = ATTRIBUTABLE_SOURCE_CLASSES - direct - transitive
     assert not uncovered, (
         f"attributable class(es) with no recognised source_id prefix: {sorted(uncovered)}"
@@ -172,6 +177,242 @@ def test_section_source_class_mapping_is_the_single_source_of_truth():
     assert _section_source_class("Crystallized Memory (deterministic floor recall)") == (
         "crystallized"
     )
+
+
+def test_every_emitted_section_title_is_mapped_in_the_producer_vocabulary(tmp_path):
+    """Closes the blind direction that let "Recent Cross-Session" drift.
+
+    test_section_source_class_mapping_is_the_single_source_of_truth (above)
+    only proves the map's VALUES are all classified against
+    _section_source_class -- it says nothing about whether the map's KEYS
+    cover every title the real producer actually emits. "Recent
+    Cross-Session" was a live injected section (_build_prefetch_sections,
+    prefetch.py) absent from SECTION_SOURCE_CLASS_BY_TITLE for exactly that
+    reason: nothing ever checked the other direction, so it silently fell
+    through to the unattributable fallback forever.
+
+    This runs the real producer (_build_prefetch_sections) against a
+    populated store rather than a hand-written list of titles -- a
+    hardcoded fixture would make this pass vacuously, which is exactly how
+    the original gap survived.
+
+    Counterfactual: remove the "Recent Cross-Session" entry from
+    SECTION_SOURCE_CLASS_BY_TITLE and this fails, because the seeded store
+    below makes the real producer emit that exact title.
+    """
+    import json
+    from datetime import timedelta
+
+    from plugins.memory.memory_os.crystallized import (
+        CrystallizedCandidate,
+        append_candidate_queue,
+    )
+    from plugins.memory.memory_os.prefetch import _build_prefetch_sections
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, EventEnvelope
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    current_session_id = "sess_guard_current"
+    other_session_id = "sess_guard_other"
+
+    # Recent Event Summaries: an event in the current session.
+    store.append_event(EventEnvelope(
+        schema_version=EVENT_SCHEMA_VERSION,
+        id="evt_guard_current",
+        ts=datetime.now(timezone.utc).isoformat(),
+        profile="memoryos-test",
+        source="test",
+        kind="conversation_turn",
+        summary="User: guard-test current session content | Assistant: ack",
+        safe_ref={"session_id": current_session_id},
+        tags=[],
+    ))
+
+    # Recent Cross-Session: a source-gate-passed event from another session
+    # within the recency window -- the exact section under test.
+    cross_event_id = "evt_guard_cross"
+    store.append_event(EventEnvelope(
+        schema_version=EVENT_SCHEMA_VERSION,
+        id=cross_event_id,
+        ts=(datetime.now(timezone.utc) - timedelta(hours=3)).isoformat(),
+        profile="memoryos-test",
+        source="test",
+        kind="conversation_turn",
+        summary="User: guard-test cross-session content | Assistant: ack",
+        safe_ref={"session_id": other_session_id},
+        tags=[],
+    ))
+    candidates_path = store.roots.crystallized_root / "candidates.jsonl"
+    candidates_path.parent.mkdir(parents=True, exist_ok=True)
+    candidates_path.write_text(
+        json.dumps({
+            "candidate_id": "cand_guard_gate",
+            "kind": "moment",
+            "body": "source-gate candidate for the guard test",
+            "source_event_ids": [cross_event_id],
+            "tags": [],
+            "sensitivity": "private",
+            "bridge_state": "inner_drive_candidate",
+        }, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    # Crystallized Review Candidates: a queue row surfaced via magic word.
+    append_candidate_queue(
+        store,
+        CrystallizedCandidate(
+            candidate_id="cand_guard_review",
+            kind="moment",
+            body="review-queue candidate for the guard test",
+            source_event_ids=["evt_guard_review"],
+            sensitivity="private",
+            tags=["synthetic"],
+            bridge_state="inner_drive_candidate",
+        ),
+    )
+
+    sections, _source_ids = _build_prefetch_sections(
+        "candidate 候选 review guard-test content",
+        store=store,
+        index=None,
+        session_id=current_session_id,
+    )
+
+    emitted_titles = [title for title, _lines in sections]
+    assert "Recent Cross-Session" in emitted_titles, (
+        f"seed did not exercise the section under test; emitted: {emitted_titles}"
+    )
+    assert len(emitted_titles) >= 3, (
+        f"guard is checking too little of the real producer's surface: {emitted_titles}"
+    )
+
+    for title in emitted_titles:
+        base_title = title.split(" (")[0] if " (" in title else title
+        assert base_title in SECTION_SOURCE_CLASS_BY_TITLE, (
+            f"{title!r} is emitted by the real producer but absent from "
+            f"SECTION_SOURCE_CLASS_BY_TITLE -- it falls through to the "
+            f"unattributable {SECTION_SOURCE_CLASS_FALLBACK!r} fallback and "
+            f"the disclosure audit can never see it. Emitted titles: {emitted_titles}"
+        )
+
+
+def test_recall_facade_section_is_mapped_and_source_ids_are_wired(tmp_path):
+    """The Recall Facade section is only emitted when a recall_facade whose
+    plan resolves to apply_canary is passed in (default recall_facade=None),
+    which is exactly why the "Recent Cross-Session" guard above -- driven
+    without a facade -- could not catch this sibling defect: the section
+    ``sections.append(("Recall Facade (unified)", [facade_text]))`` bypasses
+    ``_append_section`` entirely, so its title was absent from
+    SECTION_SOURCE_CLASS_BY_TITLE (falls through to the unattributable
+    "other" fallback) and from _budget_keep_priority (silent default 50).
+
+    This drives the real producer (_build_prefetch_sections) with a fake
+    facade whose retrieve() returns real RecallObjects across three lanes
+    that DO resolve to a canonical record (crystallized, entity_graph,
+    indexed_fts) plus one lane that does NOT (state_overlay, an aggregate
+    projection with no 1:1 record) -- proving both that attribution is wired
+    and that it is not fabricated for content that cannot honestly carry it.
+
+    Counterfactual: removing the "Recall Facade" entry from
+    SECTION_SOURCE_CLASS_BY_TITLE fails the mapping assertions below (falls
+    back to "other"); removing the source_ids wiring in
+    _build_prefetch_sections's facade block, or reverting
+    _recall_object_canonical_ids to a verbatim source_ref pass-through, fails
+    the source_ids assertions; leaving _budget_keep_priority unmodified fails
+    the priority assertion (silent default 50).
+    """
+    from plugins.memory.memory_os.prefetch import (
+        _budget_keep_priority,
+        _build_prefetch_sections,
+        _section_source_class,
+    )
+    from plugins.memory.memory_os.recall_types import RecallObject
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    class _ApplyCanaryFacadeWithRealObjects:
+        last_recall_plan = {"mode": "apply_canary"}
+
+        def retrieve(self, store, query, *, top_k=10, scope=None):
+            return {
+                "crystallized": [
+                    RecallObject(
+                        recall_type="crystallized",
+                        content="guard-test crystallized facade content",
+                        source_ref="crystallized:cryst_guard_facade",
+                    )
+                ],
+                "entity_graph": [
+                    RecallObject(
+                        recall_type="entity_graph",
+                        content="guard-test entity-graph facade content",
+                        source_ref="entity_graph:cryst_guard_facade",
+                        metadata={"related_record_id": "cryst_guard_facade"},
+                    )
+                ],
+                "indexed_fts": [
+                    RecallObject(
+                        recall_type="indexed_fts",
+                        content="guard-test fts facade content",
+                        source_ref="fts5:evt_guard_facade",
+                        metadata={"kind": "event", "record_id": "evt_guard_facade"},
+                    )
+                ],
+                "state_overlay": [
+                    RecallObject(
+                        recall_type="state_overlay",
+                        content="guard-test overlay facade content (no 1:1 record)",
+                        source_ref="active_projects",
+                    )
+                ],
+            }
+
+        def format_context(self, results, *, budget=800):
+            return "bounded canary recall spanning multiple lanes"
+
+    sections, section_source_ids = _build_prefetch_sections(
+        "guard-test facade content", store=store, index=None,
+        recall_facade=_ApplyCanaryFacadeWithRealObjects(),
+    )
+
+    emitted_titles = [title for title, _lines in sections]
+    assert "Recall Facade (unified)" in emitted_titles, (
+        f"fake facade did not exercise the section under test; emitted: {emitted_titles}"
+    )
+
+    # (d) real-producer coverage: every emitted title, not a hardcoded list.
+    for title in emitted_titles:
+        base_title = title.split(" (")[0] if " (" in title else title
+        assert base_title in SECTION_SOURCE_CLASS_BY_TITLE, (
+            f"{title!r} is emitted by the real producer but absent from "
+            f"SECTION_SOURCE_CLASS_BY_TITLE. Emitted titles: {emitted_titles}"
+        )
+
+    # (a) explicit, non-fallback classification.
+    assert _section_source_class("Recall Facade (unified)") == "recall_facade"
+    assert _section_source_class("Recall Facade (unified)") != SECTION_SOURCE_CLASS_FALLBACK
+
+    # (b) source_ids wired at the append site, translated to the canonical
+    # vocabulary -- and NOT fabricated for the state_overlay object, which
+    # has no 1:1 canonical record.
+    facade_ids = section_source_ids.get("Recall Facade (unified)")
+    assert facade_ids == [
+        "crystallized:cryst_guard_facade",
+        "crystallized:cryst_guard_facade",
+        "event:evt_guard_facade",
+    ], facade_ids
+
+    # (c) explicit budget priority, not the silent default.
+    assert _budget_keep_priority("Recall Facade (unified)") == 58
+    assert _budget_keep_priority("Recall Facade (unified)") != 50
 
 
 def test_new_records_carry_the_attribution_era_marker(tmp_path):

--- a/tests/plugins/memory/test_memory_os_clearance_cycle.py
+++ b/tests/plugins/memory/test_memory_os_clearance_cycle.py
@@ -982,3 +982,136 @@ def test_dead_judge_returning_empty_for_every_pair_fails_closed(tmp_path: Path) 
         )
     assert verdict == "clear"
     assert unknown_reason == ""
+
+
+def test_unbalanced_brace_in_claim_value_is_parsed_via_extract_json_object(
+    tmp_path: Path,
+) -> None:
+    """Defect 1 counterfactual (clearance_cycle).
+
+    The old hand-rolled brace-depth counter treated every "{" character as
+    a structural token, including one that appears inside a JSON string
+    value. When a claim's "object" field itself contained an unescaped
+    "{", the counter's depth never returned to 0, `end` stayed -1, and the
+    pair was skipped with no signal -- even though the reply was otherwise
+    perfectly valid JSON. _extract_json_object instead takes the outermost
+    find("{")..rfind("}") span and does not share that failure mode.
+
+    Counterfactual: without the fix, the reply below (prefixed with prose
+    so the first json.loads() attempt fails, forcing the extraction path)
+    is dropped -> pairs_evaluated stays 0 -> verdict "unknown" /
+    "judge_unavailable" (the same fail-closed guard as the dead-judge test
+    above). With the fix, the reply parses and the two differing objects
+    are a real contradiction -> verdict "conflict".
+    """
+    from unittest.mock import patch
+
+    from plugins.memory.memory_os.clearance_cycle import _judge_against_permanents
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+    store.initialize()
+
+    perm_records_list = [
+        {"id": "perm_brace", "body": "The config sets a clean value.",
+         "frontmatter": {"id": "perm_brace", "provisional": False}},
+    ]
+    mock_pairs = [{"permanent": perm_records_list[0], "similarity": 0.9}]
+
+    malformed_reply = (
+        "Here is the result: "
+        '{"claim_a": {"subject": "config", "predicate": "sets", '
+        '"object": "path with { unmatched brace", "confidence": 0.9}, '
+        '"claim_b": {"subject": "config", "predicate": "sets", '
+        '"object": "a different value", "confidence": 0.9}}'
+    )
+
+    with patch(
+        "plugins.memory.memory_os.clearance_cycle._pair_with_permanents",
+        return_value=mock_pairs,
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value=malformed_reply,
+    ), patch(
+        "plugins.memory.memory_os.clearance_cycle._check_llm_available",
+        return_value=True,
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ):
+        verdict, conflict_refs, _entities, _mode, unknown_reason = (
+            _judge_against_permanents(
+                store, "cand_brace", "The config sets a different value.", {},
+                perm_records_list, max_pairs=5,
+            )
+        )
+
+    assert verdict == "conflict", (
+        f"unbalanced-brace claim value must still be parsed and judged, "
+        f"got verdict={verdict!r} unknown_reason={unknown_reason!r}"
+    )
+    assert conflict_refs == ["perm_brace"]
+
+
+def test_non_dict_json_reply_does_not_crash_and_is_not_counted_as_evaluated(
+    tmp_path: Path,
+) -> None:
+    """Follow-up 1 counterfactual (clearance_cycle).
+
+    A first-attempt json.loads() success does not guarantee a dict result:
+    a bare JSON array/string/number is valid JSON. Before this fix, the
+    very next line (parsed.get("claim_a")) had no dict guard, so a
+    non-dict reply raised AttributeError uncaught inside this function's
+    pair loop -- the same defect class fixed elsewhere in this batch in
+    llm_edge_proposer._call_llm (its `if not isinstance(parsed, dict)`
+    guard, added there for exactly this reply shape, is the reference for
+    this fix).
+
+    Counterfactual: without the fix, _judge_against_permanents raises
+    AttributeError. With the fix, the pair is skipped without incrementing
+    pairs_evaluated -- and, being the only pair, the existing fail-closed
+    guard at the bottom of the function (already covered by the dead-judge
+    test above) returns "unknown"/"judge_unavailable".
+    """
+    from unittest.mock import patch
+
+    from plugins.memory.memory_os.clearance_cycle import _judge_against_permanents
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="test"))
+    store.initialize()
+
+    perm_records_list = [
+        {"id": "perm_nondict", "body": "The sky is blue.",
+         "frontmatter": {"id": "perm_nondict", "provisional": False}},
+    ]
+    mock_pairs = [{"permanent": perm_records_list[0], "similarity": 0.9}]
+
+    with patch(
+        "plugins.memory.memory_os.clearance_cycle._pair_with_permanents",
+        return_value=mock_pairs,
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value="[1, 2, 3]",
+    ), patch(
+        "plugins.memory.memory_os.clearance_cycle._check_llm_available",
+        return_value=True,
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ):
+        verdict, conflict_refs, _entities, _mode, unknown_reason = (
+            _judge_against_permanents(
+                store, "cand_nondict", "The sky is green.", {},
+                perm_records_list, max_pairs=5,
+            )
+        )
+
+    assert verdict == "unknown", (
+        f"a non-dict-but-valid-JSON reply must not crash and must fail "
+        f"closed, got verdict={verdict!r}"
+    )
+    assert unknown_reason == "judge_unavailable"
+    assert conflict_refs == []

--- a/tests/plugins/memory/test_memory_os_cognitive_loop.py
+++ b/tests/plugins/memory/test_memory_os_cognitive_loop.py
@@ -1079,3 +1079,66 @@ def test_llm_edge_proposer_wrapper_propagates_outcome_and_call_counters(tmp_path
     assert summary["llm_call_ok_count"] == 0
     assert summary["llm_call_failure_count"] == 1
     assert summary["llm_call_failure_reasons"] == {"empty_llm_response": 1}
+
+
+def test_llm_edge_proposer_degraded_status_maps_to_warning_at_step_level(tmp_path, monkeypatch):
+    """Counterfactual for the "degraded" step-status blind spot: the
+    producer above correctly returns status="degraded" when every LLM call
+    fails, but _step_status's vocabulary was closed over {ok, warning,
+    error, deferred, skipped, skipped_dependency_failed, blocked} and the
+    degraded summary carries neither an "output"=="[SILENT]" nor a
+    truthy "reason" key -- so the fall-through branch classified the
+    step (and therefore the cycle) as "ok" on the exact all-calls-failed
+    run this fix exists to expose.
+
+    Drives the REAL _run_step path (not the inner dict) so the assertion
+    is on the same step-level classification that feeds _cycle_status and
+    the persisted report.
+    """
+    from plugins.memory.memory_os.index import MemoryOSIndex
+    from plugins.memory.memory_os import llm_edge_proposer
+
+    store = _init_store(tmp_path)
+    index = MemoryOSIndex(store.roots)
+
+    for rec_id, created_at in (
+        ("cry_llm_c", "2026-06-01T10:00:00Z"),
+        ("cry_llm_d", "2026-06-01T11:00:00Z"),
+    ):
+        store.append_crystallized_record(
+            "test_llm_edge_proposer_step_status.md",
+            {
+                "schema_version": "memory-os.crystallized.v0",
+                "id": rec_id,
+                "kind": "test",
+                "created_at": created_at,
+                "approved_by": "owner",
+                "approved_at": created_at,
+                "approval_purpose": "test",
+                "approval_note": "test seed",
+                "source_event_ids": [],
+                "tags": [],
+                "sensitivity": "private",
+                "hindsight_indexed": False,
+                "bridge_state": "active",
+            },
+            "test crystallized record body",
+        )
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(
+        llm_edge_proposer, "_resolve_hermes_default_runtime",
+        lambda config: {"ok": True, "model": "test-model", "runtime": {"api_mode": "chat_completions"}},
+    )
+    # Every LLM reply is empty -> every _call_llm outcome is
+    # "empty_llm_response" -> the run is degraded, not "no relationships".
+    monkeypatch.setattr(llm_edge_proposer, "_call_hermes_runtime_model", lambda prompt, config: "")
+
+    runner = CognitiveLoopRunner(store)
+    step = runner._run_step("llm_edge_proposer", runner._llm_edge_proposer, {})
+
+    # The inner passthrough dict keeps the raw producer status untouched...
+    assert step["result"]["status"] == "degraded"
+    # ...but the step-level classification that _cycle_status/the report
+    # consume must not lie "ok" through an all-calls-failed run.
+    assert step["status"] == "warning"

--- a/tests/plugins/memory/test_memory_os_cognitive_loop.py
+++ b/tests/plugins/memory/test_memory_os_cognitive_loop.py
@@ -939,3 +939,143 @@ def test_edge_weight_feedback_wrapper_passes_through_r4_counters(tmp_path, monke
     assert summary["forget_eligible_backlog"] == 7
     assert summary["reinforced_count"] == 1
     assert summary["outcome"] == "reinforced"
+
+
+def test_edge_weight_feedback_wrapper_passes_through_cursor_alignment_fields(tmp_path, monkeypatch):
+    """Counterfactual: the outcome branch gives reinforced/forgotten/
+    saturated precedence over "cursor_misaligned", so a ledger-cursor
+    desync (future graph_layer_shadow.jsonl compaction — metadata_retention
+    is dry-run only today, no executor yet) goes dark in `outcome` exactly
+    when the run was ALSO busy reinforcing/forgetting that same cycle —
+    the case an operator most needs to see. tracked_edge_count and the five
+    cursor_* diagnostic fields must survive the wrapper's whitelist
+    independently of outcome."""
+    store = _init_store(tmp_path)
+    runner = CognitiveLoopRunner(store)
+
+    import plugins.memory.memory_os.edge_weight_feedback as ewf
+
+    def _fake_run(index_path, *, index=None, audit_path=None, now=None):
+        return {
+            "status": "ok",
+            # outcome == "reinforced" (forgetting/reinforcement took
+            # precedence) even though this run's cursor WAS misaligned.
+            "outcome": "reinforced",
+            "new_hit_record_count": 0,
+            "reinforced_count": 0,
+            "already_saturated_count": 0,
+            "skipped_not_injected_count": 0,
+            "forgotten_count": 3,
+            "invalidated_never_hit_count": 1,
+            "forget_eligible_backlog": 0,
+            "unresolved_hit_count": 0,
+            "failed_count": 0,
+            "tracked_edge_count": 12,
+            "cursor_misaligned": True,
+            "cursor_misalignment_reason": "ledger_shorter_than_cursor",
+            "cursor_previous_line_count": 500,
+            "cursor_realigned_line_count": 480,
+            "cursor_skipped_row_count": 20,
+            "duration_ms": 1,
+        }
+
+    monkeypatch.setattr(ewf, "run_edge_weight_feedback", _fake_run)
+    summary = runner._edge_weight_feedback({})
+    assert summary["outcome"] == "reinforced", (
+        "sanity: outcome alone must NOT be the only signal for this scenario"
+    )
+    assert summary["tracked_edge_count"] == 12
+    assert summary["cursor_misaligned"] is True
+    assert summary["cursor_misalignment_reason"] == "ledger_shorter_than_cursor"
+    assert summary["cursor_previous_line_count"] == 500
+    assert summary["cursor_realigned_line_count"] == 480
+    assert summary["cursor_skipped_row_count"] == 20
+
+
+def test_edge_provenance_wrapper_passes_through_write_failed_count(tmp_path, monkeypatch):
+    """Counterfactual: write_failed_count is the counter that distinguishes
+    "nothing to write" from "tried and failed" (Completion Is Not Output).
+    The monitor's _edge_fields already whitelists it; before this fix the
+    cognitive_loop wrapper never picked it off run_edge_provenance's
+    summary, so it reached no reader."""
+    store = _init_store(tmp_path)
+    runner = CognitiveLoopRunner(store)
+
+    import plugins.memory.memory_os.edge_provenance as ep
+
+    def _fake_run(index_path, *, index=None, audit_path=None):
+        return {
+            "status": "ok",
+            "outcome": "produced",
+            "record_count": 5,
+            "scanned_ref_count": 8,
+            "proposed_count": 2,
+            "dedup_skipped": 1,
+            "write_failed_count": 3,
+            "duration_ms": 1,
+        }
+
+    monkeypatch.setattr(ep, "run_edge_provenance", _fake_run)
+    summary = runner._edge_provenance({})
+    assert summary["write_failed_count"] == 3
+
+
+def test_llm_edge_proposer_wrapper_propagates_outcome_and_call_counters(tmp_path, monkeypatch):
+    """D2b counterfactual: before this fix, the step wrapper's whitelist
+    picked neither ``outcome`` nor any ``llm_call_*`` key off
+    run_llm_proposer's summary, so a run where every LLM call failed was
+    byte-identical in the cognitive-loop report to one that legitimately
+    found no relationships (both showed pair_count>0, proposed_count=0).
+
+    Drives the REAL producer (run_llm_proposer via the real _llm_edge_proposer
+    wrapper) through a monkeypatched model seam (_call_hermes_runtime_model
+    returning "") — not a hand-built summary dict — per the project's rule
+    that hand fixtures let counterfactuals pass vacuously."""
+    from plugins.memory.memory_os.index import MemoryOSIndex
+    from plugins.memory.memory_os import llm_edge_proposer
+
+    store = _init_store(tmp_path)
+    index = MemoryOSIndex(store.roots)
+
+    for rec_id, created_at in (
+        ("cry_llm_a", "2026-06-01T10:00:00Z"),
+        ("cry_llm_b", "2026-06-01T11:00:00Z"),
+    ):
+        store.append_crystallized_record(
+            "test_llm_edge_proposer_wrapper.md",
+            {
+                "schema_version": "memory-os.crystallized.v0",
+                "id": rec_id,
+                "kind": "test",
+                "created_at": created_at,
+                "approved_by": "owner",
+                "approved_at": created_at,
+                "approval_purpose": "test",
+                "approval_note": "test seed",
+                "source_event_ids": [],
+                "tags": [],
+                "sensitivity": "private",
+                "hindsight_indexed": False,
+                "bridge_state": "active",
+            },
+            "test crystallized record body",
+        )
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(
+        llm_edge_proposer, "_resolve_hermes_default_runtime",
+        lambda config: {"ok": True, "model": "test-model", "runtime": {"api_mode": "chat_completions"}},
+    )
+    # Every LLM reply is empty -> every _call_llm outcome is
+    # "empty_llm_response" -> the run is degraded, not "no relationships".
+    monkeypatch.setattr(llm_edge_proposer, "_call_hermes_runtime_model", lambda prompt, config: "")
+
+    runner = CognitiveLoopRunner(store)
+    summary = runner._llm_edge_proposer({})
+
+    assert summary["status"] == "degraded"
+    assert summary["outcome"] == "llm_degraded"
+    assert summary["llm_call_count"] == 1
+    assert summary["llm_call_ok_count"] == 0
+    assert summary["llm_call_failure_count"] == 1
+    assert summary["llm_call_failure_reasons"] == {"empty_llm_response": 1}

--- a/tests/plugins/memory/test_memory_os_contradiction_lane.py
+++ b/tests/plugins/memory/test_memory_os_contradiction_lane.py
@@ -329,35 +329,71 @@ class TestCounterfactuals:
         assert _claims_contradict(a, c) is False
 
 
-def test_nested_json_extraction_from_llm_output() -> None:
-    """Regex fallback handles nested claim objects in markdown-wrapped LLM output."""
-    from plugins.memory.memory_os.llm_contradiction_lane import CLAIM_EXTRACTION_PROMPT
-    # Simulate LLM returning JSON wrapped in markdown
-    response = '''```json
-{
-  "claim_a": {"subject": "auth", "predicate": "uses", "object": "JWT", "confidence": 0.9},
-  "claim_b": {"subject": "auth", "predicate": "uses", "object": "OAuth", "confidence": 0.85}
-}
-```'''
-    import json as _json
-    try:
-        _json.loads(response.strip())
-    except _json.JSONDecodeError:
-        # This is the path under test — should extract the nested JSON
-        start = response.find("{")
-        assert start != -1
-        depth = 0
-        end = -1
-        for i in range(start, len(response)):
-            if response[i] == "{": depth += 1
-            elif response[i] == "}":
-                depth -= 1
-                if depth == 0: end = i; break
-        assert end != -1, "balanced-brace parser should find matching close brace"
-        extracted = response[start:end + 1]
-        parsed = _json.loads(extracted)
-        assert parsed["claim_a"]["subject"] == "auth"
-        assert parsed["claim_b"]["object"] == "OAuth"
+def test_nested_json_extraction_from_markdown_fenced_llm_output(tmp_path: Path) -> None:
+    """Markdown-fenced JSON (```json ... ```) is the most common real LLM
+    reply shape and is exactly what triggers the extraction fallback: the
+    fence makes the first json.loads(response.strip()) fail, so the
+    fallback must recover the object.
+
+    This used to be a self-contained unit test that hand-duplicated the
+    old brace-depth-counter algorithm inline and asserted against that
+    local copy -- it never called into production code, so it kept
+    "passing" even after the depth counter was deleted from
+    llm_contradiction_lane.py in favor of _extract_json_object (Defect 1).
+    Rewritten to drive the real production entry point
+    (run_contradiction_lane, via a mocked _call_hermes_runtime_model) so a
+    regression in the actual parser would be caught here.
+
+    _extract_json_object's outermost find("{")..rfind("}") span handles
+    this case cleanly: the closing ``` fence contains no "}", so rfind
+    lands on the JSON object's own closing brace.
+    """
+    roots = FakeRoots(tmp_path)
+    store = FakeStore(roots)
+    _enable_lane_knob(roots)
+
+    conn = sqlite3.connect(str(roots.index_path))
+    _create_tables(conn)
+    v1 = np.array([1.0, 0.1], dtype=np.float32).tobytes()
+    v2 = np.array([0.98, 0.05], dtype=np.float32).tobytes()
+    _insert_record(conn, {"id": "cr_fenced_001", "body": "record A body", "kind": "note"}, v1)
+    _insert_record(conn, {"id": "cr_fenced_002", "body": "record B body", "kind": "note"}, v2)
+    conn.commit()
+    conn.close()
+
+    fenced_reply = (
+        '```json\n'
+        '{\n'
+        '  "claim_a": {"subject": "auth", "predicate": "uses", "object": "JWT", "confidence": 0.9},\n'
+        '  "claim_b": {"subject": "auth", "predicate": "uses", "object": "OAuth", "confidence": 0.85}\n'
+        '}\n'
+        '```'
+    )
+
+    with patch(
+        "plugins.memory.memory_os.low_clue_recall.low_clue_judge_availability"
+    ) as mock_judge, patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value=fenced_reply,
+    ):
+        mock_judge.return_value = {"available": True}
+        result = run_contradiction_lane(
+            store, embedder=_mock_embedder(), roots=roots, dry_run=True,
+        )
+
+    assert result["contradictions_found"] == 1, (
+        f"markdown-fenced JSON reply must still be parsed and judged, got {result}"
+    )
+    parse_failures = [
+        record for record in result["error_records"]
+        if record.get("error_code") == "llm_parse_failed"
+    ]
+    assert not parse_failures, (
+        f"a valid fenced reply must not be recorded as a parse failure: {parse_failures}"
+    )
 
 
 def test_error_record_on_judge_check_failure(monkeypatch, tmp_path: Path) -> None:
@@ -1002,3 +1038,175 @@ def test_empty_llm_reply_is_recorded_not_silently_skipped(tmp_path: Path) -> Non
         "quiet one via error_records"
     )
     assert empty_records[0]["component"] == "llm_contradiction_lane"
+
+
+def test_unbalanced_brace_in_claim_value_is_parsed_via_extract_json_object(
+    tmp_path: Path,
+) -> None:
+    """Defect 1 counterfactual (contradiction lane).
+
+    The old hand-rolled brace-depth counter treated every "{" character as
+    a structural token, including one that appears inside a JSON string
+    value. When a claim's "object" field itself contained an unescaped
+    "{", the counter's depth never returned to 0, `end` stayed -1, and the
+    pair was dropped with no signal -- even though the reply was otherwise
+    perfectly valid JSON. _extract_json_object instead takes the outermost
+    find("{")..rfind("}") span and does not share that failure mode.
+
+    Counterfactual: without the fix, the reply below (prefixed with prose
+    so the first json.loads() attempt fails, forcing the extraction path)
+    is dropped -> contradictions_found stays 0. With the fix, the reply
+    parses and the two differing objects are a real contradiction ->
+    contradictions_found == 1 (dry_run=True records the finding without
+    needing an edge writer).
+    """
+    roots = FakeRoots(tmp_path)
+    store = FakeStore(roots)
+    _enable_lane_knob(roots)
+
+    conn = sqlite3.connect(str(roots.index_path))
+    _create_tables(conn)
+    v1 = np.array([1.0, 0.1], dtype=np.float32).tobytes()
+    v2 = np.array([0.98, 0.05], dtype=np.float32).tobytes()
+    _insert_record(conn, {"id": "cr_brace_001", "body": "record A body", "kind": "note"}, v1)
+    _insert_record(conn, {"id": "cr_brace_002", "body": "record B body", "kind": "note"}, v2)
+    conn.commit()
+    conn.close()
+
+    malformed_reply = (
+        "Here is the result: "
+        '{"claim_a": {"subject": "config", "predicate": "sets", '
+        '"object": "path with { unmatched brace", "confidence": 0.9}, '
+        '"claim_b": {"subject": "config", "predicate": "sets", '
+        '"object": "a different value", "confidence": 0.9}}'
+    )
+
+    with patch(
+        "plugins.memory.memory_os.low_clue_recall.low_clue_judge_availability"
+    ) as mock_judge, patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value=malformed_reply,
+    ):
+        mock_judge.return_value = {"available": True}
+        result = run_contradiction_lane(
+            store, embedder=_mock_embedder(), roots=roots, dry_run=True,
+        )
+
+    assert result["contradictions_found"] == 1, (
+        f"unbalanced-brace claim value must still be parsed and judged, got {result}"
+    )
+    parse_failures = [
+        record for record in result["error_records"]
+        if record.get("error_code") == "llm_parse_failed"
+    ]
+    assert not parse_failures, (
+        f"a valid (if brace-tricky) reply must not be recorded as a parse failure: {parse_failures}"
+    )
+
+
+def test_garbage_llm_reply_is_recorded_not_silently_skipped(tmp_path: Path) -> None:
+    """Defect 2 counterfactual (contradiction lane).
+
+    The empty-reply path (see test above) already records a typed
+    llm_empty_content error record, but the parse-failure paths right
+    below it (a reply that came back non-empty but is not extractable as a
+    JSON object) just `continue`d silently. A run where every reply was
+    unparseable garbage was therefore indistinguishable from "genuinely no
+    contradictions" using the run's artifacts alone.
+
+    Counterfactual: without the fix, error_records contains no
+    llm_parse_failed entry and the report reads as a clean quiet run.
+    """
+    roots = FakeRoots(tmp_path)
+    store = FakeStore(roots)
+    _enable_lane_knob(roots)
+
+    conn = sqlite3.connect(str(roots.index_path))
+    _create_tables(conn)
+    v1 = np.array([1.0, 0.1], dtype=np.float32).tobytes()
+    v2 = np.array([0.98, 0.05], dtype=np.float32).tobytes()
+    _insert_record(conn, {"id": "cr_garbage_001", "body": "record A body", "kind": "note"}, v1)
+    _insert_record(conn, {"id": "cr_garbage_002", "body": "record B body", "kind": "note"}, v2)
+    conn.commit()
+    conn.close()
+
+    with patch(
+        "plugins.memory.memory_os.low_clue_recall.low_clue_judge_availability"
+    ) as mock_judge, patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value="Sorry, I cannot help with that request.",
+    ):
+        mock_judge.return_value = {"available": True}
+        result = run_contradiction_lane(store, embedder=_mock_embedder(), roots=roots)
+
+    assert result["contradictions_found"] == 0
+    parse_failures = [
+        record for record in result["error_records"]
+        if record.get("error_code") == "llm_parse_failed"
+    ]
+    assert parse_failures, (
+        "an all-unparseable-reply run must be distinguishable from a "
+        "genuinely quiet one via error_records"
+    )
+    assert parse_failures[0]["component"] == "llm_contradiction_lane"
+
+
+def test_non_dict_json_reply_is_recorded_not_a_crash(tmp_path: Path) -> None:
+    """Follow-up 1 counterfactual (contradiction lane).
+
+    A first-attempt json.loads() success does not guarantee a dict result:
+    a bare JSON array/string/number is valid JSON. Before this fix, the
+    very next line (parsed.get("claim_a")) had no dict guard, so a
+    non-dict reply raised AttributeError uncaught -- killing
+    run_contradiction_lane mid-loop (after any earlier pairs in the batch
+    had already been processed) instead of being recorded and skipped.
+    Same defect class fixed elsewhere in this batch in
+    llm_edge_proposer._call_llm (its `if not isinstance(parsed, dict)`
+    guard, added there for exactly this reply shape, is the reference for
+    this fix).
+
+    Counterfactual: without the fix, run_contradiction_lane raises
+    AttributeError. With the fix, it returns normally with an
+    llm_parse_failed error record and no contradictions found.
+    """
+    roots = FakeRoots(tmp_path)
+    store = FakeStore(roots)
+    _enable_lane_knob(roots)
+
+    conn = sqlite3.connect(str(roots.index_path))
+    _create_tables(conn)
+    v1 = np.array([1.0, 0.1], dtype=np.float32).tobytes()
+    v2 = np.array([0.98, 0.05], dtype=np.float32).tobytes()
+    _insert_record(conn, {"id": "cr_nondict_001", "body": "record A body", "kind": "note"}, v1)
+    _insert_record(conn, {"id": "cr_nondict_002", "body": "record B body", "kind": "note"}, v2)
+    conn.commit()
+    conn.close()
+
+    with patch(
+        "plugins.memory.memory_os.low_clue_recall.low_clue_judge_availability"
+    ) as mock_judge, patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value="[1, 2, 3]",
+    ):
+        mock_judge.return_value = {"available": True}
+        result = run_contradiction_lane(store, embedder=_mock_embedder(), roots=roots)
+
+    assert result["contradictions_found"] == 0
+    parse_failures = [
+        record for record in result["error_records"]
+        if record.get("error_code") == "llm_parse_failed"
+    ]
+    assert parse_failures, (
+        "a non-dict-but-valid-JSON reply must be recorded, not silently "
+        "dropped or allowed to crash the lane"
+    )
+    assert parse_failures[0]["component"] == "llm_contradiction_lane"

--- a/tests/plugins/memory/test_memory_os_contradiction_lane.py
+++ b/tests/plugins/memory/test_memory_os_contradiction_lane.py
@@ -1210,3 +1210,88 @@ def test_non_dict_json_reply_is_recorded_not_a_crash(tmp_path: Path) -> None:
         "dropped or allowed to crash the lane"
     )
     assert parse_failures[0]["component"] == "llm_contradiction_lane"
+
+
+def test_valid_json_with_trailing_prose_brace_is_dropped_not_parsed(tmp_path: Path) -> None:
+    """Characterization test -- pins a DELIBERATE, ACCEPTED limitation.
+
+    This branch converged the contradiction lane and llm_edge_proposer onto
+    the project's canonical parser, _extract_json_object (low_clue_recall.py:
+    outermost find("{")..rfind("}") span), replacing a hand-rolled brace-depth
+    counter. That convergence is strictly weaker for one reply shape: valid
+    JSON followed by trailing prose that itself contains a "}" character.
+    find("{")..rfind("}") anchors on the LAST "}" in the whole reply, so it
+    spans past the JSON object's real closing brace into the trailing prose,
+    producing a substring that is not valid JSON -- json.loads then raises,
+    and the pair is dropped with an llm_parse_failed error record instead of
+    being parsed.
+
+    This is NOT a bug to fix. It is the documented tradeoff of converging on
+    fact_judge.py's reference parser (see CLAUDE.md "LLM Integration - Reuse,
+    Never Rebuild" and the comment at the parse site in
+    llm_contradiction_lane.py): the prompt demands "Return ONLY a JSON
+    object", so a compliant reply never has trailing prose, and no
+    trailing-prose fallback is added because the reference implementation has
+    none either. A brace-depth counter would recover this specific shape, but
+    reintroducing one was rejected in this batch precisely because it has its
+    own, worse failure mode (an unbalanced "{" inside a claim's own string
+    value hangs depth at nonzero forever -- see
+    test_unbalanced_brace_in_claim_value_is_parsed_via_extract_json_object
+    directly above, which pins the case _extract_json_object exists to fix).
+
+    This test only PINS current, accepted behavior for the trailing-prose
+    shape. If it starts failing, someone changed parser semantics (e.g. added
+    a trailing-prose fallback or reintroduced brace-depth tracking) and must
+    re-decide the tradeoff explicitly -- not "fix" this test to match.
+    """
+    roots = FakeRoots(tmp_path)
+    store = FakeStore(roots)
+    _enable_lane_knob(roots)
+
+    conn = sqlite3.connect(str(roots.index_path))
+    _create_tables(conn)
+    v1 = np.array([1.0, 0.1], dtype=np.float32).tobytes()
+    v2 = np.array([0.98, 0.05], dtype=np.float32).tobytes()
+    _insert_record(conn, {"id": "cr_trailing_001", "body": "record A body", "kind": "note"}, v1)
+    _insert_record(conn, {"id": "cr_trailing_002", "body": "record B body", "kind": "note"}, v2)
+    conn.commit()
+    conn.close()
+
+    # A valid JSON object immediately followed by trailing prose that itself
+    # contains a "}" -- rfind("}") lands on the trailing prose's brace, not
+    # the JSON object's real closing brace, so the extracted span is not
+    # valid JSON.
+    reply_with_trailing_prose = (
+        '{"claim_a": {"subject": "delivery", "predicate": "scheduled_for", '
+        '"object": "monday", "confidence": 0.9}, '
+        '"claim_b": {"subject": "delivery", "predicate": "scheduled_for", '
+        '"object": "tuesday", "confidence": 0.9}} '
+        "Filed under ticket {42}"
+    )
+
+    with patch(
+        "plugins.memory.memory_os.low_clue_recall.low_clue_judge_availability"
+    ) as mock_judge, patch(
+        "plugins.memory.memory_os.low_clue_recall._resolve_hermes_default_runtime",
+        return_value={"ok": True},
+    ), patch(
+        "plugins.memory.memory_os.low_clue_recall._call_hermes_runtime_model",
+        return_value=reply_with_trailing_prose,
+    ):
+        mock_judge.return_value = {"available": True}
+        result = run_contradiction_lane(store, embedder=_mock_embedder(), roots=roots)
+
+    assert result["contradictions_found"] == 0, (
+        "current (accepted) behavior: trailing prose after the JSON object "
+        "defeats find('{')..rfind('}') extraction, so the otherwise-valid "
+        "pair is dropped rather than parsed"
+    )
+    parse_failures = [
+        record for record in result["error_records"]
+        if record.get("error_code") == "llm_parse_failed"
+    ]
+    assert parse_failures, (
+        "the dropped pair must still be recorded via the typed "
+        "llm_parse_failed error record, not silently skipped"
+    )
+    assert parse_failures[0]["component"] == "llm_contradiction_lane"

--- a/tests/plugins/memory/test_memory_os_crystallized.py
+++ b/tests/plugins/memory/test_memory_os_crystallized.py
@@ -689,6 +689,150 @@ def test_invalidate_provisional_record_fails_for_nonexistent_record(tmp_path):
         )
 
 
+# ── Defect B: EffectiveCandidate.provisional_backed ─────────────────────
+#
+# read_effective_candidates() marks a candidate terminal as soon as ANY
+# active crystallized record carries its candidate_id -- provisional
+# included. provisional_backed distinguishes "terminal only because of an
+# active provisional anchor" (reversible; candidate_aggregation must NOT
+# archive the queue row) from "an active permanent record backs it too"
+# (archival is correct, unchanged from the 2026-08-14 fix's five
+# production rows). See candidate_aggregation.run_candidate_aggregation_lane
+# for the consumer.
+
+
+def test_read_effective_candidates_marks_provisional_only_record_as_provisional_backed(tmp_path):
+    """A candidate whose ONLY active crystallized record is provisional=True
+    must resolve terminal=True (content already crystallized -- correctly
+    excluded from recall) AND provisional_backed=True (the anchor is
+    reversible -- must not be archived out of the live queue)."""
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import read_effective_candidates
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    candidate = CrystallizedCandidate(
+        candidate_id="cand-eff-prov-only",
+        kind="fact",
+        body="Provisional-only anchor.",
+        source_event_ids=["evt-eff-1"],
+        sensitivity="private",
+        bridge_state="owner_eligible",
+        created_at="2026-07-01T00:00:00Z",
+    )
+    append_candidate_queue(store, candidate)
+
+    service = CrystallizedMemoryService(store)
+    decision = ApprovalDecision(
+        candidate_id=candidate.candidate_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="resolver",
+        reviewed_at="2026-07-01T00:05:00Z",
+        source_state="resolver_approved",
+        provisional=True,
+        expires_at="2026-07-08T00:00:00Z",
+    )
+    _write_approved_record(service, candidate, decision, file_name="owner_approved.md")
+
+    by_id = {item.candidate.candidate_id: item for item in read_effective_candidates(store)}
+    view = by_id["cand-eff-prov-only"]
+    assert view.effective_state == "crystallized"
+    assert view.terminal is True
+    assert view.provisional_backed is True
+
+
+def test_read_effective_candidates_permanent_record_is_not_provisional_backed(tmp_path):
+    """Regression pin: a candidate anchored by an active PERMANENT record
+    must still resolve provisional_backed=False, so candidate_aggregation
+    keeps archiving it exactly as the 2026-08-14 fix intended (five
+    production rows, crystallized long ago, stuck in the live queue) --
+    this field must never widen archival exemption to permanent records."""
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import read_effective_candidates
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    candidate = CrystallizedCandidate(
+        candidate_id="cand-eff-permanent",
+        kind="fact",
+        body="Permanent anchor.",
+        source_event_ids=["evt-eff-2"],
+        sensitivity="private",
+        bridge_state="owner_eligible",
+        created_at="2026-07-01T00:00:00Z",
+    )
+    append_candidate_queue(store, candidate)
+
+    service = CrystallizedMemoryService(store)
+    decision = ApprovalDecision(
+        candidate_id=candidate.candidate_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="owner",
+        reviewed_at="2026-07-01T00:05:00Z",
+    )
+    _write_approved_record(service, candidate, decision, file_name="owner_approved.md")
+
+    by_id = {item.candidate.candidate_id: item for item in read_effective_candidates(store)}
+    view = by_id["cand-eff-permanent"]
+    assert view.effective_state == "crystallized"
+    assert view.terminal is True
+    assert view.provisional_backed is False
+
+
+def test_read_effective_candidates_permanent_record_wins_when_both_are_active(tmp_path):
+    """Safety direction of the provisional_backed set logic: if a candidate
+    somehow has BOTH an active provisional record and an active permanent
+    record (same candidate_id, different files), the permanent one wins --
+    provisional_backed must be False, so the row stays archivable. The
+    content is already durably crystallized; there is no reversible-only
+    anchor to protect."""
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import read_effective_candidates
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+
+    candidate = CrystallizedCandidate(
+        candidate_id="cand-eff-mixed",
+        kind="fact",
+        body="Mixed anchors.",
+        source_event_ids=["evt-eff-3"],
+        sensitivity="private",
+        bridge_state="owner_eligible",
+        created_at="2026-07-01T00:00:00Z",
+    )
+    append_candidate_queue(store, candidate)
+
+    service = CrystallizedMemoryService(store)
+    provisional_decision = ApprovalDecision(
+        candidate_id=candidate.candidate_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="resolver",
+        reviewed_at="2026-07-01T00:05:00Z",
+        source_state="resolver_approved",
+        provisional=True,
+        expires_at="2026-07-08T00:00:00Z",
+    )
+    _write_approved_record(service, candidate, provisional_decision, file_name="provisional.md")
+    permanent_decision = ApprovalDecision(
+        candidate_id=candidate.candidate_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="owner",
+        reviewed_at="2026-07-01T00:10:00Z",
+    )
+    _write_approved_record(service, candidate, permanent_decision, file_name="permanent.md")
+
+    by_id = {item.candidate.candidate_id: item for item in read_effective_candidates(store)}
+    view = by_id["cand-eff-mixed"]
+    assert view.terminal is True
+    assert view.provisional_backed is False
+
+
 def test_confirm_provisional_record_removes_provisional_and_expires_at(tmp_path):
     """confirm_provisional_record must set provisional=False, clear expires_at,
     set confirmed_at/confirmed_by, restore canonical_state=active."""

--- a/tests/plugins/memory/test_memory_os_datetime_expiry_sweep.py
+++ b/tests/plugins/memory/test_memory_os_datetime_expiry_sweep.py
@@ -1,0 +1,1207 @@
+"""Counterfactual coverage for the Rule-5 datetime-expiry sweep (2026-08-15).
+
+Defect shape (first fixed in knob_overrides.py::_is_expired, the reference
+implementation): ``datetime.fromisoformat(naive_iso_string)`` parses without
+error and returns a timezone-*naive* datetime. Comparing/subtracting it
+against a timezone-*aware* ``now`` raises
+``TypeError: can't subtract offset-naive and offset-aware datetimes`` --
+which a bare ``except ValueError:`` (or no try/except at all) does not
+catch, so the naive-but-otherwise-valid record crashes the caller instead
+of being handled by whatever fail-open/fail-safe contract the site intended
+for genuinely unparseable input.
+
+This file covers the six sites fixed in this sweep:
+  - owner_actions.py::_provisional_knob_override_review_items
+  - override_sweep.py::OverrideSweepModule.run_once (TTL expiry)
+  - provisional_sweep.py::ProvisionalSweepModule.run_once (TTL expiry)
+  - provisional_sweep.py::find_expiring_provisional
+  - deep_reflection.py::_reject_reason
+  - event_stats.py::read_event_stats
+  - working.py::WorkingMemoryService.decay_items (no try/except at all --
+    different shape, see the dedicated section below)
+  - working.py::WorkingMemoryService.prune_expired_items (a *second*,
+    undocumented instance of the same shape found during this sweep: the
+    existing except only wrapped the parse, not the subtraction that
+    followed it)
+
+Each test proves two things: the fixed site does not raise on a
+naive-but-valid stored timestamp, AND it computes the correct answer
+(normalizing naive-as-UTC) rather than merely swallowing the crash into a
+different wrong answer.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+
+# ── shared fixtures ──────────────────────────────────────────────────────
+
+def _store(tmp_path: Path, profile: str = "test") -> MemoryOSStore:
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile=profile)
+    store = MemoryOSStore(roots)
+    store.initialize()
+    return store
+
+
+# ── 1. owner_actions.py::_provisional_knob_override_review_items ────────
+
+class TestOwnerActionsKnobOverrideDigest:
+    def test_naive_future_expires_at_yields_correct_days_left(self, tmp_path):
+        """A knob-override record with a naive (no-offset) future expires_at
+        must not crash the digest render, and days_left must reflect the
+        real remaining time (not just a swallowed-to-empty fallback).
+
+        Fixture: register_override validates only that expires_at PARSES
+        (knob_overrides.py line ~679: "Naive (no-offset) timestamps DO
+        parse here and are accepted"), not that it is aware -- so this is
+        a legitimate value a real caller can persist through the real
+        producer, not a hand-edited corruption.
+        """
+        from plugins.memory.memory_os.knob_overrides import register_override
+        from plugins.memory.memory_os.owner_actions import _provisional_knob_override_review_items
+
+        store = _store(tmp_path)
+        now = datetime.now(timezone.utc)
+        naive_future_expiry = (now + timedelta(days=3)).replace(tzinfo=None).isoformat()
+        # Must register through roots=store.roots (not _store_root) --
+        # _provisional_knob_override_review_items reads via
+        # list_active_overrides(roots=store.roots) with no _now override
+        # (real wall-clock), so the fixture has to resolve to the same
+        # store path the digest function will read from.
+        register_override(
+            "min_cluster_size", 3, prior=2, proposed_by="test",
+            approved_via="resolver", expires_at=naive_future_expiry,
+            _now=now, roots=store.roots,
+        )
+
+        items = _provisional_knob_override_review_items(store, closed=set())
+
+        assert len(items) == 1
+        # ~3 days remain; must not have fallen back to the "?" no-parse marker.
+        assert items[0]["summary"].count("?") == 0
+        assert "3d" in items[0]["summary"] or "2d" in items[0]["summary"]
+
+
+# ── 2. override_sweep.py::OverrideSweepModule.run_once (TTL expiry) ─────
+
+class TestOverrideSweepNaiveExpiry:
+    def test_naive_future_expiry_does_not_crash_the_ttl_loop(self, tmp_path):
+        """A naive-but-not-yet-expired override must survive run_once without
+        raising, and must NOT be reverted early (it genuinely hasn't expired).
+
+        Note: an override that is *already* expired at registration time
+        never reaches override_sweep's own TTL loop at all --
+        list_active_overrides() (knob_overrides.py, already fixed) filters
+        expired provisional records out of `active` before override_sweep
+        ever sees them, using the identical `now`. So the only way to
+        exercise override_sweep.py's own parse+compare at lines 113-118 is
+        with an override that is still active as of `now`: any
+        naive-but-valid expires_at reaching that comparison -- regardless
+        of whether it is chronologically past or future -- raises
+        TypeError pre-fix, because comparing naive to aware always raises
+        (the comparison operator does not evaluate order before raising).
+        """
+        from plugins.memory.memory_os.knob_overrides import register_override, resolve_knob
+        from plugins.modules.governance.override_sweep import OverrideSweepModule
+
+        now = datetime.now(timezone.utc)
+        naive_future_expiry = (now + timedelta(days=3)).replace(tzinfo=None).isoformat()
+        register_override(
+            "min_cluster_size", 3, prior=2, proposed_by="test",
+            approved_via="resolver", expires_at=naive_future_expiry,
+            _now=now, _store_root=tmp_path,
+        )
+
+        module = OverrideSweepModule(str(tmp_path), profile="test")
+        result = module.run_once(_store_root=tmp_path, _now=now)
+
+        assert result["active_total"] == 1
+        assert result["expired_count"] == 0  # not actually expired yet
+        assert result["revert_fail_count"] == 0
+        val = resolve_knob("min_cluster_size", default=2, _now=now, _store_root=tmp_path)
+        assert val == 3  # still the override -- not prematurely reverted
+
+
+# ── 3a. provisional_sweep.py::ProvisionalSweepModule.run_once (TTL) ─────
+
+def _write_provisional_record(store: MemoryOSStore, *, record_id: str, expires_at: str, now: datetime):
+    from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+    from plugins.memory.memory_os.crystallized import CrystallizedCandidate, CrystallizedMemoryService
+
+    service = CrystallizedMemoryService(store)
+    candidate = CrystallizedCandidate(
+        candidate_id=record_id,
+        kind="moment",
+        body=f"Sweep test memory {record_id}.",
+        source_event_ids=[f"evt_{record_id}"],
+        sensitivity="private",
+        bridge_state="inner_drive_candidate",
+    )
+    decision = ApprovalDecision(
+        candidate_id=record_id,
+        purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+        reviewer="resolver",
+        reviewed_at=now.isoformat(),
+        source_state="resolver_approved",
+        provisional=True,
+        expires_at=expires_at,
+    )
+    service.write_approved_record(candidate, decision, file_name="owner_approved.md")
+    return service
+
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+class TestProvisionalSweepNaiveExpiry:
+    def test_naive_past_expiry_ttl_sweep_invalidates_not_crashes(self, tmp_path):
+        from plugins.modules.governance.provisional_sweep import ProvisionalSweepModule
+
+        store = _store(tmp_path)
+        now = datetime.now(timezone.utc)
+        naive_past = (now - timedelta(hours=1)).replace(tzinfo=None).isoformat()
+        service = _write_provisional_record(store, record_id="cand_naive_past", expires_at=naive_past, now=now)
+
+        module = ProvisionalSweepModule(tmp_path, profile="test")
+        result = module.run_once(store=store)
+
+        assert result["provisional_total"] == 1
+        assert result["expired_count"] == 1
+        assert len(service.list_provisional_records()) == 0
+
+    # ── 3b. provisional_sweep.py::find_expiring_provisional ─────────────
+
+    def test_naive_near_expiry_is_found_with_correct_remaining_time(self, tmp_path):
+        from plugins.modules.governance.provisional_sweep import find_expiring_provisional
+
+        store = _store(tmp_path)
+        now = datetime.now(timezone.utc)
+        # 10 hours out, naive -- within the default 48h window.
+        naive_near = (now + timedelta(hours=10)).replace(tzinfo=None).isoformat()
+        _write_provisional_record(store, record_id="cand_naive_near", expires_at=naive_near, now=now)
+
+        expiring = find_expiring_provisional(store, within_hours=48)
+
+        assert len(expiring) == 1
+        # Correct normalization means ~10h/~0d remaining, not a crash and
+        # not a wildly-wrong value from mis-handling the naive value.
+        assert 0 <= expiring[0]["hours_remaining"] <= 10
+        assert expiring[0]["days_remaining"] == 0
+
+
+# ── 4. deep_reflection.py::_reject_reason ────────────────────────────────
+
+class TestDeepReflectionRejectReasonNaiveExpiry:
+    def test_naive_future_expiry_is_not_rejected_as_invalid(self):
+        from plugins.modules.cognition.deep_reflection import _card, _reject_reason
+
+        now = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+        card = _card(
+            profile="main",
+            index=0,
+            text="A benign continuity note about yesterday's conversation.",
+            source_refs=["event:test"],
+            input_snapshot={},
+            now=now,
+            expires_at=(now + timedelta(hours=6)).isoformat(),
+            inject_weight=1.0,
+        )
+        # Simulate a legacy/hand-edited card whose expires_at lost its
+        # offset -- the real producer (_card, above) always stamps aware
+        # ISO strings, so this can only occur via non-standard input.
+        card["expires_at"] = (now + timedelta(hours=6)).replace(tzinfo=None).isoformat()
+
+        reason = _reject_reason(card, input_snapshot={}, now=now)
+
+        assert reason != "invalid_expiry"
+        assert reason != "expired"  # 6h in the future, must not read as expired
+
+    def test_naive_past_expiry_is_rejected_as_expired_not_crashed(self):
+        from plugins.modules.cognition.deep_reflection import _card, _reject_reason
+
+        now = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+        card = _card(
+            profile="main",
+            index=0,
+            text="A benign continuity note about yesterday's conversation.",
+            source_refs=["event:test"],
+            input_snapshot={},
+            now=now,
+            expires_at=(now - timedelta(hours=1)).isoformat(),
+            inject_weight=1.0,
+        )
+        card["expires_at"] = (now - timedelta(hours=1)).replace(tzinfo=None).isoformat()
+
+        reason = _reject_reason(card, input_snapshot={}, now=now)
+
+        assert reason == "expired"
+
+    def test_genuinely_malformed_expiry_still_falls_back_to_invalid(self):
+        """Fail-open contract for truly unparseable input must survive the fix."""
+        from plugins.modules.cognition.deep_reflection import _card, _reject_reason
+
+        now = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+        card = _card(
+            profile="main",
+            index=0,
+            text="A benign continuity note about yesterday's conversation.",
+            source_refs=["event:test"],
+            input_snapshot={},
+            now=now,
+            expires_at="not-a-timestamp",
+            inject_weight=1.0,
+        )
+
+        assert _reject_reason(card, input_snapshot={}, now=now) == "invalid_expiry"
+
+
+# ── 5. event_stats.py::read_event_stats ──────────────────────────────────
+
+class TestEventStatsNaiveUpdatedAt:
+    def test_naive_updated_at_computes_correct_freshness_not_missing(self, tmp_path):
+        from plugins.memory.memory_os.event_stats import (
+            build_event_stats, event_stats_path, read_event_stats, write_event_stats,
+        )
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="main")
+        roots.memory_os_root.mkdir(parents=True, exist_ok=True)
+        (roots.memory_os_root / "runtime").mkdir(parents=True, exist_ok=True)
+
+        stats = build_event_stats([])
+        stats.events_root = str(roots.events_root)
+        write_event_stats(roots, stats)  # writer always stamps an aware updated_at
+
+        # Hand-edit to a naive value: no writer in this codebase produces
+        # this, but a legacy/hand-repaired file could, and read_event_stats
+        # must survive it.
+        path = event_stats_path(roots)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        naive_recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).replace(tzinfo=None).isoformat()
+        data["updated_at"] = naive_recent
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+        read_back, freshness = read_event_stats(roots)
+
+        assert read_back is not None
+        # 5 minutes old must read as "fresh" (<15min), not "degraded" (the
+        # float("inf") fallback that a swallowed TypeError would produce).
+        assert freshness == "fresh"
+
+
+# ── 6a. working.py::WorkingMemoryService.decay_items (no try/except) ────
+
+def _working_service(tmp_path: Path):
+    from plugins.memory.memory_os.working import WorkingMemoryService
+
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    return WorkingMemoryService(store)
+
+
+class TestWorkingDecayNaiveOrMalformedBase:
+    def test_naive_last_decayed_at_decays_correctly_not_crashed(self, tmp_path):
+        """decay_items had NO try/except at all around this parse+subtract.
+        A naive-but-valid last_decayed_at must decay normally (elapsed
+        time computed correctly), not raise.
+        """
+        service = _working_service(tmp_path)
+        now = datetime(2026, 5, 20, 8, 0, tzinfo=timezone.utc)
+        service.add_item("lingering", "Fading thought.", weight=1.0, now=now)
+
+        # Hand-edit last_decayed_at to a naive value via the real store
+        # write path (no add_item/decay_items call ever produces a naive
+        # value itself -- this simulates a legacy/hand-repaired document).
+        document = service.read_document("lingering")
+        document["items"][0]["last_decayed_at"] = now.replace(tzinfo=None).isoformat()
+        service.store.write_working_document("lingering", document, audit=False)
+
+        updated = service.decay_items(
+            "lingering", now=now + timedelta(hours=3), half_life_hours=1.0, expire_below=0.2,
+        )
+
+        # 3 hours elapsed at half_life=1h -> weight = 1.0 * 0.5^3 = 0.125,
+        # proving the naive value was normalized and used for real decay
+        # math rather than falling back to "decayed just now" (weight 1.0).
+        assert updated[0].weight == pytest.approx(0.125)
+        assert updated[0].status == "expired"
+
+    def test_malformed_decay_base_self_heals_without_crashing(self, tmp_path):
+        """Genuinely unparseable last_decayed_at must not crash the
+        heartbeat decay path. Chosen fallback: treat as "decayed just now"
+        (weight unchanged this cycle) and re-stamp last_decayed_at with a
+        valid aware value so the record self-heals from the next cycle,
+        with a warning audit record for diagnosability.
+        """
+        service = _working_service(tmp_path)
+        now = datetime(2026, 5, 20, 8, 0, tzinfo=timezone.utc)
+        item = service.add_item("lingering", "Corrupted timestamp.", weight=1.0, now=now)
+
+        document = service.read_document("lingering")
+        document["items"][0]["last_decayed_at"] = "not-a-timestamp"
+        service.store.write_working_document("lingering", document, audit=False)
+
+        updated = service.decay_items(
+            "lingering", now=now + timedelta(hours=3), half_life_hours=1.0, expire_below=0.2,
+        )
+
+        assert updated[0].weight == pytest.approx(1.0)  # unchanged this cycle
+        assert updated[0].status == "active"
+        # last_decayed_at re-stamped with a valid, aware value (self-heal).
+        document_after = service.read_document("lingering")
+        healed = document_after["items"][0]["last_decayed_at"]
+        healed_dt = datetime.fromisoformat(healed)
+        assert healed_dt.tzinfo is not None
+
+        from plugins.memory.memory_os.audit import read_audit_entries
+        entries = read_audit_entries(service.store.roots.audit_path)
+        warnings = [e for e in entries if e.get("action") == "working_item_decay_base_invalid"]
+        assert len(warnings) == 1
+        assert warnings[0]["details"]["item_id"] == item.id
+
+
+# ── 6b. working.py::WorkingMemoryService.prune_expired_items ────────────
+#
+# Second, undocumented instance of the same defect shape found during this
+# sweep: the existing `except (ValueError, TypeError)` wrapped only the
+# `fromisoformat` call, not the `(current - expiry_dt)` subtraction that
+# followed it outside the try block -- so a naive-but-valid expired_at
+# still crashed prune, just one line lower than decay's bug.
+
+class TestWorkingPruneNaiveExpiredAt:
+    def test_naive_expired_at_prunes_correctly_not_crashed(self, tmp_path):
+        service = _working_service(tmp_path)
+        now = datetime(2026, 5, 20, 8, 0, tzinfo=timezone.utc)
+        service.add_item("attention", "Will be pruned.", weight=1.0, now=now)
+        service.decay_items(
+            "attention", now=now + timedelta(hours=4), half_life_hours=1.0, expire_below=0.2,
+        )
+        document = service.read_document("attention")
+        assert document["items"][0]["status"] == "expired"
+        naive_expired_at = document["items"][0]["expired_at"]
+        naive_expired_at = datetime.fromisoformat(naive_expired_at).replace(tzinfo=None).isoformat()
+        document["items"][0]["expired_at"] = naive_expired_at
+        service.store.write_working_document("attention", document, audit=False)
+
+        pruned = service.prune_expired_items("attention", now=now + timedelta(hours=100), min_age_hours=0)
+
+        assert pruned == 1
+        document_after = service.read_document("attention")
+        assert len(document_after["items"]) == 0
+
+    def test_malformed_expired_at_keeps_item_not_crashed(self, tmp_path):
+        """Genuinely unparseable expired_at: keep the item (no data loss) --
+        the pre-existing, unchanged fail-safe for this site.
+        """
+        service = _working_service(tmp_path)
+        now = datetime(2026, 5, 20, 8, 0, tzinfo=timezone.utc)
+        service.add_item("attention", "Corrupted expiry.", weight=1.0, now=now)
+        service.decay_items(
+            "attention", now=now + timedelta(hours=4), half_life_hours=1.0, expire_below=0.2,
+        )
+        document = service.read_document("attention")
+        document["items"][0]["expired_at"] = "not-a-timestamp"
+        document["items"][0]["updated_at"] = "not-a-timestamp"
+        service.store.write_working_document("attention", document, audit=False)
+
+        pruned = service.prune_expired_items("attention", now=now + timedelta(hours=100), min_age_hours=0)
+
+        assert pruned == 0
+        document_after = service.read_document("attention")
+        assert len(document_after["items"]) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Round 2 (2026-08-15): eight further sites of the same defect shape,
+# found by audit outside round 1's allowed files. Covers:
+#   7.  scripts/cleanup_expired_working.py::main (the production
+#       working_cleanup cron lane -- bypasses WorkingMemoryService, so
+#       round 1's working.py fix does not protect this path)
+#   8.  state_overlay.py::_read_open_threads_from_candidates
+#   9.  memory_sources.py::_records_since
+#   10. loop_health_view.py::_parse_recorded_at (+ build_loop_health_view)
+#   11. __init__.py::_read_latest_active_task_anchor
+#   12. speak_rate_limit.py::_parse_ts (+ under_speak_limit)
+#   13. cli.py::diff_report
+#   14. scripts/install_memory_os_plugin.py::_run_expired_working_migration
+# ═══════════════════════════════════════════════════════════════════════
+
+
+# ── 7. scripts/cleanup_expired_working.py::main ─────────────────────────
+#
+# The real working_cleanup cron lane: duplicates raw JSON manipulation
+# instead of calling WorkingMemoryService, so it has its own instance of
+# the "except wraps only the parse, not the subtraction" bug. This lane
+# DELETES expired items, so the malformed-input fallback keeps the item
+# (no data loss) -- matching working.py::prune_expired_items' direction
+# -- and now also records the bad-input count in the durable
+# lane_last_run counters rather than swallowing it silently.
+
+class TestCleanupExpiredWorkingNaiveOrMalformedTimestamp:
+    def test_naive_expired_timestamp_removed_not_crashed(self, tmp_path):
+        from scripts import cleanup_expired_working as working_cleanup
+        from plugins.memory.memory_os.lane_last_run import read_lane_last_run
+
+        working = tmp_path / "memory-os" / "working" / "lingering.json"
+        working.parent.mkdir(parents=True)
+        naive_old = (datetime.now(timezone.utc) - timedelta(days=10)).replace(tzinfo=None).isoformat()
+        working.write_text(
+            json.dumps({"items": [{"status": "expired", "updated_at": naive_old, "text": "old"}]}),
+            encoding="utf-8",
+        )
+
+        assert working_cleanup.main(str(tmp_path)) == 0
+
+        record = read_lane_last_run(tmp_path, "working_cleanup")
+        assert record["reason"] == "removed_expired_items"
+        assert record["counters"]["items_removed"] == 1
+        assert "items_malformed_timestamp" not in record["counters"]
+        remaining = json.loads(working.read_text(encoding="utf-8"))["items"]
+        assert remaining == []
+
+    def test_malformed_timestamp_kept_and_recorded_not_crashed(self, tmp_path):
+        """Genuinely unparseable timestamp: keep the item (no data loss) and
+        record the malformed count in the durable lane_last_run counters
+        rather than swallowing it -- this lane deletes data, so a wrong
+        answer here is data loss.
+        """
+        from scripts import cleanup_expired_working as working_cleanup
+        from plugins.memory.memory_os.lane_last_run import read_lane_last_run
+
+        working = tmp_path / "memory-os" / "working" / "lingering.json"
+        working.parent.mkdir(parents=True)
+        working.write_text(
+            json.dumps({"items": [{"status": "expired", "updated_at": "not-a-timestamp", "text": "corrupt"}]}),
+            encoding="utf-8",
+        )
+
+        assert working_cleanup.main(str(tmp_path)) == 0
+
+        record = read_lane_last_run(tmp_path, "working_cleanup")
+        assert record["reason"] == "no_expired_items"
+        assert record["counters"]["items_malformed_timestamp"] == 1
+        remaining = json.loads(working.read_text(encoding="utf-8"))["items"]
+        assert len(remaining) == 1  # kept, not deleted
+
+
+# ── 8. state_overlay.py::_read_open_threads_from_candidates ─────────────
+
+class TestStateOverlayOpenThreadsNaiveLastUpdated:
+    def test_naive_recent_last_updated_included_not_crashed(self, tmp_path):
+        """The except wrapped only the parse; the `ts < cutoff` comparison
+        sat outside it. Reachable from the per-turn prefetch path, so the
+        fix must stay a cheap `continue`, not add I/O or logging.
+        """
+        from plugins.memory.memory_os.state_overlay import _read_open_threads_from_candidates
+
+        crystallized_root = tmp_path / "crystallized"
+        crystallized_root.mkdir(parents=True)
+        naive_recent = (datetime.now(timezone.utc) - timedelta(hours=2)).replace(tzinfo=None).isoformat()
+        record = {
+            "candidate_id": "cand_naive",
+            "canonical_state": "owner_eligible",
+            "last_updated": naive_recent,
+            "summary": "A naive-timestamped open thread.",
+        }
+        (crystallized_root / "candidates.jsonl").write_text(
+            json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8",
+        )
+
+        threads = _read_open_threads_from_candidates(crystallized_root)
+
+        assert threads == [("A naive-timestamped open thread.", "cand_naive")]
+
+
+# ── 9. memory_sources.py::_records_since ─────────────────────────────────
+
+class TestMemorySourcesRecordsSinceNaiveCreatedAt:
+    def test_naive_recent_created_at_included_not_crashed(self):
+        """Pre-fix: `except ValueError` only (TypeError escaped), and the
+        `created_at >= cutoff` comparison sat outside the try. On the
+        per-turn disclosure path.
+        """
+        from plugins.memory.memory_os.memory_sources import _records_since
+
+        naive_recent = (datetime.now(timezone.utc) - timedelta(hours=1)).replace(tzinfo=None).isoformat()
+        records = [{"created_at": naive_recent, "id": "r1"}]
+
+        result = _records_since(records, hours=24)
+
+        assert result == records
+
+
+# ── 10. loop_health_view.py::_parse_recorded_at ──────────────────────────
+
+class TestLoopHealthViewNaiveRecordedAt:
+    def test_naive_recorded_at_age_computed_not_crashed(self, tmp_path):
+        """_parse_recorded_at caught (ValueError, TypeError) around the
+        parse but never normalized a successfully-parsed naive value; the
+        `moment - recorded_at` subtraction one call site above raised
+        TypeError, uncaught (nothing wraps build_loop_health_view's loop).
+        Fixed at the parser so every caller benefits.
+        """
+        from plugins.memory.memory_os.lane_last_run import lane_last_run_path
+        from plugins.memory.memory_os.loop_health_view import build_loop_health_view
+
+        now = datetime(2026, 8, 13, 12, 0, 0, tzinfo=timezone.utc)
+        naive_recorded_at = (now - timedelta(minutes=30)).replace(tzinfo=None).isoformat()
+        path = lane_last_run_path(tmp_path, "full_monitor_refresh")
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "memory-os.lane_last_run.v0",
+                    "lane_id": "full_monitor_refresh",
+                    "recorded_at": naive_recorded_at,
+                    "status": "ok",
+                    "reason": "artifact_published",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        view = build_loop_health_view(tmp_path, now=now)
+
+        observability = next(loop for loop in view["loops"] if loop["loop"] == "observability")
+        assert observability["state"] == "active"
+        member = observability["members"][0]
+        assert member["age_minutes"] == 30  # correct elapsed time, not a crash
+        assert member.get("stale") is not True
+
+
+# ── 11. __init__.py::_read_latest_active_task_anchor ─────────────────────
+
+class TestReadLatestActiveTaskAnchorNaiveSourceAt:
+    def test_naive_created_at_cross_session_age_label_not_crashed(self, tmp_path):
+        """The parse caught (ValueError, TypeError) but never normalized;
+        the age_min subtraction against the aware `now` sat outside the
+        try. This runs during provider initialize() -- a naive source_at
+        in a cross-session anchor record would crash provider startup.
+        """
+        import re
+        from plugins.memory import load_memory_provider
+        from plugins.memory.memory_os.__init__ import _active_task_anchor_path
+
+        provider = load_memory_provider("memory_os")
+        provider.initialize(
+            "session-current", hermes_home=str(tmp_path), platform="cli",
+            agent_identity="memoryos-test",
+        )
+        anchor_path = _active_task_anchor_path(provider._roots)
+        anchor_path.parent.mkdir(parents=True, exist_ok=True)
+        naive_created_at = (
+            datetime.now(timezone.utc) - timedelta(minutes=30)
+        ).replace(tzinfo=None).isoformat()
+        record = {
+            "schema_version": "memory-os.active_task_anchor.v0",
+            "record_id": "ata_naive_cross_session",
+            "created_at": naive_created_at,
+            "profile": "memoryos-test",
+            "session_id": "session-other",
+            "anchor": (
+                "### Memory-OS Current Task Anchor\n"
+                "- current task: naive时间戳跨会话恢复\n"
+                "- session: session-other"
+            ),
+            "status": "active",
+            "storage_policy": "runtime_system_metadata_not_canonical_memory",
+        }
+        anchor_path.write_text(json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8")
+
+        recovered = provider._read_latest_active_task_anchor(max_age_hours=24)
+        provider.shutdown()
+
+        assert recovered != ""
+        assert "跨会话恢复" in recovered
+        # A correctly-normalized age label is a numeric "<N>m前"/"<N>h前",
+        # not the "?" fallback reserved for genuinely unparseable input.
+        assert re.search(r"\d+[mh]前", recovered) is not None
+
+    def test_genuinely_malformed_created_at_falls_back_to_unknown_age(self, tmp_path):
+        """Fail-open contract for truly unparseable input must survive the
+        fix unchanged: age_label stays "?" rather than crashing.
+        """
+        from plugins.memory import load_memory_provider
+        from plugins.memory.memory_os.__init__ import _active_task_anchor_path
+
+        provider = load_memory_provider("memory_os")
+        provider.initialize(
+            "session-current", hermes_home=str(tmp_path), platform="cli",
+            agent_identity="memoryos-test",
+        )
+        anchor_path = _active_task_anchor_path(provider._roots)
+        anchor_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "schema_version": "memory-os.active_task_anchor.v0",
+            "record_id": "ata_malformed_cross_session",
+            "created_at": "not-a-timestamp",
+            "profile": "memoryos-test",
+            "session_id": "session-other",
+            "anchor": (
+                "### Memory-OS Current Task Anchor\n"
+                "- current task: malformed时间戳跨会话恢复\n"
+                "- session: session-other"
+            ),
+            "status": "active",
+            "storage_policy": "runtime_system_metadata_not_canonical_memory",
+        }
+        anchor_path.write_text(json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8")
+
+        # max_age_hours=0 (not 24): task_state.read_effective_current_task's
+        # OWN age gate only runs when max_age_hours > 0 and would otherwise
+        # reject this record itself (returning None) before it ever reaches
+        # _read_latest_active_task_anchor's re-parse -- that would prove the
+        # wrong site's fail-open contract. 0 isolates the site under test.
+        recovered = provider._read_latest_active_task_anchor(max_age_hours=0)
+        provider.shutdown()
+
+        assert recovered != ""
+        assert "?" in recovered
+
+
+# ── 12. speak_rate_limit.py::_parse_ts ───────────────────────────────────
+
+class TestSpeakRateLimitNaiveTimestamp:
+    def test_naive_recent_ts_counts_toward_limit_not_crashed(self):
+        """Pre-fix, a successfully-parsed-but-naive `ts` was returned
+        un-normalized; comparing it against the aware `cutoff` in
+        under_speak_limit raised TypeError. The established fail-open
+        contract (genuinely unparseable -> datetime.min -> not counted,
+        so bad data never falsely suppresses speech) is preserved; this
+        only fixes the crash for a naive-but-real timestamp, which must
+        be normalized and counted like any other recent delivery.
+        """
+        from plugins.modules.expression.speak_rate_limit import under_speak_limit
+
+        now = datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc)
+        naive_recent = (now - timedelta(minutes=5)).replace(tzinfo=None).isoformat()
+        deliveries = [
+            {"ts": naive_recent, "decision": "delivered"},
+            {"ts": "2026-06-17T11:56:00+00:00", "decision": "delivered"},
+            {"ts": "2026-06-17T11:57:00+00:00", "decision": "delivered"},
+            {"ts": "2026-06-17T11:58:00+00:00", "decision": "delivered"},
+            {"ts": "2026-06-17T11:59:00+00:00", "decision": "delivered"},
+        ]
+
+        # 5 delivered in-window (including the naive one) -> at the cap.
+        assert under_speak_limit(deliveries, now=now) is False
+
+
+# ── 13. cli.py::diff_report ───────────────────────────────────────────────
+
+class TestDiffReportSinceUntilRequiresCleanInput:
+    def test_naive_since_raises_clear_cli_error_not_traceback(self, tmp_path):
+        """since/until are raw --since/--until CLI strings. A bare
+        (offset-less) value is ambiguous user input -- the fix requires an
+        explicit UTC offset and fails with a clear SystemExit message
+        instead of silently assuming UTC or crashing with a raw
+        TypeError traceback from the per-event comparison below.
+        """
+        from plugins.memory.memory_os.cli import diff_report
+        from plugins.memory.memory_os.fixtures import build_event
+        from plugins.memory.memory_os.schema import EventEnvelope
+
+        store = _store(tmp_path)
+        store.append_event(EventEnvelope.from_dict(build_event(seed=1, profile="test")))
+
+        with pytest.raises(SystemExit, match="UTC offset"):
+            diff_report(store, since="2026-08-01T00:00:00", until="2026-08-02T00:00:00+00:00")
+
+    def test_unparseable_since_raises_clear_cli_error_not_traceback(self, tmp_path):
+        """Pre-fix, since/until had ZERO exception handling at all -- a
+        completely unparseable value raised a raw ValueError traceback.
+        """
+        from plugins.memory.memory_os.cli import diff_report
+
+        store = _store(tmp_path)
+
+        with pytest.raises(SystemExit, match="invalid --since/--until timestamp"):
+            diff_report(store, since="not-a-timestamp", until="2026-08-02T00:00:00+00:00")
+
+    def test_valid_aware_bounds_still_work(self, tmp_path):
+        """Regression guard: the common case (aware since/until) must keep
+        working exactly as before.
+        """
+        from plugins.memory.memory_os.cli import diff_report
+        from plugins.memory.memory_os.fixtures import build_event
+        from plugins.memory.memory_os.schema import EventEnvelope
+
+        store = _store(tmp_path)
+        store.append_event(EventEnvelope.from_dict(build_event(seed=1, profile="test")))
+
+        report = diff_report(
+            store,
+            since="2026-05-20T00:00:00+00:00",
+            until="2026-05-21T00:00:00+00:00",
+        )
+
+        assert report["event_count"] == 1
+
+
+# ── 14. scripts/install_memory_os_plugin.py::_run_expired_working_migration
+
+class TestInstallMigrationNaiveOrMalformedTimestamp:
+    def test_naive_expired_timestamp_removed_not_crashed(self, tmp_path):
+        from scripts.install_memory_os_plugin import _run_expired_working_migration
+
+        working_dir = tmp_path / "memory-os" / "working"
+        working_dir.mkdir(parents=True)
+        naive_old = (datetime.now(timezone.utc) - timedelta(days=10)).replace(tzinfo=None).isoformat()
+        (working_dir / "lingering.json").write_text(
+            json.dumps({"items": [{"status": "expired", "updated_at": naive_old, "text": "old"}]}),
+            encoding="utf-8",
+        )
+
+        result = _run_expired_working_migration(tmp_path, dry_run=False)
+
+        assert result["status"] == "cleaned"
+        assert result["removed"] == 1
+        remaining = json.loads((working_dir / "lingering.json").read_text(encoding="utf-8"))["items"]
+        assert remaining == []
+
+    def test_malformed_timestamp_kept_not_crashed(self, tmp_path):
+        """Same conservative direction as site 7: keep the item on
+        genuinely unparseable input rather than risk deleting something
+        that was not actually expired.
+        """
+        from scripts.install_memory_os_plugin import _run_expired_working_migration
+
+        working_dir = tmp_path / "memory-os" / "working"
+        working_dir.mkdir(parents=True)
+        (working_dir / "lingering.json").write_text(
+            json.dumps({"items": [{"status": "expired", "updated_at": "not-a-timestamp", "text": "corrupt"}]}),
+            encoding="utf-8",
+        )
+
+        result = _run_expired_working_migration(tmp_path, dry_run=False)
+
+        assert result["status"] == "no_expired_old"
+        assert result["before"] == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Round 3 (2026-08-15, final): eight further sites of the same defect
+# shape, found by two independent audits outside rounds 1-2's allowed
+# files. Covers:
+#   15. prefetch.py::_last_session_lines (per-turn hot path)
+#   16. prefetch.py::_recent_cross_session_lines (per-turn hot path)
+#   17. audit.py::last_audit_age_seconds (zero exception handling at all)
+#   18. structural_edge_proposer.py::_detect_relation via _parse_iso
+#   19. provisional_sweep.py::_days_until_expiry (silently-wrong, not crash)
+#   20. override_sweep.py::_days_until_expiry (silently-wrong, not crash)
+#   21. owner_actions.py::_provisional_crystallized_review_items
+#       (silently-wrong, not crash)
+#   22. prefetch.py::_crystallized_lines provisional countdown (both: a
+#       silently-wrong countdown AND a downstream sort crash a few lines
+#       away from the actual defect)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+# ── 15. prefetch.py::_last_session_lines ─────────────────────────────────
+
+class TestLastSessionLinesNaiveEndedAt:
+    def test_naive_ended_at_age_computed_not_crashed(self, tmp_path):
+        """Pre-fix, the try/except wrapped only the `fromisoformat` call;
+        the `ended_at > best[0]` comparison and the `now - ended_ts`
+        subtraction both sat outside it, unnormalized. Reachable from the
+        per-turn prefetch path -- a naive stored ended_at would crash the
+        user's turn.
+        """
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+        from plugins.memory.memory_os.prefetch import _last_session_lines
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        store = MemoryOSStore(roots)
+        store.initialize()
+
+        anchor_path = store.roots.memory_os_root / "system" / "last_session_anchor.jsonl"
+        anchor_path.parent.mkdir(parents=True, exist_ok=True)
+        naive_ended_at = (
+            datetime.now(timezone.utc) - timedelta(hours=5)
+        ).replace(tzinfo=None).isoformat()
+        record = {
+            "session_id": "session-1",
+            "ended_at": naive_ended_at,
+            "foreground_summary": "Naive-timestamped last session.",
+        }
+        anchor_path.write_text(json.dumps(record, ensure_ascii=False) + "\n", encoding="utf-8")
+
+        lines = _last_session_lines(store, session_id="session-2")
+
+        assert len(lines) == 1
+        assert "5h前" in lines[0]
+        assert "Naive-timestamped last session." in lines[0]
+
+
+# ── 16. prefetch.py::_recent_cross_session_lines ─────────────────────────
+
+class TestRecentCrossSessionLinesNaiveEventTs:
+    def test_naive_event_ts_age_computed_not_crashed(self, tmp_path):
+        """Pre-fix, the try/except wrapped only the `fromisoformat` call;
+        `ts < cutoff` sat outside it, unnormalized. Reachable from the
+        per-turn prefetch path.
+        """
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        from plugins.memory.memory_os.store import MemoryOSStore
+        from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, EventEnvelope
+        from plugins.memory.memory_os.prefetch import _recent_cross_session_lines
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        store = MemoryOSStore(roots)
+        store.initialize()
+
+        other_session_id = "sess_other_naive"
+        current_session_id = "sess_current_naive"
+        event_id = "evt_naive_ts_001"
+
+        candidates_path = store.roots.crystallized_root / "candidates.jsonl"
+        candidates_path.parent.mkdir(parents=True, exist_ok=True)
+        candidates_path.write_text(
+            json.dumps({
+                "candidate_id": "cand_naive_ts",
+                "kind": "moment",
+                "body": "test candidate",
+                "source_event_ids": [event_id],
+                "tags": ["inner-drive"],
+                "sensitivity": "private",
+                "bridge_state": "inner_drive_candidate",
+            }, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        naive_ts = (
+            datetime.now(timezone.utc) - timedelta(hours=3)
+        ).replace(tzinfo=None).isoformat()
+        event = EventEnvelope(
+            schema_version=EVENT_SCHEMA_VERSION,
+            id=event_id,
+            ts=naive_ts,
+            profile="test",
+            source="test",
+            kind="conversation_turn",
+            summary="Naive timestamp cross-session summary marker.",
+            safe_ref={"session_id": other_session_id},
+            tags=[],
+        )
+        store.append_event(event)
+
+        lines = _recent_cross_session_lines(store, session_id=current_session_id)
+
+        assert any("Naive timestamp cross-session" in line for line in lines)
+        assert any("3h前" in line for line in lines)
+
+
+# ── 17. audit.py::last_audit_age_seconds ──────────────────────────────────
+
+class TestLastAuditAgeSecondsMixedAwareness:
+    def test_naive_and_aware_ts_mixed_no_crash_correct_latest(self, tmp_path):
+        """Pre-fix, `max(datetime.fromisoformat(...) for entry in entries)`
+        had ZERO exception handling: a mix of naive and aware `ts` values
+        across entries raises TypeError inside max()'s own comparison.
+        """
+        from plugins.memory.memory_os.audit import last_audit_age_seconds
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")
+        audit_path = roots.audit_path
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        month_path = audit_path.parent / f"{audit_path.stem}.202608.jsonl"
+
+        now = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+        older_aware = (now - timedelta(minutes=10)).isoformat()
+        newer_naive = (now - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        records = [
+            {"id": "a1", "ts": older_aware, "action": "probe", "status": "ok", "target": "x", "details": {}},
+            {"id": "a2", "ts": newer_naive, "action": "probe", "status": "ok", "target": "y", "details": {}},
+        ]
+        with month_path.open("w", encoding="utf-8") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec) + "\n")
+
+        age = last_audit_age_seconds(audit_path, now=now)
+
+        assert age is not None
+        # The most recent record is the naive one (1 minute ago), not the
+        # aware one (10 minutes ago) -- proves max() correctly compared
+        # them (rather than crashing) and normalized the naive value
+        # instead of silently mis-ordering it.
+        assert age == pytest.approx(60.0, abs=1.0)
+
+    def test_malformed_ts_skipped_valid_ts_still_used(self, tmp_path):
+        """A malformed ts string (ValueError) must not crash the whole
+        function -- pre-fix there was no try/except at all around the
+        parse, so one bad record broke the CLI status report for every
+        entry.
+        """
+        from plugins.memory.memory_os.audit import last_audit_age_seconds
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="test")
+        audit_path = roots.audit_path
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        month_path = audit_path.parent / f"{audit_path.stem}.202608.jsonl"
+
+        now = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+        valid_recent = (now - timedelta(minutes=5)).isoformat()
+        records = [
+            {"id": "a1", "ts": "not-a-timestamp", "action": "probe", "status": "ok", "target": "x", "details": {}},
+            {"id": "a2", "ts": valid_recent, "action": "probe", "status": "ok", "target": "y", "details": {}},
+        ]
+        with month_path.open("w", encoding="utf-8") as fh:
+            for rec in records:
+                fh.write(json.dumps(rec) + "\n")
+
+        age = last_audit_age_seconds(audit_path, now=now)
+
+        assert age == pytest.approx(300.0, abs=1.0)
+
+
+# ── 18. structural_edge_proposer.py::_detect_relation via _parse_iso ─────
+
+class TestStructuralEdgeProposerParseIsoMixedAwareness:
+    def test_naive_and_aware_created_at_temporal_edge_not_crashed(self):
+        """Pre-fix, `_parse_iso` never normalized a successfully-parsed
+        naive value, and `ts_a - ts_b` had NO exception handling at all --
+        so two crystallized records whose created_at differ in
+        naive/aware-ness crashed the structural proposer for that pair.
+        Bodies chosen below the dice-similarity threshold (see
+        test_memory_os_edge_weights.py's identical strings) so temporal
+        proximity is the only signal exercised.
+        """
+        from plugins.memory.memory_os.structural_edge_proposer import _detect_relation
+
+        record_a = {
+            "id": "cry_temporal_naive",
+            "kind": "note",
+            "tags_json": "[]",
+            "source_event_ids_json": "[]",
+            "body": "内容完全不同的一段甲",
+            "created_at": "2026-08-07T00:00:00",  # naive
+        }
+        record_b = {
+            "id": "cry_temporal_aware",
+            "kind": "note",
+            "tags_json": "[]",
+            "source_event_ids_json": "[]",
+            "body": "彼此毫无词面重叠乙",
+            "created_at": "2026-08-07T00:10:00+00:00",  # aware, 10 min later
+        }
+
+        edges = _detect_relation(record_a, record_b)
+
+        temporal = [e for e in edges if e["relation_type"] == "co_occurs"]
+        assert temporal, (
+            "naive/aware created_at pair must still produce the "
+            "temporal_proximity edge, not crash or silently drop it"
+        )
+
+
+# ── 19. provisional_sweep.py::_days_until_expiry ──────────────────────────
+
+class TestProvisionalSweepDaysUntilExpiryNaive:
+    def test_naive_future_expiry_reports_correct_days_not_infinite(self):
+        """Pre-fix, naive input hit `except (ValueError, TypeError)` (from
+        the aware subtraction, not the parse) and fell back to
+        float("inf"), so the record was never "expiring soon" in
+        near_expiry_count -- an owner-facing prioritization miss, not a
+        crash.
+        """
+        from plugins.modules.governance.provisional_sweep import _days_until_expiry
+
+        naive_two_days = (
+            datetime.now(timezone.utc) + timedelta(days=2)
+        ).replace(tzinfo=None).isoformat()
+
+        days = _days_until_expiry(naive_two_days)
+
+        assert days != float("inf")
+        assert 1.5 <= days <= 2.5
+
+    def test_genuinely_malformed_expiry_still_returns_inf(self):
+        """Fail-open contract for truly unparseable input must survive the
+        fix unchanged.
+        """
+        from plugins.modules.governance.provisional_sweep import _days_until_expiry
+
+        assert _days_until_expiry("not-a-timestamp") == float("inf")
+
+
+# ── 20. override_sweep.py::_days_until_expiry ─────────────────────────────
+
+class TestOverrideSweepDaysUntilExpiryNaive:
+    def test_naive_future_expiry_reports_correct_days_not_infinite(self):
+        """Same shape as provisional_sweep.py's identically-named helper."""
+        from plugins.modules.governance.override_sweep import _days_until_expiry
+
+        naive_two_days = (
+            datetime.now(timezone.utc) + timedelta(days=2)
+        ).replace(tzinfo=None).isoformat()
+
+        days = _days_until_expiry(naive_two_days)
+
+        assert days != float("inf")
+        assert 1.5 <= days <= 2.5
+
+    def test_genuinely_malformed_expiry_still_returns_inf(self):
+        from plugins.modules.governance.override_sweep import _days_until_expiry
+
+        assert _days_until_expiry("not-a-timestamp") == float("inf")
+
+
+# ── 21. owner_actions.py::_provisional_crystallized_review_items ─────────
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+class TestOwnerActionsProvisionalCrystallizedNaiveExpiry:
+    def test_naive_near_expiry_priority_action_required_not_fyi(self, tmp_path):
+        """Pre-fix, naive expires_at hit `except (ValueError, TypeError)`
+        (from the aware subtraction, not the parse) and fell through to
+        the remaining_days=999 default, silently mis-prioritizing this
+        item to "fyi" in the owner digest instead of its real
+        action_required urgency (<=3 days out).
+        """
+        from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+        from plugins.memory.memory_os.crystallized import CrystallizedCandidate, CrystallizedMemoryService
+        from plugins.memory.memory_os import owner_actions as owner_actions_module
+
+        store = _store(tmp_path)
+        service = CrystallizedMemoryService(store)
+        now = datetime.now(timezone.utc)
+        naive_near = (now + timedelta(days=2)).replace(tzinfo=None).isoformat()
+
+        candidate = CrystallizedCandidate(
+            candidate_id="cand_oa_naive",
+            kind="moment",
+            body="Naive-expiry owner review item.",
+            source_event_ids=["evt_oa_naive"],
+        )
+        decision = ApprovalDecision(
+            candidate_id="cand_oa_naive",
+            purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+            reviewer="resolver",
+            reviewed_at=now.isoformat(),
+            source_state="resolver_approved",
+            provisional=True,
+            expires_at=naive_near,
+        )
+        service.write_approved_record(candidate, decision, file_name="owner_approved.md")
+
+        items = owner_actions_module._provisional_crystallized_review_items(store, closed=set())
+
+        assert len(items) == 1
+        assert items[0]["remaining_days"] <= 3
+        assert items[0]["priority"] == "action_required"
+
+    def test_genuinely_malformed_expiry_falls_back_to_999_fyi(self, tmp_path):
+        """Fail-open contract for truly unparseable input must survive the
+        fix unchanged: remaining_days stays 999, priority stays "fyi".
+        """
+        from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+        from plugins.memory.memory_os.crystallized import CrystallizedCandidate, CrystallizedMemoryService
+        from plugins.memory.memory_os import owner_actions as owner_actions_module
+
+        store = _store(tmp_path)
+        service = CrystallizedMemoryService(store)
+        now = datetime.now(timezone.utc)
+
+        candidate = CrystallizedCandidate(
+            candidate_id="cand_oa_malformed",
+            kind="moment",
+            body="Malformed-expiry owner review item.",
+            source_event_ids=["evt_oa_malformed"],
+        )
+        decision = ApprovalDecision(
+            candidate_id="cand_oa_malformed",
+            purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+            reviewer="resolver",
+            reviewed_at=now.isoformat(),
+            source_state="resolver_approved",
+            provisional=True,
+            expires_at="not-a-timestamp",
+        )
+        service.write_approved_record(candidate, decision, file_name="owner_approved.md")
+
+        items = owner_actions_module._provisional_crystallized_review_items(store, closed=set())
+
+        assert len(items) == 1
+        assert items[0]["remaining_days"] == 999
+        assert items[0]["priority"] == "fyi"
+
+
+# ── 22. prefetch.py::_crystallized_lines provisional countdown ───────────
+
+@pytest.mark.usefixtures("crystallized_test_write_authority")
+class TestCrystallizedLinesProvisionalCountdownNaiveExpiry:
+    """Pre-fix, the try/except wrapped BOTH the parse and the subtraction,
+    so a naive-but-valid expires_at did not raise immediately -- but the
+    partial assignment left `expires_dt` naive (not the aware
+    `datetime.max` sentinel) while `days_remaining` silently stayed at its
+    999 default. That naive `expires_dt` then went into
+    provisional_entries and crashed the LATER
+    `provisional_entries.sort(key=lambda e: e[0])` as soon as a second
+    provisional entry with a genuinely-aware expires_at existed to compare
+    against -- a defect surfacing several lines away from its cause.
+    """
+
+    def test_naive_and_aware_provisional_expiry_sort_together_correct_countdown(self, tmp_path):
+        import re
+
+        from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+        from plugins.memory.memory_os.crystallized import CrystallizedCandidate, CrystallizedMemoryService
+        from plugins.memory.memory_os.prefetch import _crystallized_lines
+
+        store = _store(tmp_path)
+        service = CrystallizedMemoryService(store)
+        now = datetime.now(timezone.utc)
+
+        naive_expiry = (now + timedelta(days=2)).replace(tzinfo=None).isoformat()
+        aware_expiry = (now + timedelta(days=5)).isoformat()
+
+        cand_naive = CrystallizedCandidate(
+            candidate_id="cand_ctdn_naive",
+            kind="moment",
+            body="Naive-expiry provisional record.",
+            source_event_ids=["evt_ctdn_naive"],
+        )
+        dec_naive = ApprovalDecision(
+            candidate_id="cand_ctdn_naive",
+            purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+            reviewer="resolver",
+            reviewed_at=now.isoformat(),
+            source_state="resolver_approved",
+            provisional=True,
+            expires_at=naive_expiry,
+        )
+        service.write_approved_record(cand_naive, dec_naive, file_name="owner_approved.md")
+
+        cand_aware = CrystallizedCandidate(
+            candidate_id="cand_ctdn_aware",
+            kind="moment",
+            body="Aware-expiry provisional record.",
+            source_event_ids=["evt_ctdn_aware"],
+        )
+        dec_aware = ApprovalDecision(
+            candidate_id="cand_ctdn_aware",
+            purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+            reviewer="resolver",
+            reviewed_at=now.isoformat(),
+            source_state="resolver_approved",
+            provisional=True,
+            expires_at=aware_expiry,
+        )
+        service.write_approved_record(cand_aware, dec_aware, file_name="owner_approved.md")
+
+        # Pre-fix this call raises TypeError inside provisional_entries.sort()
+        # as soon as both records are collected -- not at the parse site.
+        lines, _degradation, _record_ids = _crystallized_lines(store)
+
+        naive_line = next(line for line in lines if "Naive-expiry" in line)
+        match = re.search(r"剩(\d+)d", naive_line)
+        assert match is not None
+        # ~2 days remain; must not have fallen back to the 999-day sentinel.
+        assert int(match.group(1)) <= 2

--- a/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
+++ b/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
@@ -297,6 +297,89 @@ def test_f2_injection_never_live_blocks_forgetting(tmp_path):
     assert state == "active", "no forgetting while injection has never been live"
 
 
+def test_r4_cursor_misalignment_on_ledger_truncation_does_not_reprocess(tmp_path):
+    """反事实(线计数 cursor 对 compaction-eligible 账本):账本被压缩(截断)
+    到比游标短时,必须检测出错位、落类型化原因码 + skipped 计数,且绝不能
+    从零重放(乘性强化非幂等,重放会对已强化边二次加分)。截断用真实生产者
+    产出的行的子集改写(不是手写 fixture),模拟未来 compaction 只保留尾部
+    (去掉最老的头部行)的形态。"""
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        HIT_LEARNING_RATE,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge1 = _active_edge(index, 20, weight=0.5)
+    edge2 = _active_edge(index, 21, weight=0.5)
+    _record_hit(store, edge1)
+    _record_hit(store, edge2)
+
+    first = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert first["reinforced_count"] == 2
+    assert first["cursor_misaligned"] is False
+    expected = 0.5 + HIT_LEARNING_RATE * (1.0 - 0.5)
+    weight1_before, _ = _weight_of(index, edge1["edge_id"])
+    weight2_before, _ = _weight_of(index, edge2["edge_id"])
+    assert weight1_before == pytest.approx(expected)
+    assert weight2_before == pytest.approx(expected)
+
+    # Simulate a future compaction: rewrite the ledger to a real subset of its
+    # own already-produced lines (drop the oldest/head record), not a
+    # hand-written fixture. processed cursor (2) now exceeds len(lines) (1).
+    shadow_path = store.roots.memory_os_root / "system" / "graph_layer_shadow.jsonl"
+    real_lines = shadow_path.read_text(encoding="utf-8").splitlines()
+    assert len(real_lines) == 2
+    shadow_path.write_text(real_lines[1] + "\n", encoding="utf-8", newline="\n")
+
+    second = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert second["outcome"] == "cursor_misaligned"
+    assert second["cursor_misaligned"] is True
+    assert second["cursor_misalignment_reason"] == "ledger_shorter_than_cursor"
+    assert second["cursor_previous_line_count"] == 2
+    assert second["cursor_realigned_line_count"] == 1
+    assert second["cursor_skipped_row_count"] == 1
+    assert second["reinforced_count"] == 0, "misaligned run must not reprocess/reinforce anything"
+
+    # Edge weights must be byte-for-byte unchanged by the truncation — no
+    # replay-from-zero double-reinforcement of edge1 or edge2.
+    weight1_after, _ = _weight_of(index, edge1["edge_id"])
+    weight2_after, _ = _weight_of(index, edge2["edge_id"])
+    assert weight1_after == pytest.approx(weight1_before)
+    assert weight2_after == pytest.approx(weight2_before)
+
+
+def test_r4_incremental_hits_after_aligned_run_reinforce_only_new_lines(tmp_path):
+    """正常增量运行不回归:第二轮追加真实新命中后,只强化新增的那一条,
+    第一轮已强化的边权重保持不变(校验 fingerprint 对齐路径本身没有偏移
+    一位的新 bug)。"""
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        HIT_LEARNING_RATE,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge1 = _active_edge(index, 22, weight=0.5)
+    edge2 = _active_edge(index, 23, weight=0.5)
+    _record_hit(store, edge1)
+
+    first = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert first["reinforced_count"] == 1
+    assert first["cursor_misaligned"] is False
+    expected1 = 0.5 + HIT_LEARNING_RATE * (1.0 - 0.5)
+    weight1, _ = _weight_of(index, edge1["edge_id"])
+    assert weight1 == pytest.approx(expected1)
+
+    _record_hit(store, edge2)
+    second = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert second["cursor_misaligned"] is False
+    assert second["reinforced_count"] == 1, "only the newly appended hit must be reinforced"
+
+    weight1_again, _ = _weight_of(index, edge1["edge_id"])
+    weight2, _ = _weight_of(index, edge2["edge_id"])
+    assert weight1_again == pytest.approx(expected1), "edge1 must not be re-reinforced on the second run"
+    assert weight2 == pytest.approx(0.5 + HIT_LEARNING_RATE * (1.0 - 0.5))
+
+
 def test_r4_forget_backlog_and_never_hit_counters(tmp_path):
     """遗忘潮可见性:eligible 超出每轮上限时 forget_eligible_backlog 暴露
     积压;从未命中即被遗忘的边计入 invalidated_never_hit_count(饿死信号)。"""

--- a/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
+++ b/tests/plugins/memory/test_memory_os_edge_weight_feedback.py
@@ -380,6 +380,134 @@ def test_r4_incremental_hits_after_aligned_run_reinforce_only_new_lines(tmp_path
     assert weight2 == pytest.approx(0.5 + HIT_LEARNING_RATE * (1.0 - 0.5))
 
 
+def test_r4_cursor_misalignment_fingerprint_mismatch_reports_nonzero_skipped_count(tmp_path):
+    """反事实(内容指纹错位分支的 skipped 计数不得恒为 0):当账本被压缩后
+    又追加,使 len(lines) >= processed 但游标位置的内容已变(fingerprint
+    不匹配分支),该分支把整条前向未消费 backlog 丢弃(new_lines=[]),但
+    修复缺席时 `max(0, processed - len(lines))` 在此分支恒为 0 —— 专门为
+    量化这次丢失新增的字段在它存在的两种情况之一里必然报零。"""
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        HIT_LEARNING_RATE,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge1 = _active_edge(index, 40, weight=0.5)
+    edge2 = _active_edge(index, 41, weight=0.5)
+    _record_hit(store, edge1)
+    _record_hit(store, edge2)
+
+    first = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert first["reinforced_count"] == 2
+    assert first["cursor_misaligned"] is False
+    expected = 0.5 + HIT_LEARNING_RATE * (1.0 - 0.5)
+    weight1_before, _ = _weight_of(index, edge1["edge_id"])
+    weight2_before, _ = _weight_of(index, edge2["edge_id"])
+    assert weight1_before == pytest.approx(expected)
+    assert weight2_before == pytest.approx(expected)
+
+    # Simulate a future compaction+append: drop the oldest/head record
+    # (real line 0) but keep the real line 1, then append two MORE real
+    # hits via the real producer. processed cursor (2) now points at the
+    # SECOND position of a ledger that is longer than before (len=3 >=
+    # processed=2) -- content-based mismatch, not the shorter-ledger case.
+    shadow_path = store.roots.memory_os_root / "system" / "graph_layer_shadow.jsonl"
+    real_lines = shadow_path.read_text(encoding="utf-8").splitlines()
+    assert len(real_lines) == 2
+    shadow_path.write_text(real_lines[1] + "\n", encoding="utf-8", newline="\n")
+    edge3 = _active_edge(index, 42, weight=0.5)
+    edge4 = _active_edge(index, 43, weight=0.5)
+    _record_hit(store, edge3)
+    _record_hit(store, edge4)
+    post_compaction_lines = shadow_path.read_text(encoding="utf-8").splitlines()
+    assert len(post_compaction_lines) == 3, "compaction+append must land len(lines) >= processed"
+
+    second = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert second["outcome"] == "cursor_misaligned"
+    assert second["cursor_misaligned"] is True
+    assert second["cursor_misalignment_reason"] == "ledger_fingerprint_mismatch"
+    assert second["cursor_previous_line_count"] == 2
+    assert second["cursor_realigned_line_count"] == 3
+    assert second["cursor_skipped_row_count"] == 1, (
+        "len(lines) - processed = 3 - 2 = 1 (nonzero): the fingerprint-mismatch "
+        "branch drops new_lines=[] entirely and must not report a zero loss"
+    )
+    assert second["reinforced_count"] == 0, "misaligned run must not reprocess/reinforce anything"
+
+    # Edge weights must be byte-for-byte unchanged by the compaction+append —
+    # no replay-from-zero double-reinforcement.
+    weight1_after, _ = _weight_of(index, edge1["edge_id"])
+    weight2_after, _ = _weight_of(index, edge2["edge_id"])
+    assert weight1_after == pytest.approx(weight1_before)
+    assert weight2_after == pytest.approx(weight2_before)
+
+
+def test_r4_torn_last_line_is_not_counted_and_completes_next_run(tmp_path):
+    """并发反事实(读写竞态下的假错位):per-turn prefetch 写手在没有读锁的
+    账本上追加(append_jsonl_locked 单次 handle.write() 写整行+\\n,但读侧
+    `run_edge_weight_feedback` 不持锁),读侧可能在一次 write() 完成前捕获
+    到被截断、无尾随换行符的最后一行。修复缺席时该半行会被计入
+    processed_line_count 且对它取 fingerprint;下一轮该行补全后内容变化 →
+    fingerprint 不匹配 → 假 ledger_fingerprint_mismatch → 丢弃两次运行之间
+    追加的所有新行(含真正的新命中)。"""
+    from plugins.memory.memory_os.edge_weight_feedback import (
+        HIT_LEARNING_RATE,
+        run_edge_weight_feedback,
+    )
+
+    store, index = _store(tmp_path)
+    edge1 = _active_edge(index, 50, weight=0.5)
+    edge2 = _active_edge(index, 51, weight=0.5)
+
+    # Both rows built via the real producer first, so their exact serialized
+    # form is captured -- only the torn-write SIMULATION below appends raw
+    # bytes, standing in for a reader racing an in-progress writer append.
+    _record_hit(store, edge1)
+    _record_hit(store, edge2)
+    shadow_path = store.roots.memory_os_root / "system" / "graph_layer_shadow.jsonl"
+    full_lines = shadow_path.read_text(encoding="utf-8").splitlines()
+    assert len(full_lines) == 2
+    complete_line0, complete_line1 = full_lines
+    torn_line1 = complete_line1[: len(complete_line1) - 5]  # drop tail bytes
+
+    # Rewrite the ledger to what a torn write of line 1 would leave behind:
+    # line 0 complete (with its trailing \n), line 1 truncated with NO
+    # trailing \n -- exactly what a reader can observe mid-`handle.write()`
+    # of a real append, since that write is not lock-visible to this reader.
+    with shadow_path.open("wb") as fh:
+        fh.write((complete_line0 + "\n" + torn_line1).encode("utf-8"))
+
+    first = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert first["cursor_misaligned"] is False, "cold start (processed==0) must never misalign"
+    assert first["new_hit_record_count"] == 1, "the torn line must be invisible this run"
+    assert first["reinforced_count"] == 1
+
+    expected = 0.5 + HIT_LEARNING_RATE * (1.0 - 0.5)
+    weight1, _ = _weight_of(index, edge1["edge_id"])
+    assert weight1 == pytest.approx(expected)
+    weight2, _ = _weight_of(index, edge2["edge_id"])
+    assert weight2 == pytest.approx(0.5), "torn line must not be reinforced yet"
+
+    # Complete the torn line (the writer's write() finishes) and append one
+    # brand-new full row via the real producer.
+    edge3 = _active_edge(index, 52, weight=0.5)
+    with shadow_path.open("ab") as fh:
+        fh.write((complete_line1[len(torn_line1):] + "\n").encode("utf-8"))
+    _record_hit(store, edge3)
+
+    second = run_edge_weight_feedback(str(index.roots.index_path), index=index)
+    assert second["cursor_misaligned"] is False, (
+        "the now-completed line must fingerprint-match what this run actually "
+        "consumed last time -- no false ledger_fingerprint_mismatch"
+    )
+    assert second["reinforced_count"] == 2, "completed edge2 line + new edge3 line, each exactly once"
+
+    weight2_after, _ = _weight_of(index, edge2["edge_id"])
+    assert weight2_after == pytest.approx(expected), "edge2 reinforced exactly once, not twice"
+    weight3, _ = _weight_of(index, edge3["edge_id"])
+    assert weight3 == pytest.approx(expected)
+
+
 def test_r4_forget_backlog_and_never_hit_counters(tmp_path):
     """遗忘潮可见性:eligible 超出每轮上限时 forget_eligible_backlog 暴露
     积压;从未命中即被遗忘的边计入 invalidated_never_hit_count(饿死信号)。"""

--- a/tests/plugins/memory/test_memory_os_entity_index.py
+++ b/tests/plugins/memory/test_memory_os_entity_index.py
@@ -687,6 +687,313 @@ class TestQueryRelatedRecordsWithWeight:
             assert "weight" in rel, f"related record missing weight: {rel}"
 
 
+# ── Code-review fix: shared_entity/entity_class/weight provenance and
+#    min_weight join-level filtering (query_related_records) ───────────
+#
+# W9 restricts the *default* extract_entities() call (used by both
+# refresh_entity_index and index.py's _index_entities) to INDEXABLE_ENTITY_
+# CLASSES = {"proper_noun"}, so a production entity_index table today only
+# ever contains proper_noun/0.9 rows.  To build a real multi-class fixture
+# — required to exercise the mis-provenance bug at all — these tests widen
+# the module-level INDEXABLE_ENTITY_CLASSES to entity_extractor's own
+# REFERENCE_DETECTION_CLASSES (the same constant __init__.py already uses
+# for detection-style callers) for the duration of the test only, then run
+# the real refresh_entity_index producer unmodified.  classify_entity()
+# still assigns the real class/weight for every entity text; only which
+# classes are allowed through the index gate is widened.
+
+
+def _enable_reference_detection_classes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Widen the index-worthiness gate so refresh_entity_index indexes
+    path/url/uuid/ip/identifier entities too, not just proper_noun.
+
+    This does not change classify_entity()'s real (class, weight) mapping —
+    only which classes extract_entities() lets through into entity_index.
+    """
+    from plugins.memory.memory_os.entity_extractor import REFERENCE_DETECTION_CLASSES
+
+    monkeypatch.setattr(
+        "plugins.memory.memory_os.entity_extractor.INDEXABLE_ENTITY_CLASSES",
+        REFERENCE_DETECTION_CLASSES,
+    )
+
+
+class TestQueryRelatedRecordsProvenance:
+    """Counterfactuals for two verified defects in query_related_records:
+
+    1. min(entity_text) / max(weight) were independent aggregates over the
+       same GROUP BY and could describe two different entities; entity_class
+       was re-derived from the resulting weight via hardcoded float bands
+       instead of being read from the authoritative column.
+    2. min_weight was applied via `having max(weight) >= ?`, which filters
+       GROUPS (whole records), not the entities that make up overlap_count —
+       so low-weight entities could still inflate overlap_count and rank.
+    """
+
+    def test_shared_entity_class_and_weight_describe_the_same_entity(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defect 1 counterfactual: a record sharing both a low-weight path
+        entity and a high-weight proper_noun entity must return a row whose
+        shared_entity/entity_class/weight all describe ONE entity — the
+        highest-weight one — not a min(text)+max(weight) chimera.
+
+        Without the fix: min(entity_text) picks a path (paths sort first —
+        '/' < any letter), max(weight) picks the proper_noun's 0.9, and the
+        weight-band derivation reports "proper_noun" for a shared_entity
+        string that is actually a path. The returned row lies about which
+        entity earned that class and weight.
+        """
+        from plugins.memory.memory_os.entity_index import query_related_records, refresh_entity_index
+
+        _enable_reference_detection_classes(monkeypatch)
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="entity-provenance-1")
+        store = MemoryOSStore(roots)
+        _seed_crystallized(store, [
+            {
+                "id": "anchor",
+                "body": (
+                    "Reviewed /opt/hermes/a.json /opt/hermes/b.json "
+                    "/opt/hermes/c.json /opt/hermes/d.json along with "
+                    "Zeta Corp and Alpha One and Beta Two."
+                ),
+            },
+            {
+                "id": "rec_a",
+                "body": (
+                    "Audit of /opt/hermes/a.json /opt/hermes/b.json "
+                    "/opt/hermes/c.json /opt/hermes/d.json plus Zeta Corp notes."
+                ),
+            },
+        ])
+        _enable_entity_index_knob(roots)
+
+        db_path = roots.index_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        refresh_entity_index(db_path, roots.crystallized_root, enabled=True)
+
+        related = query_related_records(db_path, ["anchor"], min_weight=0.0)
+        rows_for_a = [r for r in related if r["related_record_id"] == "rec_a"]
+        assert len(rows_for_a) == 1, f"expected exactly one row for rec_a: {related}"
+        row = rows_for_a[0]
+
+        # The four shared paths (weight 0.4) must not win provenance over
+        # the shared proper_noun (weight 0.9) — the row must describe the
+        # highest-weight shared entity, consistently.
+        assert row["shared_entity"] == "Zeta Corp", (
+            f"shared_entity should be the highest-weight shared entity, got: {row}"
+        )
+        assert row["entity_class"] == "proper_noun", (
+            f"entity_class must describe the SAME entity as shared_entity: {row}"
+        )
+        assert row["weight"] == 0.9, f"weight must match the winning entity: {row}"
+        # All five shared entities (4 paths + 1 proper_noun) still counted
+        # at min_weight=0.0 — this test is about provenance, not filtering.
+        assert row["overlap_count"] == 5, f"unexpected overlap_count: {row}"
+
+        # Independent verification: the real classifier agrees with what
+        # query_related_records reported for the entity it named.
+        from plugins.memory.memory_os.entity_extractor import classify_entity
+
+        assert classify_entity(row["shared_entity"]) == (row["entity_class"], row["weight"])
+
+    def test_entity_class_read_from_column_not_weight_band(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defect 1 counterfactual: entity_class must come from the stored
+        column, not be re-derived from weight via hardcoded float bands.
+
+        uuid (weight 0.5) and url (weight 0.5) collide in the old band
+        table — both hit the `weight == 0.5` branch, which always reported
+        "url". A record sharing only a uuid must be reported as "uuid".
+        """
+        from plugins.memory.memory_os.entity_index import query_related_records, refresh_entity_index
+
+        _enable_reference_detection_classes(monkeypatch)
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="entity-provenance-2")
+        store = MemoryOSStore(roots)
+        _seed_crystallized(store, [
+            {"id": "anchor", "body": "Ticket ref 550e8400-e29b-41d4-a716-446655440000 filed."},
+            {"id": "rec_c", "body": "Follow-up for ticket 550e8400-e29b-41d4-a716-446655440000 pending."},
+        ])
+        _enable_entity_index_knob(roots)
+
+        db_path = roots.index_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        refresh_entity_index(db_path, roots.crystallized_root, enabled=True)
+
+        related = query_related_records(db_path, ["anchor"], min_weight=0.0)
+        rows_for_c = [r for r in related if r["related_record_id"] == "rec_c"]
+        assert len(rows_for_c) == 1, f"expected exactly one row for rec_c: {related}"
+        row = rows_for_c[0]
+
+        assert row["weight"] == 0.5
+        assert row["entity_class"] == "uuid", (
+            "entity_class must be read from the stored column (uuid), not "
+            f"re-derived from the weight==0.5 band (which said url): {row}"
+        )
+
+    def test_min_weight_filters_entities_not_whole_groups(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defect 2 counterfactual: min_weight must exclude low-weight
+        entities from the JOIN (and thus from overlap_count), not merely
+        gate whole groups via HAVING max(weight) >= threshold.
+
+        rec_a shares 4 low-weight (0.4) paths + 1 high-weight (0.9) proper
+        noun with the anchor (5 total). rec_b shares only 2 high-weight
+        (0.9) proper nouns (2 total). At min_weight=0.5 the old HAVING
+        clause let rec_a through with overlap_count=5 (inflated by the four
+        sub-threshold paths) and ranked it above rec_b's overlap_count=2 —
+        exactly backwards, since rec_a's genuinely-qualifying overlap is
+        only 1.
+        """
+        from plugins.memory.memory_os.entity_index import query_related_records, refresh_entity_index
+
+        _enable_reference_detection_classes(monkeypatch)
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="entity-provenance-3")
+        store = MemoryOSStore(roots)
+        _seed_crystallized(store, [
+            {
+                "id": "anchor",
+                "body": (
+                    "Reviewed /opt/hermes/a.json /opt/hermes/b.json "
+                    "/opt/hermes/c.json /opt/hermes/d.json along with "
+                    "Zeta Corp and Alpha One and Beta Two."
+                ),
+            },
+            {
+                "id": "rec_a",
+                "body": (
+                    "Audit of /opt/hermes/a.json /opt/hermes/b.json "
+                    "/opt/hermes/c.json /opt/hermes/d.json plus Zeta Corp notes."
+                ),
+            },
+            {"id": "rec_b", "body": "Meeting notes: Alpha One and Beta Two discussed rollout."},
+        ])
+        _enable_entity_index_knob(roots)
+
+        db_path = roots.index_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        refresh_entity_index(db_path, roots.crystallized_root, enabled=True)
+
+        related = query_related_records(db_path, ["anchor"], min_weight=0.5)
+        by_record = {r["related_record_id"]: r for r in related}
+
+        assert by_record["rec_a"]["overlap_count"] == 1, (
+            f"low-weight paths must not inflate overlap_count: {by_record['rec_a']}"
+        )
+        assert by_record["rec_b"]["overlap_count"] == 2, by_record["rec_b"]
+
+        # Ranking must reflect genuinely-qualifying overlap: rec_b (2) ahead
+        # of rec_a (1), not rec_a ahead on its inflated pre-filter count of 5.
+        ranked_ids = [r["related_record_id"] for r in related]
+        assert ranked_ids.index("rec_b") < ranked_ids.index("rec_a"), (
+            f"rec_b should outrank rec_a once low-weight entities are "
+            f"excluded from overlap_count: {related}"
+        )
+
+    def test_production_caller_min_weight_ranking_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Severity check: the only production caller (entity_graph.py,
+        min_weight=0.3) sits below every real class weight (min is path at
+        0.4), so the WHERE-vs-HAVING distinction is a no-op at that
+        threshold — no entity is ever excluded either way. Same fixture as
+        the min_weight=0.5 counterfactual above, but at the real call-site
+        threshold: overlap_count and ranking must match the pre-fix values
+        (rec_a=5 ahead of rec_b=2), proving the fix does not change today's
+        production ranking.
+        """
+        from plugins.memory.memory_os.entity_index import query_related_records, refresh_entity_index
+
+        _enable_reference_detection_classes(monkeypatch)
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="entity-provenance-4")
+        store = MemoryOSStore(roots)
+        _seed_crystallized(store, [
+            {
+                "id": "anchor",
+                "body": (
+                    "Reviewed /opt/hermes/a.json /opt/hermes/b.json "
+                    "/opt/hermes/c.json /opt/hermes/d.json along with "
+                    "Zeta Corp and Alpha One and Beta Two."
+                ),
+            },
+            {
+                "id": "rec_a",
+                "body": (
+                    "Audit of /opt/hermes/a.json /opt/hermes/b.json "
+                    "/opt/hermes/c.json /opt/hermes/d.json plus Zeta Corp notes."
+                ),
+            },
+            {"id": "rec_b", "body": "Meeting notes: Alpha One and Beta Two discussed rollout."},
+        ])
+        _enable_entity_index_knob(roots)
+
+        db_path = roots.index_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        refresh_entity_index(db_path, roots.crystallized_root, enabled=True)
+
+        related = query_related_records(db_path, ["anchor"], min_weight=0.3)
+        by_record = {r["related_record_id"]: r for r in related}
+
+        assert by_record["rec_a"]["overlap_count"] == 5, by_record["rec_a"]
+        assert by_record["rec_b"]["overlap_count"] == 2, by_record["rec_b"]
+        ranked_ids = [r["related_record_id"] for r in related]
+        assert ranked_ids.index("rec_a") < ranked_ids.index("rec_b"), (
+            f"at the real call-site min_weight=0.3, ranking must be unchanged: {related}"
+        )
+
+    def test_query_related_records_fails_open_on_missing_weight_columns(
+        self, tmp_path: Path
+    ) -> None:
+        """Preserve the existing fail-open contract: a table lacking
+        entity_class/weight (pre-migration schema, not self-healed via
+        refresh_entity_index's ALTER) must degrade to [] rather than raise,
+        with a durable warning log — not silently swallowed either.
+        """
+        from plugins.memory.memory_os.entity_index import query_related_records
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="entity-provenance-5")
+        db_path = roots.index_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                """
+                create table entity_index (
+                    entity_id text not null,
+                    entity_text text not null,
+                    record_id text not null,
+                    role text not null,
+                    proposed_by text not null default 'structural',
+                    created_at text not null,
+                    primary key (entity_id, record_id, role)
+                )
+                """
+            )
+            conn.execute(
+                "insert into entity_index (entity_id, entity_text, record_id, role,"
+                " proposed_by, created_at) values ('e1', 'Alice Bob', 'anchor', 'mention',"
+                " 'structural', '2026-01-01T00:00:00Z')"
+            )
+            conn.execute(
+                "insert into entity_index (entity_id, entity_text, record_id, role,"
+                " proposed_by, created_at) values ('e1', 'Alice Bob', 'rec_other', 'mention',"
+                " 'structural', '2026-01-01T00:00:00Z')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        related = query_related_records(db_path, ["anchor"], min_weight=0.0)
+        assert related == [], f"missing-column schema must degrade to [], got: {related}"
+
+
 # ── Analysis-doc M2: index.py rebuild/sync must not drift from the
 #    entity_index producer schema (class/weight columns) ────────────────
 

--- a/tests/plugins/memory/test_memory_os_execution_gate.py
+++ b/tests/plugins/memory/test_memory_os_execution_gate.py
@@ -786,6 +786,254 @@ class TestGateIndex:
         assert result is not None
         assert result["reason"] == "execution_gate_lane_mismatch"
 
+    # ── Perf fix: success-path index rebuild removed ──────────────────
+
+    def test_require_unused_success_does_not_rewrite_index(self, tmp_path, monkeypatch):
+        """Perf fix: N successful require_unused=True resolutions against an
+        already-fresh sidecar entry must not scale index rewrites with N.
+
+        Counterfactual: before this fix, resolve_execution_gate_permit()
+        called _rebuild_gate_index_from_records() unconditionally on every
+        successful full-scan resolution. require_unused=True always takes
+        that full-scan path (see the fast-path comment), so N sequential
+        append_governed_jsonl() calls under one envelope rewrote
+        execution_gate_index.json N times -- the verified perf defect this
+        fix removes.
+        """
+        import plugins.memory.memory_os.execution_gate as execution_gate
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        store = MemoryOSStore(roots)
+        store.initialize()
+
+        permit = start_execution_gate_envelope(
+            store,
+            lane_id="cost-test-lane",
+            trigger_surface="test",
+            risk_class="bounded_reversible_queue",
+            human_approval_required=False,
+            why_no_human_approval="test",
+            scope={"key": "value"},
+            boundary={},
+        )
+        envelope_id = permit["execution_gate_envelope_id"]
+
+        rebuild_calls: list[int] = []
+        real_rebuild = execution_gate._rebuild_gate_index_from_records
+
+        def counting_rebuild(roots_arg, records_arg):
+            rebuild_calls.append(1)
+            return real_rebuild(roots_arg, records_arg)
+
+        monkeypatch.setattr(execution_gate, "_rebuild_gate_index_from_records", counting_rebuild)
+
+        for _ in range(50):
+            result = execution_gate.resolve_execution_gate_permit(
+                roots,
+                envelope_id=envelope_id,
+                lane_id="cost-test-lane",
+                risk_class="bounded_reversible_queue",
+                require_fresh=True,
+                require_unused=True,
+                expected_scope_hash=execution_gate_scope_hash({"key": "value"}),
+            )
+            assert result["status"] == "valid", result
+
+        assert len(rebuild_calls) == 0, (
+            f"expected 0 index rebuilds across 50 require_unused=True resolutions "
+            f"against an already-fresh sidecar entry (non-scaling); got {len(rebuild_calls)}"
+        )
+
+    def test_not_found_and_conflict_resolutions_still_rebuild_index(self, tmp_path, monkeypatch):
+        """Regression guard: removing the success-path rebuild must not touch
+        the two genuine-staleness rebuild paths (not found / conflict).
+        """
+        import plugins.memory.memory_os.execution_gate as execution_gate
+
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        store = MemoryOSStore(roots)
+        store.initialize()
+
+        rebuild_calls: list[int] = []
+        real_rebuild = execution_gate._rebuild_gate_index_from_records
+
+        def counting_rebuild(roots_arg, records_arg):
+            rebuild_calls.append(1)
+            return real_rebuild(roots_arg, records_arg)
+
+        monkeypatch.setattr(execution_gate, "_rebuild_gate_index_from_records", counting_rebuild)
+
+        # not found: no permit record exists for this envelope id at all.
+        result = execution_gate.resolve_execution_gate_permit(
+            roots,
+            envelope_id="xgate_does_not_exist",
+            lane_id="whatever",
+            risk_class="whatever",
+        )
+        assert result["status"] == "invalid"
+        assert result["reason"] == "execution_gate_permit_not_found"
+        assert len(rebuild_calls) == 1, "not-found resolution must still rebuild the index"
+
+        # conflict: two permit records for the same envelope id, written
+        # straight to the journal so the sidecar has no entry for it either.
+        conflict_id = "xgate_conflict_test"
+        dup_permit = {
+            "schema_version": "memory-os.execution_gate_envelope.v0",
+            "stage": "permit",
+            "execution_gate_envelope_id": conflict_id,
+            "created_at": "2026-08-01T00:00:00Z",
+            "expires_at": "2030-08-01T01:00:00Z",
+            "lane_id": "dup-lane",
+            "risk_class": "bounded_reversible_queue",
+            "permit_decision": "allowed",
+        }
+        with execution_gate_records_path(roots).open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(dup_permit) + "\n")
+            handle.write(json.dumps(dup_permit) + "\n")
+
+        result = execution_gate.resolve_execution_gate_permit(
+            roots,
+            envelope_id=conflict_id,
+            lane_id="dup-lane",
+            risk_class="bounded_reversible_queue",
+        )
+        assert result["status"] == "invalid"
+        assert result["reason"] == "execution_gate_permit_conflict"
+        assert len(rebuild_calls) == 2, "conflict resolution must still rebuild the index"
+
+    def test_index_miss_success_still_rebuilds_index(self, tmp_path):
+        """Regression guard for test_index_miss_falls_back_to_full_scan's
+        contract: a success resolved via full scan because the sidecar
+        entry was genuinely missing (not because of a require_unused=True
+        bypass) must still populate the index, preserving self-healing.
+        """
+        roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+        store = MemoryOSStore(roots)
+        store.initialize()
+
+        permit = start_execution_gate_envelope(
+            store,
+            lane_id="self-heal-lane",
+            trigger_surface="test",
+            risk_class="bounded_reversible_queue",
+            human_approval_required=False,
+            why_no_human_approval="test",
+            scope={},
+            boundary={},
+        )
+        envelope_id = permit["execution_gate_envelope_id"]
+
+        from plugins.memory.memory_os.execution_gate import _gate_index_path, _read_gate_index
+
+        _gate_index_path(roots).unlink()
+        assert envelope_id not in _read_gate_index(roots)
+
+        result = resolve_execution_gate_permit(
+            roots,
+            envelope_id=envelope_id,
+            lane_id="self-heal-lane",
+            risk_class="bounded_reversible_queue",
+        )
+        assert result["status"] == "valid"
+        assert envelope_id in _read_gate_index(roots), (
+            "index should self-heal (be repopulated) after a success resolved "
+            "via full scan due to a genuine index miss"
+        )
+
+    # ── Invariant: require_unused=True must never validate a used permit ──
+
+    def test_require_unused_invariant_never_validates_completed_permit(self, tmp_path):
+        """Invariant (must hold under both ways a completion can reach the
+        journal): a permit that has already been completed must NEVER
+        validate when require_unused=True.
+
+        Case A: completion recorded through the real API
+        (complete_execution_gate_envelope) -- the sidecar index DOES
+        correctly show completion_count > 0.
+
+        Case B: completion appended straight to the canonical journal,
+        bypassing the sidecar update entirely -- simulates the crash
+        window documented in resolve_execution_gate_permit, where the
+        sidecar entry exists but is stale. This is the same scenario as
+        test_resolve_require_unused_rejects_canonical_completion_missing_
+        from_sidecar; it is repeated here, paired with Case A, as the
+        single invariant test both cases must jointly satisfy.
+
+        Both cases exercise the same code route today (the full-journal
+        fallback, since require_unused=True unconditionally disables the
+        O(1) index fast path) -- but are asserted independently so a
+        future change to that gate cannot silently reintroduce the hole
+        for either case.
+        """
+        store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test"))
+        store.initialize()
+
+        # Case A: sidecar index correctly reflects the completion.
+        permit_a = start_execution_gate_envelope(
+            store,
+            lane_id="invariant-lane-a",
+            trigger_surface="test",
+            risk_class="bounded_reversible_queue",
+            human_approval_required=False,
+            why_no_human_approval="test",
+            scope={},
+            boundary={},
+        )
+        complete_execution_gate_envelope(
+            store,
+            envelope_id=permit_a["execution_gate_envelope_id"],
+            lane_id="invariant-lane-a",
+            execution_status="completed",
+        )
+        result_a = resolve_execution_gate_permit(
+            store.roots,
+            envelope_id=permit_a["execution_gate_envelope_id"],
+            lane_id="invariant-lane-a",
+            risk_class="bounded_reversible_queue",
+            require_unused=True,
+        )
+        assert result_a["status"] == "invalid"
+        assert result_a["reason"] == "execution_gate_permit_already_completed"
+
+        # Case B: sidecar index does NOT know about the completion.
+        permit_b = start_execution_gate_envelope(
+            store,
+            lane_id="invariant-lane-b",
+            trigger_surface="test",
+            risk_class="bounded_reversible_queue",
+            human_approval_required=False,
+            why_no_human_approval="test",
+            scope={},
+            boundary={},
+        )
+        bypass_completion = {
+            "schema_version": "memory-os.execution_gate_envelope.v0",
+            "stage": "completion",
+            "execution_gate_envelope_id": permit_b["execution_gate_envelope_id"],
+            "created_at": "2026-08-01T00:00:00Z",
+            "lane_id": "invariant-lane-b",
+            "execution_status": "completed",
+        }
+        with execution_gate_records_path(store.roots).open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(bypass_completion) + "\n")
+
+        from plugins.memory.memory_os.execution_gate import _read_gate_index
+
+        idx = _read_gate_index(store.roots)
+        assert idx[permit_b["execution_gate_envelope_id"]].get("completion_count", 0) == 0, (
+            "test setup invariant: sidecar must NOT know about the bypass completion"
+        )
+
+        result_b = resolve_execution_gate_permit(
+            store.roots,
+            envelope_id=permit_b["execution_gate_envelope_id"],
+            lane_id="invariant-lane-b",
+            risk_class="bounded_reversible_queue",
+            require_unused=True,
+        )
+        assert result_b["status"] == "invalid"
+        assert result_b["reason"] == "execution_gate_permit_already_completed"
+
 
 # ── resolve_trigger_class() tests ────────────────────────────────────────────
 

--- a/tests/plugins/memory/test_memory_os_index_rebuild_guard.py
+++ b/tests/plugins/memory/test_memory_os_index_rebuild_guard.py
@@ -1,0 +1,258 @@
+"""Counterfactual tests for the P0.2 embedding-preservation guard.
+
+_copy_embeddings_from_live (index.py) exists to prevent a silent vector
+recall wipe: when rebuild_from_store runs with no embedder available, it
+must copy memory_embeddings across from the live index rather than ship a
+staging DB with zero embedding rows. Before this fix the function swallowed
+every sqlite3.Error with a bare ``pass`` and the ATTACH statement string-
+interpolated the live path -- both defects made a total embedding loss
+byte-identical, in the audit log, to a healthy rebuild.
+
+These tests build all fixtures through the real producers (MemoryOSStore,
+CrystallizedMemoryService, MemoryOSIndex.rebuild_from_store) rather than
+hand-written dicts, per repo convention.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import numpy as np
+import pytest
+
+from plugins.memory.memory_os.approval import ApprovalDecision, ApprovalPurpose
+from plugins.memory.memory_os.audit import read_audit_records
+from plugins.memory.memory_os.crystallized import (
+    CrystallizedCandidate,
+    CrystallizedMemoryService,
+)
+from plugins.memory.memory_os.index import MemoryOSIndex, _copy_embeddings_from_live
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
+
+class MockEmbedder:
+    """Deterministic mock embedder -- no model download needed."""
+
+    def __init__(self, available: bool = True):
+        self._available = available
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def embed(self, text: str) -> bytes:
+        vec = np.array([float(len(text)), float(len(text)) * 0.5, 1.0], dtype=np.float32)
+        padded = np.zeros(384, dtype=np.float32)
+        padded[: len(vec)] = vec
+        return padded.tobytes()
+
+
+def _make_store(home: "os.PathLike[str] | str") -> tuple[MemoryOSRoots, MemoryOSStore]:
+    roots = MemoryOSRoots.from_hermes_home(str(home), profile="test")
+    roots.memory_os_root.mkdir(parents=True, exist_ok=True)
+    store = MemoryOSStore(roots)
+    store.initialize()
+    return roots, store
+
+
+def _write_crystallized_records(store: MemoryOSStore, count: int) -> None:
+    svc = CrystallizedMemoryService(store)
+    for i in range(count):
+        candidate = CrystallizedCandidate(
+            candidate_id=f"guard-c{i}",
+            kind="note",
+            body=f"记忆内容 guard {i}",
+            source_event_ids=[f"guard-evt-{i}"],
+        )
+        decision = ApprovalDecision(
+            candidate_id=f"guard-c{i}",
+            purpose=ApprovalPurpose.APPROVE_FOR_CRYSTALLIZED,
+            reviewer="owner",
+            reviewed_at="2026-06-22T10:00:00Z",
+            source_state="active",
+        )
+        svc.write_approved_record(candidate, decision, file_name="guard.md")
+
+
+def _embedding_count(index_path) -> int:
+    conn = sqlite3.connect(str(index_path))
+    try:
+        return conn.execute("select count(*) from memory_embeddings").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _latest(records: list[dict], action: str) -> dict:
+    matches = [r for r in records if r.get("action") == action]
+    assert matches, f"no audit record found for action={action!r}"
+    return matches[-1]
+
+
+# ── Acceptance 1: healthy rebuild preserves embeddings and audits counts ──
+
+
+def test_rebuild_preserves_embeddings_when_embedder_unavailable_and_audits_counts(tmp_path):
+    roots, store = _make_store(tmp_path / "hermes")
+    _write_crystallized_records(store, count=3)
+
+    # First rebuild with an embedder available -- populates the live index.
+    index = MemoryOSIndex(roots)
+    index._embedder = MockEmbedder(available=True)
+    index.rebuild_from_store(store)
+    assert _embedding_count(roots.index_path) == 3
+
+    # Second rebuild with the embedder unavailable: must preserve, not wipe.
+    index2 = MemoryOSIndex(roots)
+    index2._embedder = MockEmbedder(available=False)
+    index2.rebuild_from_store(store)
+
+    assert _embedding_count(roots.index_path) == 3
+
+    entry = _latest(read_audit_records(roots.audit_path), "index_rebuild")
+    preservation = entry["details"]["embedding_preservation"]
+    assert preservation["outcome"] == "copied"
+    assert preservation["live_row_count"] == 3
+    assert preservation["copied_row_count"] == 3
+
+
+# ── Acceptance 2: a copy failure is loud, not silent, and fail-open ──────
+
+
+def test_rebuild_reports_copy_failed_with_nonzero_live_row_count_when_attach_raises(tmp_path, monkeypatch):
+    roots, store = _make_store(tmp_path / "hermes")
+    _write_crystallized_records(store, count=4)
+
+    index = MemoryOSIndex(roots)
+    index._embedder = MockEmbedder(available=True)
+    index.rebuild_from_store(store)
+    assert _embedding_count(roots.index_path) == 4
+
+    real_connect = sqlite3.connect
+
+    class _AttachRaisingConnection:
+        """Proxy that raises only on the ATTACH statement; everything else
+        passes through to the real connection untouched. sqlite3.Connection
+        is a C type and cannot be monkeypatched directly (attempting
+        ``sqlite3.Connection.execute = ...`` raises TypeError: cannot set
+        'execute' attribute of immutable type), so the proxy wraps the
+        object returned by sqlite3.connect instead."""
+
+        def __init__(self, real_conn):
+            object.__setattr__(self, "_real", real_conn)
+
+        def execute(self, sql, *args, **kwargs):
+            if "ATTACH DATABASE" in sql:
+                raise sqlite3.OperationalError("database is locked")
+            return self._real.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+        def __setattr__(self, name, value):
+            setattr(self._real, name, value)
+
+    def wrapped_connect(*args, **kwargs):
+        return _AttachRaisingConnection(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr("plugins.memory.memory_os.index.sqlite3.connect", wrapped_connect)
+
+    index2 = MemoryOSIndex(roots)
+    index2._embedder = MockEmbedder(available=False)
+    index2.rebuild_from_store(store)  # must NOT raise -- fail-open
+
+    monkeypatch.undo()
+
+    # The rebuild completed and shipped a staging DB with zero embeddings.
+    assert _embedding_count(roots.index_path) == 0
+
+    records = read_audit_records(roots.audit_path)
+    rebuild_entry = _latest(records, "index_rebuild")
+    preservation = rebuild_entry["details"]["embedding_preservation"]
+    assert preservation["outcome"] == "copy_failed"
+    assert preservation["live_row_count"] > 0
+    assert preservation["copied_row_count"] == 0
+
+    # No Silent Failures: a bounded error record must have been emitted,
+    # consistent with the entity_index_knob_resolution_failed pattern
+    # already used elsewhere in index.py.
+    failure_entry = _latest(records, "index_rebuild_embeddings_copy_failed")
+    assert failure_entry["status"] == "warning"
+    error_record = failure_entry["details"]["error_record"]
+    assert error_record["component"] == "sqlite"
+    assert error_record["severity"] == "warning"
+    assert error_record["recoverable"] is True
+    assert error_record["details"]["live_row_count"] > 0
+
+
+# ── Acceptance 3: apostrophe in the live index path no longer breaks ATTACH ──
+
+
+def test_rebuild_preserves_embeddings_when_hermes_home_path_has_apostrophe(tmp_path):
+    home = tmp_path / "o'brien" / "hermes"
+    roots, store = _make_store(home)
+    _write_crystallized_records(store, count=2)
+
+    index = MemoryOSIndex(roots)
+    index._embedder = MockEmbedder(available=True)
+    index.rebuild_from_store(store)
+    assert _embedding_count(roots.index_path) == 2
+
+    index2 = MemoryOSIndex(roots)
+    index2._embedder = MockEmbedder(available=False)
+    index2.rebuild_from_store(store)  # must not raise despite the apostrophe
+
+    assert _embedding_count(roots.index_path) == 2
+    entry = _latest(read_audit_records(roots.audit_path), "index_rebuild")
+    preservation = entry["details"]["embedding_preservation"]
+    assert preservation["outcome"] == "copied"
+    assert preservation["live_row_count"] == 2
+    assert preservation["copied_row_count"] == 2
+
+
+# ── Closed reason-code coverage: no live index yet, and a live index with ──
+# ── no memory_embeddings table (e.g. pre-embeddings schema).             ──
+
+
+def test_rebuild_reports_no_live_index_on_first_ever_rebuild(tmp_path):
+    roots, store = _make_store(tmp_path / "hermes")
+    _write_crystallized_records(store, count=1)
+
+    index = MemoryOSIndex(roots)
+    index._embedder = MockEmbedder(available=False)
+    index.rebuild_from_store(store)  # no prior live index exists at all
+
+    entry = _latest(read_audit_records(roots.audit_path), "index_rebuild")
+    preservation = entry["details"]["embedding_preservation"]
+    assert preservation == {
+        "outcome": "no_live_index",
+        "live_row_count": 0,
+        "copied_row_count": 0,
+    }
+
+
+def test_copy_embeddings_from_live_reports_live_table_missing(tmp_path):
+    live_path = tmp_path / "live.db"
+    live_conn = sqlite3.connect(str(live_path))
+    live_conn.execute("create table not_embeddings (x int)")
+    live_conn.commit()
+    live_conn.close()
+
+    staging_conn = sqlite3.connect(":memory:")
+    staging_conn.execute(
+        """
+        create table memory_embeddings (
+            record_type text not null,
+            record_id text not null,
+            embedding_model text not null,
+            embedding blob not null,
+            created_at text not null,
+            primary key (record_type, record_id, embedding_model)
+        )
+        """
+    )
+
+    result = _copy_embeddings_from_live(staging_conn, live_path)
+    staging_conn.close()
+
+    assert result == {"outcome": "live_table_missing", "live_row_count": 0, "copied_row_count": 0}

--- a/tests/plugins/memory/test_memory_os_knob_expiry.py
+++ b/tests/plugins/memory/test_memory_os_knob_expiry.py
@@ -1,0 +1,207 @@
+"""Counterfactual tests for DEFECT 1: naive-datetime expiry handling in
+knob_overrides.py.
+
+Before the fix, ``_is_expired`` caught only ``ValueError``. A
+timezone-naive ``expires_at`` (e.g. ``"2026-12-31T00:00:00"``) parses fine
+via ``datetime.fromisoformat`` and then raises ``TypeError`` on comparison
+against the aware ``now`` used throughout this store -- uncaught, that
+propagates out of ``resolve_knob`` / ``resolve_knobs`` /
+``list_active_overrides`` into every hot-path caller (verified: prefetch's
+``_graph_layer_shadow_lines`` calls ``_resolve_knob(...)`` with no try
+around it, and ``build_prefetch`` does not wrap that section).
+
+Fixtures are built through the real producer (``register_override``)
+wherever possible, per project convention. The one exception is the
+genuinely-unparseable-garbage case: since part (b) of the fix makes
+``register_override`` reject a value that does not parse at all, that
+fixture must be hand-written directly into the JSONL store to simulate a
+pre-existing / hand-edited legacy record register_override would now
+refuse to create.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from plugins.memory.memory_os.knob_overrides import (
+    _override_store_path,
+    list_active_overrides,
+    register_override,
+    resolve_knob,
+    resolve_knobs,
+)
+
+
+class TestNaiveExpiryIsExpiredComparison:
+    """DEFECT 1(a): _is_expired must not raise TypeError on a naive expires_at."""
+
+    def test_naive_future_expiry_resolves_override_value_without_raising(self, tmp_path):
+        """Counterfactual: a naive (no-offset) future expires_at, registered
+        through the real producer, must resolve deterministically instead of
+        raising TypeError. Before the fix this raised
+        'TypeError: can't compare offset-naive and offset-aware datetimes'
+        out of resolve_knob -- the fail-open `except ValueError` never ran.
+        """
+        now = datetime.now(timezone.utc)
+        naive_future = (now + timedelta(days=7)).replace(tzinfo=None).isoformat()
+        assert "+" not in naive_future and "Z" not in naive_future  # sanity: truly naive
+
+        register_override(
+            "min_cluster_size", 3,
+            prior=2, proposed_by="test", approved_via="test",
+            expires_at=naive_future, _now=now, _store_root=tmp_path,
+        )
+
+        result = resolve_knob("min_cluster_size", default=2, _now=now, _store_root=tmp_path)
+        assert result == 3
+
+    def test_naive_past_expiry_treated_as_utc_and_returns_default(self, tmp_path):
+        """A naive PAST expiry (interpreted as UTC per the fix's documented
+        assumption) must be treated as expired -- default returned, no raise.
+        """
+        now = datetime.now(timezone.utc)
+        naive_past = (now - timedelta(days=1)).replace(tzinfo=None).isoformat()
+
+        register_override(
+            "min_cluster_size", 3,
+            prior=2, proposed_by="test", approved_via="test",
+            expires_at=naive_past, _now=now - timedelta(days=2), _store_root=tmp_path,
+        )
+
+        result = resolve_knob("min_cluster_size", default=2, _now=now, _store_root=tmp_path)
+        assert result == 2
+
+    def test_naive_future_expiry_excluded_correctly_from_list_active_overrides(self, tmp_path):
+        """list_active_overrides shares the same _is_expired call and must
+        not raise either."""
+        now = datetime.now(timezone.utc)
+        naive_future = (now + timedelta(days=7)).replace(tzinfo=None).isoformat()
+
+        reg = register_override(
+            "max_provisional", 50,
+            prior=30, proposed_by="test", approved_via="test",
+            expires_at=naive_future, _now=now, _store_root=tmp_path,
+        )
+
+        active = list_active_overrides(_store_root=tmp_path, _now=now)
+        assert len(active) == 1
+        assert active[0]["id"] == reg["id"]
+
+    def test_resolve_knobs_batch_over_naive_expiry_store_does_not_raise(self, tmp_path):
+        """Mirrors the verified hot-path shape: prefetch's
+        _graph_layer_shadow_lines calls resolve_knob (which delegates to
+        resolve_knobs) with no surrounding try/except. A naive-expiry record
+        anywhere in the store must not make that call raise.
+        """
+        now = datetime.now(timezone.utc)
+        naive_future = (now + timedelta(days=1)).replace(tzinfo=None).isoformat()
+        register_override(
+            "graph_layer_injection_enabled", False,
+            prior=True, proposed_by="test", approved_via="test",
+            expires_at=naive_future, _now=now, _store_root=tmp_path,
+        )
+
+        # Simulate a prefetch-style multi-knob batch resolve over the same store.
+        result = resolve_knobs(
+            {"graph_layer_injection_enabled": True, "lane_continuity_freshness_enabled": True},
+            _now=now, _store_root=tmp_path,
+        )
+        assert result["graph_layer_injection_enabled"] is False
+        assert result["lane_continuity_freshness_enabled"] is True
+
+    def test_hand_written_unparseable_expiry_still_fails_open(self, tmp_path):
+        """Genuinely unparseable expires_at (garbage, not just naive) must
+        still fail open (treated as not-expired) via the ValueError branch,
+        which the fix preserves. This record is hand-written because part
+        (b) of the fix makes register_override reject it -- it simulates a
+        pre-existing legacy record that predates the write-boundary guard.
+        """
+        store_path = _override_store_path(None, _store_root=tmp_path)
+        store_path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "schema_version": "memory-os.knob_override.v0",
+            "id": "ko_legacy_garbage",
+            "knob": "min_cluster_size",
+            "override_value": 4,
+            "prior_value": 2,
+            "bounds": [1, 5],
+            "provisional": True,
+            "expires_at": "not-a-timestamp",
+            "proposed_by": "legacy",
+            "approved_via": "legacy",
+            "state": "active",
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+        with store_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+
+        # Fail-open: unparseable expiry treated as not-expired -> override wins.
+        result = resolve_knob("min_cluster_size", default=2, _store_root=tmp_path)
+        assert result == 4
+
+
+class TestRegisterOverrideRejectsMalformedExpiry:
+    """DEFECT 1(b): register_override must validate expires_at at the write
+    boundary, while keeping expires_at="" (no expiry) valid."""
+
+    def test_unparseable_expires_at_is_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="not a valid ISO-8601 timestamp"):
+            register_override(
+                "min_cluster_size", 3,
+                prior=2, proposed_by="test", approved_via="test",
+                expires_at="not-a-timestamp", _store_root=tmp_path,
+            )
+
+    def test_garbage_expires_at_does_not_get_written_to_store(self, tmp_path):
+        """The rejected write must not land in the JSONL at all."""
+        with pytest.raises(ValueError):
+            register_override(
+                "min_cluster_size", 3,
+                prior=2, proposed_by="test", approved_via="test",
+                expires_at="garbage", _store_root=tmp_path,
+            )
+        store_path = _override_store_path(None, _store_root=tmp_path)
+        assert not store_path.exists()
+
+    def test_empty_string_expires_at_still_means_no_expiry(self, tmp_path):
+        """Regression guard: expires_at="" (documented no-expiry sentinel)
+        must remain valid and must never expire."""
+        now = datetime.now(timezone.utc)
+        reg = register_override(
+            "min_cluster_size", 3,
+            prior=2, proposed_by="test", approved_via="test",
+            expires_at="", _now=now, _store_root=tmp_path,
+        )
+        assert reg["state"] == "active"
+        result = resolve_knob(
+            "min_cluster_size", default=2,
+            _now=now + timedelta(days=3650), _store_root=tmp_path,
+        )
+        assert result == 3
+
+    def test_naive_expires_at_is_still_accepted_at_write_time(self, tmp_path):
+        """A naive (no-offset) ISO timestamp parses fine and must still be
+        accepted for registration -- only genuinely unparseable values are
+        rejected. _is_expired's naive-as-UTC handling covers the rest."""
+        now = datetime.now(timezone.utc)
+        naive_future = (now + timedelta(days=7)).replace(tzinfo=None).isoformat()
+        reg = register_override(
+            "min_cluster_size", 3,
+            prior=2, proposed_by="test", approved_via="test",
+            expires_at=naive_future, _now=now, _store_root=tmp_path,
+        )
+        assert reg["state"] == "active"
+        assert reg["expires_at"] == naive_future
+
+    def test_existing_aware_expiry_callers_are_unaffected(self, tmp_path):
+        """Regression guard: the ordinary aware-ISO caller shape used
+        throughout the rest of the test suite must be unaffected."""
+        now = datetime.now(timezone.utc)
+        expires = (now + timedelta(days=7)).isoformat()
+        reg = register_override(
+            "min_cluster_size", 3,
+            prior=2, proposed_by="test", approved_via="test",
+            expires_at=expires, _now=now, _store_root=tmp_path,
+        )
+        assert reg["state"] == "active"
+        assert resolve_knob("min_cluster_size", default=2, _store_root=tmp_path) == 3

--- a/tests/plugins/memory/test_memory_os_llm_edge_proposer.py
+++ b/tests/plugins/memory/test_memory_os_llm_edge_proposer.py
@@ -1,0 +1,367 @@
+"""llm_edge_proposer.py — two verified defect fixes.
+
+D1: ``_call_llm``'s confidence parsing (``float(parsed.get("confidence", 0.0))``)
+had no guard. A model reply with a non-numeric confidence (``"high"``) raised
+ValueError; ``null`` raised TypeError. Either propagated out of ``_call_llm``
+and out of ``run_llm_proposer``'s pair loop *after* some edges from earlier
+pairs in the same run had already been written via ``write_governed_edge`` —
+ending the run with no summary, no audit entry, and a partially-processed
+pair set (the next run re-pays the LLM cost for pairs it never reached).
+Fixed by typing the failure the way fact_judge.py (the project's reference
+governed-LLM-lane implementation) types LLM-reply failures: a typed failure
+dict, never a raised exception.
+
+D2: ``run_llm_proposer``'s ``batch: bool = True`` parameter was documented as
+"batches all pairs into a single LLM call (cheaper)" but never read anywhere
+in the function body — every run made sequential per-pair calls regardless.
+No caller ever passed it (grepped repo-wide: only cognitive_loop.py calls
+run_llm_proposer, without ``batch=``), so it was removed rather than wired
+up. Additionally, the summary hardcoded ``"status": "ok"`` and never counted
+``_call_llm``'s four failure outcomes, so ``pair_count=100, proposed_count=0``
+was byte-identical whether the judge legitimately found no relationships or
+every call returned garbage. Fixed by tallying every ``_call_llm`` outcome
+into the summary (``llm_call_count`` / ``llm_call_ok_count`` /
+``llm_call_failure_count`` / ``llm_call_failure_reasons``), a closed-set
+``outcome`` value (no_eligible_pairs / llm_degraded / no_relationships_found
+/ produced), and a ``status`` that turns "degraded" once any call failed.
+
+All fixtures drive the real producer: ``_call_llm`` / ``run_llm_proposer``
+are exercised through a monkeypatched ``_call_hermes_runtime_model`` that
+returns real-shaped response strings (JSON text, empty string) — never by
+constructing hand-written result dicts, per the project's counterfactual
+rule that hand fixtures let counterfactuals pass vacuously.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+import pytest
+
+from plugins.memory.memory_os import llm_edge_proposer
+from plugins.memory.memory_os.audit import read_audit_records
+from plugins.memory.memory_os.index import MemoryOSIndex
+from plugins.memory.memory_os.llm_edge_proposer import _call_llm, run_llm_proposer
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _store(tmp_path) -> tuple[MemoryOSStore, MemoryOSIndex]:
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="llm-edge-proposer-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    index = MemoryOSIndex(roots)
+    index.rebuild_from_store(store)
+    return store, index
+
+
+def _seed_canonical_crystallized(store: MemoryOSStore, records: list[dict[str, Any]]) -> None:
+    """Write canonical crystallized record files directly so index rebuild
+    picks them up (mirrors test_memory_os_graph_layer.py's producer-backed
+    seed helper — ``store.append_crystallized_record`` is the direct
+    file-append primitive and does not require canonical-write authority,
+    unlike ``CrystallizedMemoryService.write_approved_record``)."""
+    for rec in records:
+        frontmatter = {
+            "schema_version": "memory-os.crystallized.v0",
+            "id": rec["id"],
+            "kind": rec.get("kind", "test"),
+            "created_at": rec.get("created_at", "2026-06-01T00:00:00Z"),
+            "approved_by": "owner",
+            "approved_at": rec.get("created_at", "2026-06-01T00:00:00Z"),
+            "approval_purpose": "test",
+            "approval_note": "test seed",
+            "source_event_ids": rec.get("source_event_ids", []),
+            "tags": rec.get("tags", []),
+            "sensitivity": "private",
+            "hindsight_indexed": False,
+            "bridge_state": "active",
+        }
+        body = rec.get("body", "test crystallized record body")
+        store.append_crystallized_record("test_llm_edge_proposer.md", frontmatter, body)
+
+
+def _ok_runtime(config: dict[str, Any]) -> dict[str, Any]:
+    """Stand-in for ``_resolve_hermes_default_runtime`` reporting the LLM
+    runtime as available, so run_llm_proposer proceeds past its availability
+    guard instead of hitting the (already-tested, unrelated) skip branch."""
+    return {"ok": True, "model": "test-model", "runtime": {"api_mode": "chat_completions"}}
+
+
+def _queued_responses(monkeypatch: pytest.MonkeyPatch, responses: list[str]) -> list[str]:
+    """Monkeypatch _call_hermes_runtime_model (the real producer surface
+    _call_llm consumes) to return *responses* in call order. Records prompts
+    seen, for assertions that don't care about exact per-pair mapping."""
+    queue = list(responses)
+    prompts_seen: list[str] = []
+
+    def _fake(prompt: str, config: dict[str, Any]) -> str:
+        prompts_seen.append(prompt)
+        return queue.pop(0) if queue else ""
+
+    monkeypatch.setattr(llm_edge_proposer, "_call_hermes_runtime_model", _fake)
+    return prompts_seen
+
+
+_VALID_REFINES_JSON = json.dumps(
+    {"relation_type": "refines", "confidence": 0.8, "reasoning": "B extends A"}
+)
+_VALID_NONE_JSON = json.dumps(
+    {"relation_type": "none", "confidence": 0.0, "reasoning": "unrelated"}
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# D1 — _call_llm confidence guard (unit level)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_call_llm_non_numeric_confidence_returns_typed_failure(monkeypatch):
+    """D1 counterfactual: {"confidence": "high"} used to raise ValueError out
+    of the unguarded float() call. Must now return a typed failure dict."""
+    monkeypatch.setattr(
+        llm_edge_proposer, "_call_hermes_runtime_model",
+        lambda prompt, config: json.dumps(
+            {"relation_type": "refines", "confidence": "high", "reasoning": "x"}
+        ),
+    )
+    result = _call_llm({"kind": "note", "body": "a"}, {"kind": "note", "body": "b"})
+    assert result["outcome"] == "invalid_confidence"
+    assert result["relation_type"] == "none"
+    assert result["confidence"] == 0.0
+
+
+def test_call_llm_null_confidence_returns_typed_failure(monkeypatch):
+    """D1 counterfactual: {"confidence": null} used to raise TypeError out of
+    the unguarded float(None) call. Must now return a typed failure dict."""
+    monkeypatch.setattr(
+        llm_edge_proposer, "_call_hermes_runtime_model",
+        lambda prompt, config: '{"relation_type": "refines", "confidence": null, "reasoning": "x"}',
+    )
+    result = _call_llm({"kind": "note", "body": "a"}, {"kind": "note", "body": "b"})
+    assert result["outcome"] == "invalid_confidence"
+    assert result["relation_type"] == "none"
+    assert result["confidence"] == 0.0
+
+
+def test_call_llm_valid_confidence_still_succeeds(monkeypatch):
+    """Regression guard: the D1 try/except must not swallow legitimate
+    numeric (including numeric-string) confidence values."""
+    monkeypatch.setattr(
+        llm_edge_proposer, "_call_hermes_runtime_model",
+        lambda prompt, config: json.dumps(
+            {"relation_type": "refines", "confidence": "0.7", "reasoning": "ok"}
+        ),
+    )
+    result = _call_llm({"kind": "note", "body": "a"}, {"kind": "note", "body": "b"})
+    assert result["outcome"] == "ok"
+    assert result["relation_type"] == "refines"
+    assert result["confidence"] == pytest.approx(0.7)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# D1 — run_llm_proposer survives a bad-confidence pair (run level)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_run_llm_proposer_survives_invalid_confidence_and_writes_audit(tmp_path, monkeypatch):
+    """D1 counterfactual at the run level: before the fix, a single
+    bad-confidence pair raised out of the pair loop entirely — no summary,
+    no audit entry, next run re-pays the LLM cost for unreached pairs. Must
+    now finish cleanly with a summary and a written audit entry."""
+    store, index = _store(tmp_path)
+    _seed_canonical_crystallized(store, [
+        {"id": "cry_conf_a", "created_at": "2026-06-01T10:00:00Z", "body": "Record A body."},
+        {"id": "cry_conf_b", "created_at": "2026-06-01T11:00:00Z", "body": "Record B body."},
+    ])
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(llm_edge_proposer, "_resolve_hermes_default_runtime", _ok_runtime)
+    _queued_responses(monkeypatch, [
+        json.dumps({"relation_type": "refines", "confidence": "high", "reasoning": "x"}),
+    ])
+
+    audit_path = store.roots.audit_path
+    result = run_llm_proposer(str(index.roots.index_path), index=index, audit_path=str(audit_path))
+
+    assert result["pair_count"] == 1
+    assert result["proposed_count"] == 0
+    assert result["llm_call_count"] == 1
+    assert result["llm_call_failure_count"] == 1
+    assert result["llm_call_failure_reasons"] == {"invalid_confidence": 1}
+    assert result["status"] == "degraded"
+
+    audit_actions = [rec.get("action") for rec in read_audit_records(audit_path)]
+    assert "llm_edge_proposer_run" in audit_actions, (
+        f"run must still write its audit entry after an in-pair failure: {audit_actions}"
+    )
+
+
+def test_run_llm_proposer_continues_past_failure_to_later_pairs(tmp_path, monkeypatch):
+    """D1 counterfactual: a failure on one pair must not stop the loop from
+    reaching and correctly processing the remaining pairs in the same run."""
+    store, index = _store(tmp_path)
+    _seed_canonical_crystallized(store, [
+        {"id": "cry_multi_a", "created_at": "2026-06-01T10:00:00Z", "body": "Record A body."},
+        {"id": "cry_multi_b", "created_at": "2026-06-01T11:00:00Z", "body": "Record B body."},
+        {"id": "cry_multi_c", "created_at": "2026-06-01T12:00:00Z", "body": "Record C body."},
+    ])
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(llm_edge_proposer, "_resolve_hermes_default_runtime", _ok_runtime)
+    # 3 records -> 3 pairs. One bad-confidence failure, one legitimate
+    # "none", one real relationship that must still get written.
+    _queued_responses(monkeypatch, [
+        json.dumps({"relation_type": "refines", "confidence": "high", "reasoning": "x"}),
+        _VALID_NONE_JSON,
+        _VALID_REFINES_JSON,
+    ])
+
+    result = run_llm_proposer(str(index.roots.index_path), index=index)
+
+    assert result["pair_count"] == 3
+    assert result["llm_call_count"] == 3
+    assert result["llm_call_ok_count"] == 2
+    assert result["llm_call_failure_count"] == 1
+    assert result["proposed_count"] == 1, (
+        "the failure on one pair must not prevent a real edge from a later pair"
+    )
+    assert result["status"] == "degraded"
+    assert result["outcome"] == "produced"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# D2a — dead `batch` parameter removed
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_run_llm_proposer_batch_param_removed():
+    """D2a counterfactual: `batch` was documented ("batches all pairs into a
+    single LLM call (cheaper)") but never read in the function body, and no
+    caller passed it (grepped repo-wide: only cognitive_loop.py calls
+    run_llm_proposer, never with batch=). Removed rather than wired up.
+    Passing it must now raise TypeError, proving the parameter is actually
+    gone rather than merely undocumented."""
+    sig = inspect.signature(run_llm_proposer)
+    assert "batch" not in sig.parameters
+
+    with pytest.raises(TypeError):
+        run_llm_proposer("/nonexistent/index.db", index=None, batch=True)  # type: ignore[call-arg]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# D2b — per-run _call_llm outcome accounting distinguishes garbage from
+# legitimate "no relationships found"
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_garbage_run_distinguishable_from_legitimate_none_run(tmp_path, monkeypatch):
+    """D2b counterfactual (the acceptance criterion, verbatim): a run where
+    every LLM call returns garbage must be distinguishable from a run where
+    the judge genuinely found no relationships, using the returned summary
+    alone. Before the fix pair_count/proposed_count were byte-identical in
+    both cases and status was an unconditional "ok" — this test proves the
+    two runs now diverge on status/outcome/llm_call_failure_count while
+    pair_count/proposed_count stay identical (that's precisely why those two
+    counters could never carry this distinction on their own)."""
+    monkeypatch.setattr(llm_edge_proposer, "_resolve_hermes_default_runtime", _ok_runtime)
+
+    # Run A: every call returns garbage (empty response -> empty_llm_response).
+    store_a, index_a = _store(tmp_path / "a")
+    _seed_canonical_crystallized(store_a, [
+        {"id": "cry_garbage_a", "created_at": "2026-06-01T10:00:00Z", "body": "A"},
+        {"id": "cry_garbage_b", "created_at": "2026-06-01T11:00:00Z", "body": "B"},
+    ])
+    index_a.rebuild_from_store(store_a)
+    _queued_responses(monkeypatch, [""])
+    result_garbage = run_llm_proposer(str(index_a.roots.index_path), index=index_a)
+
+    # Run B: LLM legitimately parses and reports no relationship.
+    store_b, index_b = _store(tmp_path / "b")
+    _seed_canonical_crystallized(store_b, [
+        {"id": "cry_legit_a", "created_at": "2026-06-01T10:00:00Z", "body": "A"},
+        {"id": "cry_legit_b", "created_at": "2026-06-01T11:00:00Z", "body": "B"},
+    ])
+    index_b.rebuild_from_store(store_b)
+    _queued_responses(monkeypatch, [_VALID_NONE_JSON])
+    result_legit = run_llm_proposer(str(index_b.roots.index_path), index=index_b)
+
+    # The two counters the pre-fix summary relied on are identical...
+    assert result_garbage["pair_count"] == result_legit["pair_count"] == 1
+    assert result_garbage["proposed_count"] == result_legit["proposed_count"] == 0
+
+    # ...but the summary as a whole is not: status/outcome/failure counters
+    # diverge, so a reader can tell the two runs apart without re-running
+    # anything or reading source.
+    assert result_garbage["status"] == "degraded"
+    assert result_garbage["outcome"] == "llm_degraded"
+    assert result_garbage["llm_call_failure_count"] == 1
+    assert result_garbage["llm_call_failure_reasons"] == {"empty_llm_response": 1}
+
+    assert result_legit["status"] == "ok"
+    assert result_legit["outcome"] == "no_relationships_found"
+    assert result_legit["llm_call_failure_count"] == 0
+    assert result_legit["llm_call_failure_reasons"] == {}
+
+
+def test_run_llm_proposer_all_failure_reason_kinds_counted(tmp_path, monkeypatch):
+    """D2b: each of _call_llm's four pre-existing failure outcomes plus D1's
+    new invalid_confidence outcome must be tallied by type, not just totaled."""
+    store, index = _store(tmp_path)
+    _seed_canonical_crystallized(store, [
+        {"id": f"cry_reason_{n}", "created_at": f"2026-06-01T{10 + n:02d}:00:00Z", "body": f"body {n}"}
+        for n in range(4)
+    ])
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(llm_edge_proposer, "_resolve_hermes_default_runtime", _ok_runtime)
+    # 4 records -> 6 pairs. Feed 6 distinct outcomes: 4 typed failures +
+    # 1 legitimate "none" + 1 real relationship.
+    _queued_responses(monkeypatch, [
+        "",                                    # empty_llm_response
+        "not json at all {{{",                 # parse_failed
+        "[1, 2, 3]",                            # not_a_dict
+        json.dumps({"relation_type": "refines", "confidence": "bad", "reasoning": "x"}),  # invalid_confidence
+        _VALID_NONE_JSON,
+        _VALID_REFINES_JSON,
+    ])
+
+    result = run_llm_proposer(str(index.roots.index_path), index=index)
+
+    assert result["pair_count"] == 6
+    assert result["llm_call_count"] == 6
+    assert result["llm_call_ok_count"] == 2
+    assert result["llm_call_failure_count"] == 4
+    assert result["llm_call_failure_reasons"] == {
+        "empty_llm_response": 1,
+        "parse_failed": 1,
+        "not_a_dict": 1,
+        "invalid_confidence": 1,
+    }
+    assert result["status"] == "degraded"
+    assert result["proposed_count"] == 1
+
+
+def test_run_llm_proposer_status_ok_when_no_failures(tmp_path, monkeypatch):
+    """Regression guard: a fully healthy run must not be marked degraded."""
+    store, index = _store(tmp_path)
+    _seed_canonical_crystallized(store, [
+        {"id": "cry_healthy_a", "created_at": "2026-06-01T10:00:00Z", "body": "A"},
+        {"id": "cry_healthy_b", "created_at": "2026-06-01T11:00:00Z", "body": "B"},
+    ])
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(llm_edge_proposer, "_resolve_hermes_default_runtime", _ok_runtime)
+    _queued_responses(monkeypatch, [_VALID_REFINES_JSON])
+
+    result = run_llm_proposer(str(index.roots.index_path), index=index)
+
+    assert result["status"] == "ok"
+    assert result["outcome"] == "produced"
+    assert result["llm_call_failure_count"] == 0
+    assert result["llm_call_failure_reasons"] == {}
+    assert result["proposed_count"] == 1

--- a/tests/plugins/memory/test_memory_os_owner_actions.py
+++ b/tests/plugins/memory/test_memory_os_owner_actions.py
@@ -4751,6 +4751,121 @@ def test_digest_fyi_includes_candidate_aggregation_when_available(tmp_path):
     assert aggr_item["source_module"] == "candidate_aggregation"
 
 
+# ── 2026-08-15: compaction_skip_reason wiring ───────────────────────────────
+#
+# Two explicit key-picking whitelists dropped compaction_skip_reason after it
+# was added to run_candidate_aggregation_lane's return value:
+#   layer 1 -- write_candidate_aggregation_status's `record` dict
+#             (crystallized.py, builds the ledger row written via
+#             append_governed_jsonl)
+#   layer 2 -- _candidate_aggregation_status_block's returned dict
+#             (owner_actions.py, reads the ledger back for the digest)
+# A third point (the FYI summary string builder, also in owner_actions.py)
+# renders layer 2's dict into the actual text an owner reads -- "the
+# artifact a reader actually opens" for this counterfactual. Worse than a
+# drop, a THIRD-file misreport (scripts/memory_os_candidate_aggregation_
+# lane.py's run_status/reason derivation) let a skipped compaction
+# masquerade as a healthy "no_triage_actions"/"triaged" tick, since both
+# report compacted_count=0 -- covered separately in
+# tests/scripts/test_memory_os_candidate_aggregation_lane.py, next to that
+# script's own producers.
+
+
+def test_compaction_skip_reason_survives_end_to_end_to_the_digest(tmp_path, monkeypatch):
+    """Counterfactual: compaction_skip_reason must survive from the lane's
+    REAL return value (a genuine read_effective_candidates failure, not a
+    hand-written summary dict -- Section W: build fixtures via the real
+    producer), through both whitelists, to the rendered owner-digest FYI
+    line. Each whitelist is proven independently load-bearing by reverting
+    it alone (see the two hand-revert cycles in the dispatch report) --
+    only reverting BOTH would look identical to reverting one if the test
+    only checked the final digest text, so this also asserts the
+    intermediate ledger and status-block values."""
+    import plugins.modules.governance.candidate_aggregation as aggregation
+    from plugins.memory.memory_os.crystallized import (
+        latest_candidate_aggregation_status,
+        write_candidate_aggregation_status,
+    )
+
+    store = _store(tmp_path)
+
+    def _raise_view_failure(_store):
+        raise RuntimeError("synthetic effective-view failure")
+
+    monkeypatch.setattr(aggregation, "read_effective_candidates", _raise_view_failure)
+    result = aggregation.run_candidate_aggregation_lane(store, execution_gate_envelope_id="")
+    assert result["compaction_skip_reason"] == "effective_view_unavailable", (
+        "sanity: the lane itself must produce the reason, otherwise this "
+        f"test proves nothing about the wiring. result={result}"
+    )
+
+    write_candidate_aggregation_status(store, summary=result)
+
+    ledger = latest_candidate_aggregation_status(store)
+    assert ledger is not None
+    assert ledger["compaction_skip_reason"] == "effective_view_unavailable", (
+        "layer 1 (write_candidate_aggregation_status's record whitelist, "
+        "crystallized.py) dropped compaction_skip_reason"
+    )
+
+    status = owner_review_status_report(store)
+    block = status["candidate_aggregation"]
+    assert block["compaction_skip_reason"] == "effective_view_unavailable", (
+        "layer 2 (_candidate_aggregation_status_block's returned-dict "
+        "whitelist, owner_actions.py) dropped compaction_skip_reason"
+    )
+
+    preview = owner_review_digest_preview(store)
+    fyi_items = preview.get("sections", {}).get("fyi", [])
+    aggr_item = next(
+        (it for it in fyi_items if it.get("target_id") == "candidate_aggregation"),
+        None,
+    )
+    assert aggr_item is not None
+    assert "compaction_skipped=effective_view_unavailable" in aggr_item["summary"], (
+        "the artifact a reader actually opens (the digest FYI line) does "
+        f"not surface the skip reason: {aggr_item['summary']!r}"
+    )
+
+
+def test_healthy_tick_digest_line_has_no_skip_reason_suffix(tmp_path):
+    """A healthy tick (compaction ran, nothing set compaction_skip_reason)
+    must render the byte-identical digest line as before this field
+    existed -- the skip-reason clause is appended ONLY when the reason is
+    set, never as an empty/'none' placeholder."""
+    from plugins.memory.memory_os.crystallized import write_candidate_aggregation_status
+
+    store = _store(tmp_path)
+    write_candidate_aggregation_status(
+        store,
+        summary={
+            "candidates_read": 10,
+            "pending": 2,
+            "already_triaged": 8,
+            "promoted_count": 3,
+            "rejected_demoted_count": 1,
+            "demoted_count": 2,
+            "fleeting_count": 2,
+            "compacted_count": 4,
+            # No compaction_skip_reason key at all -- matches a summary
+            # dict produced before this field existed.
+        },
+    )
+
+    preview = owner_review_digest_preview(store)
+    fyi_items = preview.get("sections", {}).get("fyi", [])
+    aggr_item = next(
+        (it for it in fyi_items if it.get("target_id") == "candidate_aggregation"),
+        None,
+    )
+    assert aggr_item is not None
+    assert aggr_item["summary"] == (
+        "聚合上次运行: promoted=3; rejected_demoted=1; demoted=2; "
+        "fleeting=2; compacted=4"
+    ), aggr_item["summary"]
+    assert "compaction_skipped" not in aggr_item["summary"]
+
+
 # ── P2 fix: _review_consequence / _review_question / _review_suggested_action ──
 # must not lie for provisional_crystallized_record / knob_override, whose
 # approval DOES change state (see owner_actions.py ~3639-3651 apply_owner_action

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -9,7 +9,7 @@ from plugins.memory.memory_os.fixtures import (
     build_working_item,
 )
 from plugins.memory.memory_os.index import MemoryOSIndex
-from plugins.memory.memory_os.prefetch import _budget_keep_priority, _build_prefetch_sections, _continuity_bridge_lines, _crystallized_lines, _event_lines, _fit_budget, _floor_match_score, _recent_cross_session_lines, _tokenize_for_floor_match, build_prefetch, build_prefetch_with_observability, continuity_selector_report
+from plugins.memory.memory_os.prefetch import _budget_keep_priority, _build_prefetch_sections, _continuity_bridge_lines, _crystallized_lines, _deep_reflection_card_is_safe, _event_lines, _fit_budget, _floor_match_score, _recent_cross_session_lines, _tokenize_for_floor_match, build_prefetch, build_prefetch_with_observability, continuity_selector_report
 from plugins.memory.memory_os.roots import MemoryOSRoots
 from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, WORKING_SCHEMA_VERSION, EventEnvelope
 from plugins.memory.memory_os.store import MemoryOSStore
@@ -811,6 +811,89 @@ def test_prefetch_ignores_deep_reflection_when_disabled_or_unsafe(tmp_path):
 
     assert "Conversation Carryover" not in context
     assert "hidden analysis" not in context
+
+
+def test_deep_reflection_card_naive_future_expiry_does_not_raise():
+    """Rule-5 sweep: datetime.fromisoformat("2026-12-31") is timezone-naive;
+    comparing it against datetime.now(timezone.utc) raises TypeError, which
+    the bare `except ValueError` does not catch, so it used to escape this
+    function on the per-turn prefetch path. A naive-but-unexpired timestamp
+    must not raise, and the card must still be treated as safe (matches the
+    aware-timestamp behavior for a future expiry).
+
+    Counterfactual: reverting to `except ValueError` alone (or dropping the
+    naive -> aware normalization) makes this raise TypeError instead of
+    returning True.
+    """
+    card = {
+        "text": "naive-expiry card should survive without raising",
+        "source_refs": ["event:evt_naive"],
+        "expires_at": "2099-01-01",
+    }
+    assert _deep_reflection_card_is_safe(card) is True
+
+
+def test_deep_reflection_card_naive_past_expiry_is_treated_as_expired():
+    """Same naive-parsing hazard, past date: before the fix this also raised
+    TypeError (the comparison itself raises regardless of which side is
+    larger); after the fix it must return False (card excluded), preserving
+    this call site's existing intent that unparseable/expired input is
+    treated as unsafe -- unlike knob_overrides._is_expired's fail-open
+    contract, this function fails closed by design.
+    """
+    card = {
+        "text": "naive-expiry card in the past",
+        "source_refs": ["event:evt_naive_past"],
+        "expires_at": "2000-01-01",
+    }
+    assert _deep_reflection_card_is_safe(card) is False
+
+
+def test_prefetch_deep_reflection_naive_future_expiry_does_not_crash_the_turn(tmp_path):
+    """End-to-end version of the two unit tests above, through the real
+    per-turn path (build_prefetch -> _deep_reflection_lines ->
+    _deep_reflection_card_is_safe), which is where the TypeError actually
+    surfaced -- unhandled, since _deep_reflection_lines does not wrap the
+    per-card safety check in its own try/except.
+    """
+    store = _store(tmp_path)
+    event = EventEnvelope.from_dict(
+        {
+            **build_event(seed=84, profile="memoryos-test"),
+            "source": "telegram",
+            "kind": "conversation_turn",
+            "summary": "Owner tested naive expiry handling end to end.",
+        }
+    )
+    store.append_event(event)
+    module_root = tmp_path / "system-modules" / "deep_reflection"
+    module_root.mkdir(parents=True)
+    (module_root / "config.json").write_text(
+        '{"injection_mode": "auto_bounded"}\n', encoding="utf-8",
+    )
+    (module_root / "injection").mkdir()
+    (module_root / "injection" / "current.json").write_text(
+        (
+            "{\n"
+            '  "schema_version": "hermes.deep_reflection.injection.v0",\n'
+            '  "selected_cards": [\n'
+            "    {\n"
+            f'      "source_refs": ["event:{event.id}"],\n'
+            '      "text": "Naive-expiry card content should remain visible without an error.",\n'
+            '      "expires_at": "2099-01-01",\n'
+            '      "instruction_like_hit": false,\n'
+            '      "mechanism_terms_hit": false\n'
+            "    }\n"
+            "  ]\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    context = build_prefetch("继续刚才的聊天", budget_chars=2200, store=store, index=None)
+
+    assert "### Conversation Carryover" in context
+    assert "Naive-expiry card content should remain visible without an error" in context
 
 
 def test_provider_status_distinguishes_candidates_from_approved_crystallized_records(tmp_path):
@@ -3591,3 +3674,180 @@ def test_rrf_union_returns_membership_set_capped_at_top_n():
     assert isinstance(result, set)
     assert len(result) == 3
     assert "b" in result  # appears in both lists → highest fused score
+
+
+# ── Attribution hole: Recent Cross-Session had no source_ids parameter ─────
+
+
+def test_recent_cross_session_populates_source_ids(tmp_path):
+    """source_ids out-param must carry event:<id> refs for the disclosure audit.
+
+    Counterfactual: before this fix, _recent_cross_session_lines had no
+    source_ids parameter at all -- calling with source_ids= raises TypeError,
+    which is exactly why its disclosure row could carry no source IDs even in
+    principle (the other half of attribution item 16a for this section).
+    """
+    store = _store(tmp_path)
+    session_id = "sess_ids_current"
+    other_session_id = "sess_ids_other"
+    event_id = "evt_ids_001"
+
+    candidates_path = store.roots.crystallized_root / "candidates.jsonl"
+    candidates_path.parent.mkdir(parents=True, exist_ok=True)
+    candidates_path.write_text(
+        json.dumps({
+            "candidate_id": "cand_ids_001",
+            "kind": "moment",
+            "body": "test",
+            "source_event_ids": [event_id],
+            "tags": [],
+            "sensitivity": "private",
+            "bridge_state": "inner_drive_candidate",
+        }, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    event = EventEnvelope(
+        schema_version=EVENT_SCHEMA_VERSION,
+        id=event_id,
+        ts=(datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(),
+        profile="test",
+        source="test",
+        kind="conversation_turn",
+        summary="cross session content for source id test",
+        safe_ref={"session_id": other_session_id},
+        tags=[],
+    )
+    store.append_event(event)
+
+    source_ids: list[str] = []
+    lines = _recent_cross_session_lines(
+        store,
+        session_id=session_id,
+        source_ids=source_ids,
+    )
+    assert lines, "expected the event to surface"
+    assert source_ids == [f"event:{event_id}"]
+
+
+def test_recent_cross_session_budget_priority_is_explicit_and_ordered(tmp_path):
+    """Recent Cross-Session must not silently fall through to the shared
+    default (50) and tie with Crystallized Review Candidates under budget
+    pressure -- it needs its own, deliberately chosen rank.
+
+    Counterfactual: before this fix, _budget_keep_priority("Recent
+    Cross-Session") returned the bare default of 50, which EQUALS
+    "Crystallized Review Candidates" -- the strict ordering chain below
+    fails on that tie (50 < 50 is False).
+    """
+    assert _budget_keep_priority("Recent Cross-Session") == 55
+    assert (
+        _budget_keep_priority("Crystallized Review Candidates")
+        < _budget_keep_priority("Recent Cross-Session")
+        < _budget_keep_priority("Crystallized Memory")
+    )
+
+
+def test_candidate_lines_dedups_duplicate_queue_rows_to_latest(tmp_path):
+    """A candidate_id with multiple raw queue rows (re-triage/update) must be
+    scored and emitted at most once, using the latest row's content.
+
+    append_candidate_queue itself dedups at write time, so a duplicate row
+    is constructed directly (mirrors how a hand-edited or legacy-imported
+    queue can carry more than one row for the same candidate_id).
+
+    Counterfactual: without the latest-row-per-candidate_id dedup, both rows
+    survive the excluded_ids filter (which only removes terminal candidates,
+    not duplicates) and both get emitted -- two lines for one candidate_id.
+    """
+    from plugins.memory.memory_os.prefetch import _candidate_lines
+
+    store = _store(tmp_path)
+    candidates_path = store.roots.crystallized_root / "candidates.jsonl"
+    candidates_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "candidate_id": "cand_dup_test",
+            "kind": "moment",
+            "body": "OLD_BODY_MARKER_1 stale candidate content",
+            "source_event_ids": ["evt_dup_1"],
+            "tags": [],
+            "sensitivity": "private",
+            "bridge_state": "inner_drive_candidate",
+        },
+        {
+            "candidate_id": "cand_dup_test",
+            "kind": "moment",
+            "body": "NEW_BODY_MARKER_2 latest candidate content",
+            "source_event_ids": ["evt_dup_1"],
+            "tags": [],
+            "sensitivity": "private",
+            "bridge_state": "inner_drive_candidate",
+        },
+    ]
+    candidates_path.write_text(
+        "\n".join(json.dumps(row, ensure_ascii=False) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+    lines = _candidate_lines(store, query="candidate 候选", seen=set(), source_ids=[])
+
+    matches = [line for line in lines if "cand_dup_test" in line]
+    assert len(matches) == 1, (
+        f"expected exactly one line for a duplicated candidate_id, got: {matches}"
+    )
+    assert "NEW_BODY_MARKER_2" in matches[0]
+    assert "OLD_BODY_MARKER_1" not in matches[0]
+
+
+def test_last_continuity_freshness_signature_read_is_bounded(tmp_path, monkeypatch):
+    """The tail read must be bounded at the I/O layer, not just at the
+    line-count-kept-after-parsing layer.
+
+    Counterfactual: the pre-fix implementation called Path.read_text() to
+    pull in the WHOLE file before slicing [-20:]. This test forbids
+    Path.read_text on the target file; the pre-fix code path would hit the
+    forbidden call, get caught by the function's fail-open `except Exception:
+    return None`, and this assertion (expecting the real signature) would
+    fail.
+    """
+    from pathlib import Path
+
+    from plugins.memory.memory_os.continuity import continuity_freshness_signature
+    from plugins.memory.memory_os.prefetch import _last_continuity_freshness_signature
+
+    path = tmp_path / "continuity_freshness.jsonl"
+    filler_record = {
+        "session_id": "filler",
+        "current_task_object_id": "filler-task",
+        "current_task_revision": 0,
+        "current_task_grade": "unknown",
+        "unknown_grade_count": 0,
+    }
+    real_record = {
+        "session_id": "s-real",
+        "current_task_object_id": "task-9",
+        "current_task_revision": 3,
+        "current_task_grade": "fresh",
+        "unknown_grade_count": 0,
+    }
+    filler_line = json.dumps(filler_record, ensure_ascii=False)
+    with path.open("w", encoding="utf-8") as fh:
+        for _ in range(20_000):  # ~2MB: far bigger than any bounded tail window
+            fh.write(filler_line + "\n")
+        fh.write(json.dumps(real_record, ensure_ascii=False) + "\n")
+
+    original_read_text = Path.read_text
+
+    def _forbid_read_text(self, *args, **kwargs):
+        if self == path:
+            raise AssertionError(
+                "read_text must not be called on the ledger -- the tail read "
+                "must be bounded at the I/O layer, not whole-file"
+            )
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _forbid_read_text)
+
+    result = _last_continuity_freshness_signature(path)
+    assert result == continuity_freshness_signature(real_record)

--- a/tests/plugins/memory/test_memory_os_prefetch.py
+++ b/tests/plugins/memory/test_memory_os_prefetch.py
@@ -99,6 +99,70 @@ def test_prefetch_records_substrate_shadow_recall_without_injecting_fact_or_quer
     assert ledger_record["substrate_snapshot_id"] == "hindsight:bank:v1"
 
 
+def test_prefetch_records_shadow_row_when_all_providers_fail_with_zero_facts(tmp_path):
+    store = _store(tmp_path)
+
+    build_prefetch(
+        "ALL_PROVIDERS_FAILED_QUERY",
+        budget_chars=2200,
+        store=store,
+        index=None,
+        substrate_recall_report={
+            "schema_version": "memory-os.substrate_recall.v0",
+            "query_class": "shadow",
+            "selected_provider": "deterministic_fallback",
+            "facts": [],
+            "authoritative": False,
+            "external_authoritative_count": 0,
+            "local_first_authority_preserved": True,
+            "recall_llm_triggered": False,
+            "fallback_triggered": True,
+            "provider_error_count": 2,
+            "provider_errors": [
+                {"provider": "hindsight", "stage": "health", "error_type": "RuntimeError"},
+                {"provider": "hindsight", "stage": "recall", "error_type": "TimeoutError"},
+            ],
+        },
+    )
+
+    shadow_path = store.roots.memory_os_root / "system" / "substrate_recall_shadow.jsonl"
+    assert shadow_path.exists(), "an all-providers-failed turn must leave evidence even with zero facts"
+    shadow_record = json.loads(shadow_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert shadow_record["fact_count"] == 0
+    assert shadow_record["provider_error_count"] == 2
+    assert shadow_record["provider_errors"] == [
+        {"provider": "hindsight", "stage": "health", "error_type": "RuntimeError"},
+        {"provider": "hindsight", "stage": "recall", "error_type": "TimeoutError"},
+    ]
+
+
+def test_prefetch_writes_no_shadow_row_for_quiet_turn(tmp_path):
+    store = _store(tmp_path)
+
+    build_prefetch(
+        "QUIET_TURN_QUERY",
+        budget_chars=2200,
+        store=store,
+        index=None,
+        substrate_recall_report={
+            "schema_version": "memory-os.substrate_recall.v0",
+            "query_class": "shadow",
+            "selected_provider": "deterministic_fallback",
+            "facts": [],
+            "authoritative": False,
+            "external_authoritative_count": 0,
+            "local_first_authority_preserved": True,
+            "recall_llm_triggered": False,
+            "fallback_triggered": True,
+            "provider_error_count": 0,
+            "provider_errors": [],
+        },
+    )
+
+    shadow_path = store.roots.memory_os_root / "system" / "substrate_recall_shadow.jsonl"
+    assert not shadow_path.exists()
+
+
 def test_prefetch_injects_active_substrate_recall_as_advisory_context(tmp_path):
     store = _store(tmp_path)
 
@@ -2125,6 +2189,123 @@ def test_recent_cross_session_respects_max_items_cap(tmp_path):
     # With 8 events and knob default 5, we expect 5 items + header.
     assert len(lines) == 6, f"Expected 6 lines (header + 5 items), got {len(lines)}: {lines}"
     assert any("跨会话·待结晶" in line for line in lines)
+
+
+def test_recent_cross_session_query_ranking_keeps_newest_within_tied_score(tmp_path):
+    """Query-aware ranking must be newer-first within a tied score tier.
+
+    `collected` is pre-sorted newest-first before scoring. The comment on
+    the ranking sort says "higher score first, then newer first within same
+    score" -- the sort key must actually deliver that, not silently reverse
+    the tie-break to oldest-first.
+
+    Three events (ONE/TWO/THREE) share the same nonzero token-overlap score
+    against the query, at three different timestamps; a fourth (FOUR) has a
+    strictly lower score. This asserts three things:
+      1. Higher score sorts before lower score.
+      2. Within the tied trio, newer sorts before older (ONE < TWO < THREE).
+      3. With a knob-forced max_items=2, truncation keeps the two NEWEST of
+         the tied trio (ONE, TWO) -- not the two oldest, which is what the
+         pre-fix reversed tie-break would keep.
+
+    The no-query path (pure timestamp order, ignoring score) is asserted
+    unchanged, to prove the fix is scoped to the query-ranking branch only.
+    """
+    store = _store(tmp_path)
+    current_session_id = "sess_tie_current"
+    other_session_id = "sess_tie_other"
+    query = "rollout window capacity plan"
+
+    events = [
+        # (event_id, tag, hours_ago, summary)
+        ("evt_tie_one", "ONE_NEWEST_TAG", 1, f"rollout window capacity update ONE_NEWEST_TAG"),
+        ("evt_tie_two", "TWO_MID_TAG", 3, f"rollout window capacity notes TWO_MID_TAG"),
+        ("evt_tie_three", "THREE_OLDEST_TAG", 6, f"rollout window capacity summary THREE_OLDEST_TAG"),
+        ("evt_tie_four", "FOUR_LOW_TAG", 2, f"rollout only mention FOUR_LOW_TAG"),
+    ]
+
+    candidates_path = store.roots.crystallized_root / "candidates.jsonl"
+    candidates_path.parent.mkdir(parents=True, exist_ok=True)
+    candidate_json = ""
+    for eid, _tag, hours_ago, summary in events:
+        candidate_json += json.dumps({
+            "candidate_id": f"cand_{eid}",
+            "kind": "moment",
+            "body": "test",
+            "source_event_ids": [eid],
+            "tags": [],
+            "sensitivity": "private",
+            "bridge_state": "inner_drive_candidate",
+        }, ensure_ascii=False) + "\n"
+        store.append_event(EventEnvelope(
+            schema_version=EVENT_SCHEMA_VERSION,
+            id=eid,
+            ts=(datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat(),
+            profile="test",
+            source="test",
+            kind="conversation_turn",
+            summary=summary,
+            safe_ref={"session_id": other_session_id},
+            tags=[],
+        ))
+    candidates_path.write_text(candidate_json, encoding="utf-8")
+
+    # ── Query-aware ranking: score tier first, newest-first within tie ──
+    lines_query = _recent_cross_session_lines(
+        store,
+        session_id=current_session_id,
+        query=query,
+    )
+    idx_one = next(i for i, l in enumerate(lines_query) if "ONE_NEWEST_TAG" in l)
+    idx_two = next(i for i, l in enumerate(lines_query) if "TWO_MID_TAG" in l)
+    idx_three = next(i for i, l in enumerate(lines_query) if "THREE_OLDEST_TAG" in l)
+    idx_four = next(i for i, l in enumerate(lines_query) if "FOUR_LOW_TAG" in l)
+    assert idx_one < idx_two < idx_three, (
+        f"Tied-score events must be newest-first (ONE < TWO < THREE), got: {lines_query}"
+    )
+    assert idx_three < idx_four, (
+        f"Lower-score event must sort after the tied higher-score tier, got: {lines_query}"
+    )
+
+    # ── No-query path unchanged: pure newest-first by timestamp ─────────
+    lines_no_query = _recent_cross_session_lines(
+        store,
+        session_id=current_session_id,
+        query="",
+    )
+    tag_order = [
+        next(tag for _eid, tag, _h, _s in events if tag in line)
+        for line in lines_no_query
+        if any(tag in line for _eid, tag, _h, _s in events)
+    ]
+    assert tag_order == ["ONE_NEWEST_TAG", "FOUR_LOW_TAG", "TWO_MID_TAG", "THREE_OLDEST_TAG"], (
+        f"No-query path must stay strict newest-first by ts, got: {tag_order}"
+    )
+
+    # ── Truncation: force max_items=2 via knob override, tied trio only ──
+    override_path = store.roots.memory_os_root / "system" / "knob_overrides.jsonl"
+    override_path.parent.mkdir(parents=True, exist_ok=True)
+    override_path.write_text(
+        json.dumps({
+            "knob": "recent_cross_session_max_items",
+            "override_value": 2,
+            "state": "confirmed",
+        }) + "\n",
+        encoding="utf-8",
+    )
+    lines_truncated = _recent_cross_session_lines(
+        store,
+        session_id=current_session_id,
+        query=query,
+    )
+    joined = "\n".join(lines_truncated)
+    assert "ONE_NEWEST_TAG" in joined and "TWO_MID_TAG" in joined, (
+        f"Truncation must keep the two NEWEST of the tied trio, got: {lines_truncated}"
+    )
+    assert "THREE_OLDEST_TAG" not in joined and "FOUR_LOW_TAG" not in joined, (
+        f"Truncation must drop the oldest tied event and the lower-score event, "
+        f"got: {lines_truncated}"
+    )
 
 
 def test_cross_session_dedup_prevents_duplicate_injection(tmp_path):

--- a/tests/plugins/memory/test_memory_os_runtime.py
+++ b/tests/plugins/memory/test_memory_os_runtime.py
@@ -466,6 +466,83 @@ def test_runtime_policy_source_caps_prevent_cron_batch_from_dominating(tmp_path)
     assert report["candidate_count"] == 1
 
 
+def test_read_state_preserves_persisted_processed_event_ids_compacted_flag(tmp_path):
+    """反事实:_read_state 之前无条件把 processed_event_ids_compacted 写死
+    False(line 337 旧代码),导致该字段结构性地永远无法报告 True — 任何
+    未来的 compactor 把它设为 True 都会在下一次读取时被抹掉。这里模拟
+    一个 processed_event_ids 仍在(非 reverse-migration 分支)但持久化了
+    compacted=True 的 state 文件,验证 _read_state 如实反映而非硬编码。"""
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path))
+    store.initialize()
+    runtime = MemoryOSRuntime(store)
+    state_path = tmp_path / "memory-os" / "runtime" / "heartbeat_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "memory-os.runtime_state.v0",
+                "processed_event_ids": ["evt_seed_1"],
+                "recent_processed_event_ids": ["evt_seed_1"],
+                "processed_event_count_total": 1,
+                "processed_event_ids_compacted": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = runtime._read_state()
+
+    assert state["processed_event_ids_compacted"] is True
+
+
+def test_heartbeat_round_trip_preserves_processed_event_ids_compacted_flag(tmp_path):
+    """反事实(读+写两半合一):_read_state 修好但 heartbeat 写状态时(line
+    216)仍硬编码 False 的话,持久化文件里的 compacted 依旧会被抹回 False。
+    经完整 heartbeat 往返验证两半都修好。"""
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path))
+    store.initialize()
+    runtime = MemoryOSRuntime(store)
+    state_path = tmp_path / "memory-os" / "runtime" / "heartbeat_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "memory-os.runtime_state.v0",
+                "processed_event_ids": ["evt_seed_1"],
+                "recent_processed_event_ids": ["evt_seed_1"],
+                "processed_event_count_total": 1,
+                "processed_event_ids_compacted": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runtime.heartbeat(now=datetime(2026, 5, 23, 1, tzinfo=timezone.utc))
+
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["processed_event_ids_compacted"] is True
+
+
+def test_heartbeat_report_exposes_processed_event_ids_ledger_size(tmp_path):
+    """反事实:heartbeat 报告之前不暴露 processed_event_ids 全量账本的大小
+    (只能手工打开 state 文件才能看到它在无界增长)。修复前该 key 不存在,
+    直接 KeyError。"""
+    provider = load_memory_provider("memory_os")
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli", agent_identity="main")
+    provider.sync_turn("ledger size marker alpha", "stored alpha", session_id="session-1")
+    provider.sync_turn("ledger size marker beta", "stored beta", session_id="session-1")
+    provider.shutdown()
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path))
+
+    first = MemoryOSRuntime(store).heartbeat()
+    assert first["processed_event_ids_ledger_size"] == 2
+
+    second = MemoryOSRuntime(store).heartbeat()
+    # Idempotent heartbeat processes 0 NEW events but the ledger still holds
+    # the full history, so ledger size must not drop back to 0.
+    assert second["processed_event_ids_ledger_size"] == 2
+
+
 # ── _index_health_counts_findings O(1) tests ──────────────────────────
 
 def test_counts_findings_healthy_when_all_match():

--- a/tests/plugins/memory/test_memory_os_substrate_ledger.py
+++ b/tests/plugins/memory/test_memory_os_substrate_ledger.py
@@ -1,7 +1,20 @@
+import json
+
+from plugins.memory.memory_os.cli import _hindsight_substrate_monitor
+from plugins.memory.memory_os.prefetch import _record_substrate_shadow_recall
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
 from plugins.memory.memory_os.substrates.ledger import (
     SubstrateOperationLedger,
     derive_substrate_monitor_fields,
 )
+
+
+def _store(tmp_path):
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    return store
 
 
 def test_monitor_fields_are_derived_from_operation_records(tmp_path):
@@ -58,3 +71,52 @@ def test_monitor_fields_fail_closed_when_raw_retain_is_recorded(tmp_path):
 
     assert fields["raw_retained_count"] == 1
     assert fields["no_raw_retained"] is False
+
+
+def test_provider_errors_reach_shadow_ledger_and_hindsight_substrate_monitor(tmp_path):
+    """End-to-end wiring: SubstrateRouter.recall's provider_error_count /
+    provider_errors must reach a durable shadow-ledger row (prefetch.py
+    ``_record_substrate_shadow_recall``) AND be surfaced by
+    ``hermes memory-os status`` (cli.py ``_hindsight_substrate_monitor``).
+    Before this test, an all-providers-failed turn left no evidence anywhere
+    in this chain.
+    """
+    store = _store(tmp_path)
+
+    _record_substrate_shadow_recall(
+        store=store,
+        query="ALL_PROVIDERS_FAILED_QUERY",
+        report={
+            "schema_version": "memory-os.substrate_recall.v0",
+            "query_class": "shadow",
+            "selected_provider": "deterministic_fallback",
+            "facts": [],
+            "authoritative": False,
+            "external_authoritative_count": 0,
+            "local_first_authority_preserved": True,
+            "recall_llm_triggered": False,
+            "fallback_triggered": True,
+            "provider_error_count": 2,
+            "provider_errors": [
+                {"provider": "hindsight", "stage": "health", "error_type": "RuntimeError"},
+                {"provider": "hindsight", "stage": "recall", "error_type": "TimeoutError"},
+            ],
+        },
+    )
+
+    shadow_path = store.roots.memory_os_root / "system" / "substrate_recall_shadow.jsonl"
+    assert shadow_path.exists(), "an all-providers-failed turn must leave evidence even with zero facts"
+    shadow_record = json.loads(shadow_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert shadow_record["provider_error_count"] == 2
+    assert shadow_record["provider_errors"] == [
+        {"provider": "hindsight", "stage": "health", "error_type": "RuntimeError"},
+        {"provider": "hindsight", "stage": "recall", "error_type": "TimeoutError"},
+    ]
+
+    monitor = _hindsight_substrate_monitor(store)
+
+    assert monitor["provider_error_count"] == 2
+    assert monitor["provider_errors"] == [
+        {"provider": "hindsight", "stage": "health", "error_type": "RuntimeError"},
+        {"provider": "hindsight", "stage": "recall", "error_type": "TimeoutError"},
+    ]

--- a/tests/plugins/memory/test_memory_os_substrate_router.py
+++ b/tests/plugins/memory/test_memory_os_substrate_router.py
@@ -30,6 +30,22 @@ class RaisingHealthProvider:
         raise AssertionError("recall() must not be called when health() raises")
 
 
+class RaisingRecallProvider:
+    """A substrate provider whose health() reports healthy but recall()
+    itself raises -- e.g. a provider whose backend connection drops between
+    the health check and the recall call. This swallow predates the
+    health()-placement fix; it must be counted the same way."""
+
+    def __init__(self, name="flaky"):
+        self.name = name
+
+    def health(self):
+        return ProviderHealth(provider=self.name, status="ok", capabilities=["recall"])
+
+    def recall(self, query, *, consumer):
+        raise ValueError("recall backend exploded")
+
+
 def test_router_returns_fallback_when_provider_disabled():
     router = SubstrateRouter(providers=[FakeProvider("hindsight", status="disabled")])
 
@@ -226,6 +242,92 @@ def test_provider_health_raise_before_local_artifact_does_not_abort_recall():
     assert result["facts"][0]["provider"] == "local_artifact"
     assert result["selected_provider"] == "local_artifact"
     assert result["fallback_triggered"] is False
+
+
+def test_provider_health_raise_is_counted_as_a_provider_error():
+    """Counterfactual: a provider whose health() raises must not be
+    silently dropped -- it must be distinguishable in the report from a
+    provider that legitimately reports status != "ok". Before this fix,
+    moving health() inside the per-provider try/except (to stop it aborting
+    the whole loop) widened the existing swallow: the raise vanished with
+    no error record anywhere. Recall must still return LocalArtifact's
+    facts, AND the report must carry provider_error_count == 1 with
+    stage == "health" and the raising provider's name.
+    """
+    local_fact = GroundingFact(
+        provider="local_artifact",
+        capability="recall",
+        body_summary="local canonical",
+        confidence=1.0,
+        provenance="crystallized",
+        source_event_refs=["cmem_1"],
+        substrate_snapshot_id="local:canonical:v4",
+        advisory_only=False,
+        authority_class="local_canonical",
+    )
+    router = SubstrateRouter(
+        providers=[RaisingHealthProvider(name="broken"), FakeProvider("local_artifact", facts=[local_fact])],
+        mode="active",
+    )
+
+    result = router.recall("memory", consumer="grounded_expression")
+
+    assert result["facts"][0]["provider"] == "local_artifact"
+    assert result["provider_error_count"] == 1
+    assert len(result["provider_errors"]) == 1
+    error = result["provider_errors"][0]
+    assert error["provider"] == "broken"
+    assert error["stage"] == "health"
+    assert error["error_type"] == "RuntimeError"
+
+
+def test_provider_recall_raise_is_counted_as_a_provider_error():
+    """Same defect shape as the health() swallow, but for recall() itself --
+    this swallow predates the health()-placement branch entirely. A
+    provider that reports healthy but whose recall() raises must be
+    counted with stage == "recall", not silently dropped.
+    """
+    local_fact = GroundingFact(
+        provider="local_artifact",
+        capability="recall",
+        body_summary="local canonical",
+        confidence=1.0,
+        provenance="crystallized",
+        source_event_refs=["cmem_1"],
+        substrate_snapshot_id="local:canonical:v4",
+        advisory_only=False,
+        authority_class="local_canonical",
+    )
+    router = SubstrateRouter(
+        providers=[RaisingRecallProvider(name="flaky"), FakeProvider("local_artifact", facts=[local_fact])],
+        mode="active",
+    )
+
+    result = router.recall("memory", consumer="grounded_expression")
+
+    assert result["facts"][0]["provider"] == "local_artifact"
+    assert result["provider_error_count"] == 1
+    assert len(result["provider_errors"]) == 1
+    error = result["provider_errors"][0]
+    assert error["provider"] == "flaky"
+    assert error["stage"] == "recall"
+    assert error["error_type"] == "ValueError"
+
+
+def test_disabled_provider_status_is_not_counted_as_a_provider_error():
+    """The entire point of provider_error_count: a provider that legitimately
+    reports status="disabled" (no exception, a clean health report) must
+    remain distinguishable from one whose health()/recall() raised. This is
+    the test that proves the two cases no longer collapse into the same
+    silent-skip shape.
+    """
+    router = SubstrateRouter(providers=[FakeProvider("hindsight", status="disabled")])
+
+    result = router.recall("memory", consumer="grounded_expression")
+
+    assert result["fallback_triggered"] is True
+    assert result["provider_error_count"] == 0
+    assert result["provider_errors"] == []
 
 
 def test_provider_health_raise_after_facts_collected_does_not_discard_them():

--- a/tests/plugins/memory/test_memory_os_substrate_router.py
+++ b/tests/plugins/memory/test_memory_os_substrate_router.py
@@ -15,6 +15,21 @@ class FakeProvider:
         return list(self.facts)
 
 
+class RaisingHealthProvider:
+    """A substrate provider whose health() raises -- e.g. a live probe that
+    throws instead of reporting degraded status. Used to prove DEFECT 2's
+    fix: this must never abort the whole SubstrateRouter.recall() call."""
+
+    def __init__(self, name="broken"):
+        self.name = name
+
+    def health(self):
+        raise RuntimeError("health check exploded")
+
+    def recall(self, query, *, consumer):
+        raise AssertionError("recall() must not be called when health() raises")
+
+
 def test_router_returns_fallback_when_provider_disabled():
     router = SubstrateRouter(providers=[FakeProvider("hindsight", status="disabled")])
 
@@ -178,3 +193,66 @@ def test_spoofed_local_authority_claim_excluded_even_alongside_genuine_local_fac
     assert result["selected_provider"] == "local_artifact"
     assert result["external_authoritative_count"] == 1
     assert result["local_first_authority_preserved"] is False
+
+
+def test_provider_health_raise_before_local_artifact_does_not_abort_recall():
+    """Counterfactual: DEFECT 2. Before the fix, provider.health() was
+    called OUTSIDE any try/except in the per-provider loop. A raising
+    health() therefore propagated straight out of SubstrateRouter.recall(),
+    aborting the whole call before LocalArtifactProvider -- the
+    architecture's always-primary authority -- ever got its turn.
+    RaisingHealthProvider is listed FIRST here to reproduce that exact
+    failure shape. Reverting the router.py fix makes this test raise
+    RuntimeError instead of returning a result.
+    """
+    local_fact = GroundingFact(
+        provider="local_artifact",
+        capability="recall",
+        body_summary="local canonical",
+        confidence=1.0,
+        provenance="crystallized",
+        source_event_refs=["cmem_1"],
+        substrate_snapshot_id="local:canonical:v4",
+        advisory_only=False,
+        authority_class="local_canonical",
+    )
+    router = SubstrateRouter(
+        providers=[RaisingHealthProvider(), FakeProvider("local_artifact", facts=[local_fact])],
+        mode="active",
+    )
+
+    result = router.recall("memory", consumer="grounded_expression")
+
+    assert result["facts"][0]["provider"] == "local_artifact"
+    assert result["selected_provider"] == "local_artifact"
+    assert result["fallback_triggered"] is False
+
+
+def test_provider_health_raise_after_facts_collected_does_not_discard_them():
+    """A second ordering: the raising provider comes AFTER a provider that
+    already contributed facts. Before the fix, the uncaught raise happened
+    mid-loop, so the function never reached its `return` -- facts already
+    appended into raw_facts from earlier providers were lost along with it,
+    not merely left out of this iteration.
+    """
+    local_fact = GroundingFact(
+        provider="local_artifact",
+        capability="recall",
+        body_summary="local canonical",
+        confidence=1.0,
+        provenance="crystallized",
+        source_event_refs=["cmem_1"],
+        substrate_snapshot_id="local:canonical:v4",
+        advisory_only=False,
+        authority_class="local_canonical",
+    )
+    router = SubstrateRouter(
+        providers=[FakeProvider("local_artifact", facts=[local_fact]), RaisingHealthProvider()],
+        mode="active",
+    )
+
+    result = router.recall("memory", consumer="grounded_expression")
+
+    assert result["facts"][0]["provider"] == "local_artifact"
+    assert result["selected_provider"] == "local_artifact"
+    assert result["fallback_triggered"] is False

--- a/tests/plugins/memory/test_memory_os_timeutil.py
+++ b/tests/plugins/memory/test_memory_os_timeutil.py
@@ -13,6 +13,7 @@ from plugins.memory.memory_os.timeutil import (
     age_seconds,
     parse_timestamp,
     parse_dt,
+    ensure_utc_aware,
 )
 
 
@@ -150,6 +151,26 @@ class TestAgeSeconds:
 
     def test_age_seconds_none(self):
         assert age_seconds(None) is None
+
+
+class TestEnsureUtcAware:
+    def test_naive_becomes_utc(self):
+        dt = datetime(2026, 7, 22, 12, 0, 0)
+        result = ensure_utc_aware(dt)
+        assert result.tzinfo == timezone.utc
+        assert result.year == 2026 and result.month == 7 and result.day == 22
+        assert result.hour == 12
+
+    def test_aware_returned_unchanged(self):
+        dt = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+        result = ensure_utc_aware(dt)
+        assert result is dt
+        assert result.tzinfo == timezone(timedelta(hours=8))
+
+    def test_utc_aware_returned_unchanged(self):
+        dt = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+        result = ensure_utc_aware(dt)
+        assert result is dt
 
 
 class TestAliases:

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -8650,3 +8650,244 @@ def test_r4_counters_survive_both_whitelists_end_to_end(tmp_path, monkeypatch):
     assert surfaced["invalidated_never_hit_count"] == 5
     assert surfaced["forget_eligible_backlog"] == 7
     assert surfaced["reinforced_count"] == 1
+
+
+def test_llm_call_counters_survive_both_whitelists_end_to_end(tmp_path, monkeypatch):
+    """D2b 双层白名单防漂移守卫:llm_edge_proposer 的 outcome/llm_call_*
+    计数要抵达监控读者,必须先穿过 cognitive_loop 包装器的键透传、再穿过
+    采集端 _edge_fields 过滤 — 两层漏任何一层,计数对读者即不存在(与
+    上面 R4 守卫同构)。本测试用真实包装器(经真实 run_llm_proposer,
+    仅打桩模型座 _call_hermes_runtime_model)的输出喂真实监控采集器,
+    端到端断言 outcome 与四个 llm_call_* 计数存活,证明"每个 LLM 调用
+    都失败"与"判官确实未发现关系"在监控读者眼中可区分。"""
+    import json as _json
+
+    from plugins.memory.memory_os.cognitive_loop import CognitiveLoopRunner
+    from plugins.memory.memory_os.index import MemoryOSIndex
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+    from plugins.memory.memory_os import llm_edge_proposer
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="default")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    index = MemoryOSIndex(roots)
+
+    for rec_id, created_at in (
+        ("cry_mon_a", "2026-06-01T10:00:00Z"),
+        ("cry_mon_b", "2026-06-01T11:00:00Z"),
+    ):
+        store.append_crystallized_record(
+            "test_llm_edge_proposer_monitor.md",
+            {
+                "schema_version": "memory-os.crystallized.v0",
+                "id": rec_id,
+                "kind": "test",
+                "created_at": created_at,
+                "approved_by": "owner",
+                "approved_at": created_at,
+                "approval_purpose": "test",
+                "approval_note": "test seed",
+                "source_event_ids": [],
+                "tags": [],
+                "sensitivity": "private",
+                "hindsight_indexed": False,
+                "bridge_state": "active",
+            },
+            "test crystallized record body",
+        )
+    index.rebuild_from_store(store)
+
+    monkeypatch.setattr(
+        llm_edge_proposer, "_resolve_hermes_default_runtime",
+        lambda config: {"ok": True, "model": "test-model", "runtime": {"api_mode": "chat_completions"}},
+    )
+    # Every reply is empty -> every _call_llm outcome is "empty_llm_response"
+    # -> real run_llm_proposer marks the run degraded/llm_degraded.
+    monkeypatch.setattr(llm_edge_proposer, "_call_hermes_runtime_model", lambda prompt, config: "")
+
+    runner = CognitiveLoopRunner(store)
+    wrapper_summary = runner._llm_edge_proposer({})
+
+    report = {
+        "cycle_id": "cycle-guard-2",
+        "status": "ok",
+        "steps": [{
+            "step": "llm_edge_proposer",
+            "status": "degraded",
+            "duration_ms": 1,
+            "result": wrapper_summary,
+        }],
+        "step_summary": {"step_count": 1, "omitted_step_count": 0, "tail_step_statuses": {}},
+    }
+    mod_dir = tmp_path / "system-modules" / "cognitive_loop"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "reports.jsonl").write_text(
+        _json.dumps(report) + "\n", encoding="utf-8",
+    )
+
+    namespace = _exec_graph_knob_probe_prefix(tmp_path)
+    evidence = namespace["cognitive_loop_step_evidence"]()
+    surfaced = evidence["edge_step_results"]["llm_edge_proposer"]
+    assert surfaced["outcome"] == "llm_degraded"
+    assert surfaced["llm_call_count"] == 1
+    assert surfaced["llm_call_ok_count"] == 0
+    assert surfaced["llm_call_failure_count"] == 1
+    assert surfaced["llm_call_failure_reasons"] == {"empty_llm_response": 1}
+
+    # And it renders as ungraded INFO, not a new WARN/FAIL, via the real
+    # classify_snapshot path.
+    graded = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "cognitive_loop_step_evidence": evidence,
+    })
+    info_entry = next(
+        item for item in graded["info"] if item["code"] == "v2_graph_governance_state"
+    )
+    assert info_entry["value"]["llm_edge_proposer"]["outcome"] == "llm_degraded"
+    assert not any(item["code"].startswith("v2_graph") for item in graded["warn"])
+    assert not any(item["code"].startswith("v2_graph") for item in graded["fail"])
+
+
+def test_cursor_alignment_fields_survive_both_whitelists_end_to_end(tmp_path, monkeypatch):
+    """Counterfactual: a ledger-cursor desync (future graph_layer_shadow.jsonl
+    compaction — metadata_retention.py is dry-run only today, no executor
+    yet) is invisible in `outcome` exactly when the run was ALSO busy
+    reinforcing/forgetting that same cycle (the outcome branch gives those
+    precedence over "cursor_misaligned") — the case an operator most needs
+    to see. tracked_edge_count and the five cursor_* fields must independently
+    survive both the cognitive_loop wrapper's whitelist and the monitor's
+    _edge_fields to reach a reader, and must render as ungraded INFO only —
+    a misaligned cursor ahead of any compaction executor is a bounded,
+    expected condition, not an incident."""
+    import json as _json
+
+    from plugins.memory.memory_os.cognitive_loop import CognitiveLoopRunner
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="default")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    runner = CognitiveLoopRunner(store)
+
+    import plugins.memory.memory_os.edge_weight_feedback as ewf
+
+    def _fake_run(index_path, *, index=None, audit_path=None, now=None):
+        return {
+            "status": "ok",
+            "outcome": "reinforced",  # precedence hides cursor_misaligned here
+            "new_hit_record_count": 0, "reinforced_count": 0,
+            "already_saturated_count": 0, "skipped_not_injected_count": 0,
+            "forgotten_count": 3, "invalidated_never_hit_count": 1,
+            "forget_eligible_backlog": 0, "unresolved_hit_count": 0,
+            "failed_count": 0, "tracked_edge_count": 12,
+            "cursor_misaligned": True,
+            "cursor_misalignment_reason": "ledger_shorter_than_cursor",
+            "cursor_previous_line_count": 500,
+            "cursor_realigned_line_count": 480,
+            "cursor_skipped_row_count": 20,
+            "duration_ms": 1,
+        }
+
+    monkeypatch.setattr(ewf, "run_edge_weight_feedback", _fake_run)
+    wrapper_summary = runner._edge_weight_feedback({})
+    assert wrapper_summary["outcome"] == "reinforced", (
+        "sanity: this scenario must not be distinguishable via outcome alone"
+    )
+
+    report = {
+        "cycle_id": "cycle-guard-3",
+        "status": "ok",
+        "steps": [{
+            "step": "edge_weight_feedback",
+            "status": "ok",
+            "duration_ms": 1,
+            "result": wrapper_summary,
+        }],
+        "step_summary": {"step_count": 1, "omitted_step_count": 0, "tail_step_statuses": {}},
+    }
+    mod_dir = tmp_path / "system-modules" / "cognitive_loop"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "reports.jsonl").write_text(
+        _json.dumps(report) + "\n", encoding="utf-8",
+    )
+
+    namespace = _exec_graph_knob_probe_prefix(tmp_path)
+    evidence = namespace["cognitive_loop_step_evidence"]()
+    surfaced = evidence["edge_step_results"]["edge_weight_feedback"]
+    assert surfaced["tracked_edge_count"] == 12
+    assert surfaced["cursor_misaligned"] is True
+    assert surfaced["cursor_misalignment_reason"] == "ledger_shorter_than_cursor"
+    assert surfaced["cursor_previous_line_count"] == 500
+    assert surfaced["cursor_realigned_line_count"] == 480
+    assert surfaced["cursor_skipped_row_count"] == 20
+
+    # Renders as ungraded INFO only — no new WARN/FAIL for a bounded,
+    # expected cursor-alignment condition.
+    graded = monitor.classify_snapshot({
+        "monitor_profile": "live",
+        "cognitive_loop_step_evidence": evidence,
+    })
+    info_entry = next(
+        item for item in graded["info"] if item["code"] == "v2_graph_governance_state"
+    )
+    assert info_entry["value"]["edge_weight_feedback"]["cursor_misaligned"] is True
+    assert not any(item["code"].startswith("v2_graph") for item in graded["warn"])
+    assert not any(item["code"].startswith("v2_graph") for item in graded["fail"])
+
+
+def test_edge_provenance_write_failed_count_survives_both_whitelists_end_to_end(tmp_path, monkeypatch):
+    """Counterfactual: write_failed_count is the counter that distinguishes
+    "nothing to write" from "tried and failed" (Completion Is Not Output).
+    The monitor's _edge_fields already whitelisted it; the cognitive_loop
+    wrapper was the missing half. Must survive both layers end to end."""
+    import json as _json
+
+    from plugins.memory.memory_os.cognitive_loop import CognitiveLoopRunner
+    from plugins.memory.memory_os.roots import MemoryOSRoots
+    from plugins.memory.memory_os.store import MemoryOSStore
+
+    roots = MemoryOSRoots.from_hermes_home(str(tmp_path), profile="default")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    runner = CognitiveLoopRunner(store)
+
+    import plugins.memory.memory_os.edge_provenance as ep
+
+    def _fake_run(index_path, *, index=None, audit_path=None):
+        return {
+            "status": "ok",
+            "outcome": "produced",
+            "record_count": 5,
+            "scanned_ref_count": 8,
+            "proposed_count": 2,
+            "dedup_skipped": 1,
+            "write_failed_count": 3,
+            "duration_ms": 1,
+        }
+
+    monkeypatch.setattr(ep, "run_edge_provenance", _fake_run)
+    wrapper_summary = runner._edge_provenance({})
+
+    report = {
+        "cycle_id": "cycle-guard-4",
+        "status": "ok",
+        "steps": [{
+            "step": "edge_provenance",
+            "status": "ok",
+            "duration_ms": 1,
+            "result": wrapper_summary,
+        }],
+        "step_summary": {"step_count": 1, "omitted_step_count": 0, "tail_step_statuses": {}},
+    }
+    mod_dir = tmp_path / "system-modules" / "cognitive_loop"
+    mod_dir.mkdir(parents=True)
+    (mod_dir / "reports.jsonl").write_text(
+        _json.dumps(report) + "\n", encoding="utf-8",
+    )
+
+    namespace = _exec_graph_knob_probe_prefix(tmp_path)
+    evidence = namespace["cognitive_loop_step_evidence"]()
+    surfaced = evidence["edge_step_results"]["edge_provenance"]
+    assert surfaced["write_failed_count"] == 3

--- a/tests/scripts/test_memory_os_candidate_aggregation_lane.py
+++ b/tests/scripts/test_memory_os_candidate_aggregation_lane.py
@@ -14,6 +14,7 @@ downstream that scans the same shape).
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime, timezone
 
 from plugins.memory.memory_os.crystallized import CrystallizedCandidate, append_candidate_queue
@@ -122,3 +123,70 @@ def test_candidate_aggregation_lane_empty_tick_boundary_stays_false(tmp_path, mo
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert any_boundary_true(report["boundary"]) is False
+
+
+# ── 2026-08-15: compaction_skip_reason wiring through main() ───────────────
+#
+# main() builds two separate closed-set surfaces from the lane's result:
+# the printed cron-delivery `summary` dict (an explicit key-picking
+# whitelist that dropped compaction_skip_reason), and the run_status/reason
+# derivation for record_lane_last_run, which used to derive purely from
+# counters (promoted+demoted+fleeting+compacted). Since compacted_count is
+# 0 both when compaction ran with nothing to archive AND when it was
+# skipped, a skipped compaction misreported as "no_triage_actions"/
+# "triaged" -- byte-identical to a healthy tick. Both need the fix; this
+# test proves both from ONE real lane failure.
+
+
+def test_compaction_skip_reason_flows_through_script_summary_and_lane_last_run(
+    tmp_path, monkeypatch, capsys,
+):
+    """Invokes main() in-process (not subprocess) so
+    aggregation.read_effective_candidates can be monkeypatched to a genuine
+    failure -- the real-producer discipline used throughout this batch's
+    counterfactuals. A hand-written result dict would only prove the
+    key-picking lines exist, not that main() actually receives the field
+    from a real lane run."""
+    import scripts.memory_os_candidate_aggregation_lane as lane_script
+    import plugins.modules.governance.candidate_aggregation as aggregation
+    from plugins.memory.memory_os.lane_last_run import read_lane_last_run
+
+    _store_with_gate(tmp_path)  # writes the envelope main() will read from disk
+
+    def _raise_view_failure(_store):
+        raise RuntimeError("synthetic effective-view failure")
+
+    monkeypatch.setattr(aggregation, "read_effective_candidates", _raise_view_failure)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "memory_os_candidate_aggregation_lane.py",
+            "--hermes-home", str(tmp_path),
+            "--profile", "memoryos-test",
+            "--envelope-id", _VALID_ENVELOPE_ID,
+        ],
+    )
+
+    rc = lane_script.main()
+    assert rc == 0
+
+    printed = capsys.readouterr().out
+    summary = json.loads(printed)
+    assert summary["compaction_skip_reason"] == "effective_view_unavailable", (
+        "the script's printed cron-delivery summary dropped "
+        f"compaction_skip_reason: {summary}"
+    )
+
+    last_run = read_lane_last_run(str(tmp_path), "candidate_aggregation")
+    assert last_run is not None
+    assert last_run["status"] == "ok", (
+        "a view failure is visibility, not alerting: a view failure already "
+        "emits its own error record, and a queue that merely grows is "
+        "recoverable, so status must stay ok, not warn/fail"
+    )
+    assert last_run["reason"] == "compaction_skipped_effective_view_unavailable", (
+        "counterfactual: without the fix this reports 'no_triage_actions' "
+        "-- byte-identical to a healthy tick with nothing to compact, "
+        f"because compacted_count is 0 either way. got: {last_run}"
+    )

--- a/tests/scripts/test_memory_os_cron_group_runner.py
+++ b/tests/scripts/test_memory_os_cron_group_runner.py
@@ -210,6 +210,48 @@ def test_calendar_member_waits_for_its_anchor(tmp_path, stub_helpers):
     assert before_anchor["members"][0]["reason"] == "before_calendar_anchor"
 
 
+def test_is_due_calendar_anchor_normalizes_now_to_utc(tmp_path):
+    """Defect 4 counterfactual: _is_due's calendar branch must compare the
+    anchor against a UTC-normalized `now`, not `now`'s raw wall-clock
+    hour/minute.
+
+    The date check (`last_started.astimezone(utc).date() >= now.astimezone
+    (utc).date()`) was already UTC-normalized, but the anchor-minutes
+    check right below it used raw `now.hour * 60 + now.minute`. Production
+    always calls this with `datetime.now(timezone.utc)`, so the bug is
+    latent there -- it is only reachable through the documented
+    testing-only `--now` override, which is why this test drives `_is_due`
+    directly with a non-UTC-aware `now` rather than through the CLI.
+
+    Counterfactual: anchor = 06:00 UTC. now = 2026-07-30T03:00 in UTC-8,
+    which is 2026-07-30T11:00Z -- five hours PAST the anchor. Without the
+    fix, the raw local hour (3) is compared against the anchor (360
+    minutes) and wrongly reports "before_calendar_anchor". With the fix,
+    the UTC-equivalent hour (11) is compared and correctly reports
+    "calendar_day_due" -- matching the verdict for the UTC-equivalent
+    instant passed directly.
+    """
+    runner = _load_group_runner()
+    tz_minus8 = timezone(timedelta(hours=-8))
+    now_local = datetime(2026, 7, 30, 3, 0, tzinfo=tz_minus8)  # == 2026-07-30T11:00:00Z
+    now_utc_equivalent = now_local.astimezone(timezone.utc)
+
+    spec = {"due_policy": "calendar", "calendar_anchor": "06:00"}
+    # Ran the previous UTC day, so the "already_ran_today" branch does not
+    # fire before reaching the anchor comparison under test.
+    entry = {"last_started_at": "2026-07-29T10:00:00Z"}
+
+    due_local, reason_local = runner._is_due(spec, entry, now=now_local, force=False)
+    due_utc, reason_utc = runner._is_due(spec, entry, now=now_utc_equivalent, force=False)
+
+    assert (due_utc, reason_utc) == (True, "calendar_day_due")
+    assert (due_local, reason_local) == (due_utc, reason_utc), (
+        f"a non-UTC-aware `now` must produce the same verdict as its UTC-"
+        f"equivalent instant, got local={(due_local, reason_local)!r} "
+        f"utc={(due_utc, reason_utc)!r}"
+    )
+
+
 def test_owner_disabled_lane_is_skipped(tmp_path, stub_helpers):
     """Per-lane disable replaces the per-job disable owners lost to grouping."""
     runner = _load_group_runner()

--- a/tests/scripts/test_memory_os_l3_probe_repo_root.py
+++ b/tests/scripts/test_memory_os_l3_probe_repo_root.py
@@ -317,3 +317,114 @@ def test_deploy_l3_probe_plan_does_not_ask_to_create_the_superseded_job(tmp_path
 
     assert "create_cron_job" not in plan.get("needs", [])
     assert all(cmd.get("operation") != "hermes cron create" for cmd in dry_run.get("commands", []))
+
+
+def test_deploy_l3_probe_helper_comparison_requires_explicit_utf8_encoding(
+    tmp_path, monkeypatch,
+):
+    """Defect 3 counterfactual: run_plan()'s helper-current check used
+    ``DEPLOY_HELPER.read_text() == SOURCE_HELPER.read_text()`` with no
+    ``encoding=`` on either call, so Python fell back to the locale's
+    preferred encoding. The real helper scripts are full of Chinese
+    comments, so on a non-UTF-8 locale this raises UnicodeDecodeError
+    instead of comparing the two files.
+
+    This test does not depend on the host's actual locale (which may well
+    already be UTF-8, making the bug non-reproducible by environment
+    alone). Instead it monkeypatches ``Path.read_text`` to raise whenever
+    it is called WITHOUT an explicit ``encoding=`` kwarg -- exactly what a
+    non-UTF-8 locale would do to the old unencoded calls -- so the test is
+    deterministic on any host.
+
+    Counterfactual: without ``encoding="utf-8"`` on both read_text() calls
+    in run_plan(), this raises UnicodeDecodeError. With the fix, run_plan()
+    returns normally with the correct helper_current verdict.
+    """
+    import pathlib
+
+    module = _load_deploy_module()
+    home = tmp_path / "home"
+
+    helper_dir = tmp_path / "helpers"
+    helper_dir.mkdir()
+    source_helper = helper_dir / "source_helper.py"
+    deploy_helper = helper_dir / "deploy_helper.py"
+    content = "# 中文注释\nprint('ok')\n"  # Chinese comment
+    source_helper.write_text(content, encoding="utf-8")
+    deploy_helper.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(module, "SOURCE_HELPER", source_helper)
+    monkeypatch.setattr(module, "DEPLOY_HELPER", deploy_helper)
+
+    real_read_text = pathlib.Path.read_text
+
+    def _locale_sensitive_read_text(self, encoding=None, errors=None):
+        if encoding is None:
+            # Stand-in for what a non-UTF-8 locale does to an unencoded
+            # read_text() call on a file containing non-ASCII bytes.
+            raise UnicodeDecodeError(
+                "ascii", b"\xe4\xb8\xad", 0, 1, "simulated non-UTF-8 locale",
+            )
+        return real_read_text(self, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", _locale_sensitive_read_text)
+
+    plan = module.run_plan(home)  # must not raise UnicodeDecodeError
+
+    assert plan["helper_installed"] is True
+    assert plan["helper_current"] is True
+
+
+def test_l3_probe_helper_last_run_write_requires_explicit_utf8_encoding(
+    tmp_path, monkeypatch,
+):
+    """Follow-up 2 counterfactual: memory_os_l3_probe_helper.py's
+    LAST_RUN_FILE.write_text(json.dumps(...)) had no ``encoding=``, and its
+    payload includes ``stderr_truncated`` -- captured subprocess output
+    that can carry non-ASCII bytes -- so on a non-UTF-8 locale this raises
+    UnicodeEncodeError on write instead of saving the diagnostic. Same
+    defect class as Defect 3 (deploy_l3_probe.py), write side rather than
+    read side. (Checked for a matching read side: grepped the project for
+    ``l3_probe_last_result`` and found only this write site -- the
+    artifact is never read back programmatically anywhere in the repo, so
+    there is no read-side counterpart to fix.)
+
+    Deterministic on any host, same technique as the Defect 3 test:
+    monkeypatch ``Path.write_text`` to raise whenever called without an
+    explicit ``encoding=`` kwarg.
+    """
+    import pathlib
+
+    mod = _load_l3_helper()
+
+    fake_probe = tmp_path / "fake_probe.py"
+    fake_probe.write_text("print('GOVERNANCE PATH OK')\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "PROBE_SCRIPT", fake_probe)
+    last_run_file = tmp_path / "system" / "l3_probe_last_result.json"
+    monkeypatch.setattr(mod, "LAST_RUN_FILE", last_run_file)
+
+    class _FakeCompletedProcess:
+        returncode = 0
+        stdout = "GOVERNANCE PATH OK\n"
+        # Non-ASCII captured subprocess output, the realistic trigger for
+        # this bug (stderr_truncated is built directly from this).
+        stderr = "子进程输出中含有非 ASCII 字符"
+
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: _FakeCompletedProcess())
+
+    real_write_text = pathlib.Path.write_text
+
+    def _locale_sensitive_write_text(self, data, encoding=None, errors=None, newline=None):
+        if encoding is None:
+            # Stand-in for what a non-UTF-8 locale does to an unencoded
+            # write_text() call on non-ASCII data.
+            raise UnicodeEncodeError(
+                "ascii", data, 0, 1, "simulated non-UTF-8 locale",
+            )
+        return real_write_text(self, data, encoding=encoding, errors=errors, newline=newline)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", _locale_sensitive_write_text)
+
+    returncode = mod.main(smoke=True)  # must not raise UnicodeEncodeError
+
+    assert returncode == 0
+    assert last_run_file.exists(), "LAST_RUN_FILE must be written even with non-ASCII stderr"


### PR DESCRIPTION
## What

Closes all 20 findings from the whole-project code review (15 primary + 5 truncated), plus the second instances of the same defect classes that fixing them surfaced. 15 parallel fix packages with non-overlapping file ownership; every fix carries a counterfactual test empirically verified to fail without it (cp-backup revert → FAIL → restore → PASS).

## Highlights by class

**Silent failures made observable**
- `index._copy_embeddings_from_live`: bare `pass` on every `sqlite3.Error` meant a wiped embeddings table shipped under a `status="ok"` audit row. Now: closed outcome set (`copied` / `no_live_index` / `live_table_missing` / `copy_failed`) with independent live/copied row counts; `ATTACH` parameterized (apostrophe-safe); `DETACH` leak fixed.
- `llm_edge_proposer`: unguarded `float(confidence)` crashed the lane mid-loop after edges were written; dead `batch` knob deleted; four typed failure counters + `outcome` + `degraded` status added (fact_judge pattern).
- `edge_weight_feedback`: line-count cursor now detects misalignment (length + content fingerprint), never replays (reinforcement is non-idempotent), and reports the skipped-row bound instead of a clean `no_new_hits`.
- `clearance_cycle` / `llm_contradiction_lane`: hand-rolled brace counters converged on `_extract_json_object` per the reuse contract; parse failures typed; non-dict JSON replies no longer raise `AttributeError` through the lane.

**Data-loss paths closed**
- A provisional-backed candidate is never archived on any branch of `compact_candidate_queue` (both the terminal-ids branch and the age-based retention branch). The enforcing parameter is required, not defaulted — rule 4.
- All three compaction-skip sources now agree and record `compaction_skip_reason` (closed set), wired through the cron summary → status ledger → owner digest; a healthy tick's digest line is byte-identical to before (test-pinned).

**Attribution coverage (deliberate widening)**
- "Recent Cross-Session" and "Recall Facade (unified)" were live injected sections invisible to the attribution gate (unmapped title → `other` → non-attributable). Both now classified, carry source ids (facade side translates lane-local prefixes to canonical vocabulary), and have explicit budget priorities. The guard test now asserts emitted titles ⊆ mapping keys — the direction whose absence let the drift survive. **Attribution-gap counts will rise: coverage got correct, quality did not regress.**

**Observability wiring**
- Counters that reached no reader (`llm_call_*`, `cursor_*`, `tracked_edge_count`, `edge_provenance.write_failed_count`, `compaction_skip_reason`) now survive both whitelist layers, INFO-only, each layer proven independently load-bearing by per-layer revert.

**ExecutionGate: invariant kept, cost removed**
- The `require_unused` fast-path stays disabled — the sidecar's `completion_count` is not authoritative (non-atomic journal→sidecar write; second independent writer in `memory_os_execution_gate_runner.py`) — now documented in place so nobody "fixes" it into a hole. The unconditional success-path index rebuild is gone: 50 governed writes = 0 rebuilds (was 50), index-miss self-heal preserved.

**Rule-5 naive-datetime sweep (23 sites, 3 rounds)**
- `TypeError` from naive-vs-aware comparisons escaping `except ValueError`, including two per-turn prefetch hot paths and `scripts/cleanup_expired_working.py` — the actual daily `working_cleanup` cron lane, which bypasses `WorkingMemoryService` entirely. Fail direction decided per site (delete paths keep the item; decay self-heals; CLI args error clearly). All 94 `fromisoformat` call sites in the repo now have a definitive disposition.

**Correctness**
- `entity_index.query_related_records` no longer attributes one entity's class/weight to another's name (`min(text)` + `max(weight)` were independent aggregates); `min_weight` filters entities at the join, matching the docstring; float-band class derivation deleted in favor of the authoritative column.
- `event_stats` continuity-selector mirror gained the bookkeeping exclusion the live selector had; three hand-copied constants now single-sourced from `prefetch`.

## Pre-merge independent review round

Before opening this PR, an independent high-effort review of the full branch diff produced 10 findings; 8 were fixed (each verified against source first), 2 declined with recorded reasons:

- **Fixed — the guard this branch added lapsed at the eviction transition**: `invalidate_provisional_record` writes no triage row, so an evicted-anchor candidate's effective state stays frozen at `resolver_approved` and the age branch archived it one tick later. `resolver_approved` is now sticky in the retention branch (same as `owner_eligible`); non-immortality proven via the `_demote_aged` 3-day sweep, and a regression test pins that permanent-confirmed candidates still archive.
- **Fixed — `status="degraded"` fell through `_step_status` to `"ok"`**, un-doing the very fix that introduced it. Now maps to `"warning"` (like `deferred`). Expected behavior change: `cognitive_loop.last_status` will show `warning` on hosts with intermittent LLM failures — that is honesty, not regression; the monitor treats both `ok` and `warning` as presence-pass.
- **Fixed**: fingerprint-branch skipped-count was identically 0; torn-read of an in-progress append could fake a cursor misalignment (reader now ignores a non-newline-terminated tail line); cross-session tie-break sorted oldest-first within equal scores, contradicting its own comment; router swallowed provider exceptions indistinguishably from clean disablement (bounded `provider_error_count`/`provider_errors` added and wired through the shadow ledger — including the `if not facts: return` early-exit that skipped writing exactly when every provider failed — and the CLI status reader, each layer proven independently load-bearing).
- **Fixed — convergence**: the branch's three datetime sweeps had hand-pasted the same normalize idiom 25 times; all 25 branch-introduced sites now use a new `timeutil.ensure_utc_aware()` (parse structure and per-site fail directions untouched; timeutil verified leaf, 0 import cycles).
- **Declined with reasons**: the event_stats `(ts,id)` tie-break counterfactual is provably unconstructible today (20k-trial differential fuzz — all consumers re-sort or aggregate order-independently; fabricating a white-box failure would violate this batch's own rules), and the "double sort" cost claim does not survive Timsort on nearly-sorted input. Moving the compound key upstream would change owner-facing `recent_event_summaries` ordering semantics — out of scope pre-merge.

## Verification

- Full suite: **3521 passed / 13 skipped / 0 failed** (baseline 3408/13, +113 tests)
- Static gates: `import_cycle_check` pass, `write_surface_check` unclassified_count=0, `static_hygiene_check` pass, `git diff --check` clean
- Ownership audit: 34 source + 24 test files, zero out-of-scope edits by any package
- Splice audit: every deleted test line accounted for (one real splice incident was caught and repaired mid-batch)
- Stabilization checklist: section CW added, "一句话" updated (`5c1bad6`)

## Follow-ups (registered in checklist 待办, not in this PR)

- `vector_edge_proposer` emits no `outcome` and no write-failure counter (producer gap, needs its own scoping)
- `timeutil.py` exists but only 3 files use it; ~25 inline copies of the same normalization logic (drift-shape risk; per-site fail directions differ, so convergence needs real evaluation)
