### PR TITLE
fix(install): honest exit codes, fresh-host config guard, CLI wrapper, deployment doctor checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ HERMES_HOME=/root/.hermes \
 Switching an upgraded host back to `active-closure` pauses known optional jobs;
 it does not delete them.
 
+> `install_memory_os_plugin.py` is low-level plumbing, shown here only for this
+> one cron-profile task. Every switch it has is opt-in, so running it directly
+> to install a host produces whatever subset of flags you happened to pass —
+> for example `--install-cognitive-loop` without `--enable-cognitive-loop`
+> writes the systemd unit files but never registers them, so the loop never
+> runs. Use `scripts/install_memory_os.sh` to install: it supplies the
+> production defaults and fails loudly when a core component is missing.
+
 ## Verify the Installation
 
 ```bash

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4384,9 +4384,38 @@ warning 在安装路径不可见——**"要不要让漂移挡安装"是毕业�
 
 ### 待办（本节新增）
 
-`cron_registry_snapshot_missing_lanes` 目前是 warning 且安装路径 `>/dev/null`
-不可见。是否升级为 error（从而经 doctor 退出码挡住安装）需先在生产影子观察，
-确认无版本错位误报后由 owner 裁定。
+**owner 裁定 2026-08-18：维持 warning。** 毕业条件定死为二者之一——两台主机
+下一次 full monitor 零误报，或生产上抓到第一例真 drift；届时改一个词即可升级。
+
+裁定前的两处事实更正（原记录有误，一并钉在此处以免再被引用）：
+
+- **不是"安装路径不可见"**：`install_memory_os.sh:804` 的核心 doctor 调用
+  **没有** `>/dev/null`，完整 JSON 打到控制台；`>/dev/null` 的是 `:809/816`
+  两次 shell 插件 doctor。
+- **不是"自动部署路径零覆盖"**：`deploy_memory_os.py` 虽然每次 apply 都传
+  `--skip-verify`（使 `verify_install` 早退、`:804` 那次不跑），但
+  `memory_os_upgrade_compat_check.py` 的 `shell_doctor` spec 会跑
+  `hermes memory-os-agent-os doctor`，它经 `_delegate_to_memory_os_cli` 直通
+  `build_doctor_result`；该 compat check 在 **preflight / apply 后 / postcheck
+  各跑一次**。所以这条 finding 在部署路径上是可见的，只是不阻断。
+
+**因此"让 `.sh` 解析 findings"是伪命题**：severity 已经是三个消费者共用的
+唯一杠杆，且三者都已实现该策略——`_require_doctor_ok`（error 失败 / warning
+通过）、`memory_os_3_200_monitor` 分类端（`doctor.status=="ok"` 否则
+`doctor_not_ok` FAIL）、`.sh:804` 在 `set -e` 下（exit 1 即中止）。任何新增的
+shell 侧 code 名单或 `blocking_count` 都是重复建设，且 shell 侧名单无测试可钉，
+正是 CLAUDE.md「gate 词表与生产者漂移即静默失效」那一条。
+
+**升级的真实代价**（选择维持 warning 的理由）：`build_doctor_result` 有 error
+即置 `status="fail"`，monitor 直接判 `doctor_not_ok` **FAIL**。所以升 error
+不是"让安装更严"，而是**让这条 drift 成为生产 FAIL 级条件**——而它至今没有
+一次生产实例。升级时另需按 exit-3 的模式把 doctor 退出折进 `verify_failures`，
+否则 `set -e` 直接中止、fail-loud 框不渲染。
+
+**待观察（下次 monitor 运行确认，非既知事实）**：3.200 双 profile 且 systemd
+单元经历过 per-profile 改名。若 `memory-os/systemd/` 仍留有改名前的无后缀 unit
+文件，下次 full monitor 会出现 `systemd_timer_unit_not_registered` 的
+`doctor_warning_finding`（外层 WARN 码为既有码，新 finding 只是内层字段）。
 
 ### 测试计数与门
 

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4274,9 +4274,22 @@ preset 写入器先建 config.json，故只咬直调 plugin.py 的路径。
 
 ### 测试计数与门
 
-新增 **9 个测试函数**（骨架创建 2、timer 状态/孤儿告警 2、未达成判定 3、
-smoke 状态分级 1、退出码正反各 1 中的 1）；另修正 1 个既有测试的附带断言。
-全量 3537 → **3546 passed / 13 skipped / 0 failed**（12:03）。
+新增 **10 个测试函数**（骨架创建 2、timer 状态/孤儿告警 2、未达成判定 2、
+smoke 状态分级 2、退出码正反各 1）；另修正 1 个既有测试的附带断言。
+全量 3537 → **3547 passed / 13 skipped / 0 failed**。
+
+smoke 状态那 2 个是**合入前顾问全量 diff 复审**加的第 2 个：原先只有分类
+函数的测试，而它的 detail 串是**拿常量自己拼的** —— 正是本项目
+`counterfactual-tests-must-use-real-producer` 那个坑：生产端
+`_verify_memory_os_hot_path` 若哪天不再发该前缀，测试照绿，而所有没装
+hermes-agent 的环境会开始退 3。补的那条直接调真实生产端（用
+`sys.modules[...] = None` 让 import 确定性失败），断言它真的发出分类器所依赖的前缀。
+
+**Rule 5 记录不改**：失败框 `printf "║  ✗ %-54s ║"` 的两条**既有**条目
+（`cognitive-loop timer is not active/enabled (ENABLE_COGNITIVE_LOOP=1)`，60/61 字符）
+本就撑破边框。本轮新增条目已压到 50 字符合规；既有两条不动——缩写会丢掉
+`ENABLE_COGNITIVE_LOOP=1` 这个"是哪个变量驱动了检查"的诊断信息，而加宽整个框
+比这个纯观感缺陷本身更具侵入性。
 四静态门（import_cycle / write_surface `unclassified_count=0` /
 static_hygiene / public_checkout_probe --strict）+ `git diff --check` 全绿。
 
@@ -6607,4 +6620,4 @@ failed**（11:46），四静态门 + `git diff --check` 全绿。
   分级（否则合法环境被判失败），并在 `.sh` 把 exit 3 **折进** `verify_failures`
   而非仅容忍（否则同一 envelope bug 搬到 shell 层）。自审否掉自己加的
   `--skip-verify` 透传（会静默取消每次生产部署的 smoke）。
-  全量 3537→3546 passed（+9）/13 skipped，四门全绿。
+  全量 3537→3547 passed（+10）/13 skipped，四门全绿。合入前另做一次**最终统一 diff** 顾问复审（此前只审过中间态与逐条 Edit），据其发现补生产端前缀断言、压缩失败框条目长度、修正测试分桶。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4304,6 +4304,100 @@ static_hygiene / public_checkout_probe --strict）+ `git diff --check` 全绿。
 
 ---
 
+## CZ — 部署报告两项待放行项的最小实现：CLI wrapper + doctor 部署完整性（2026-08-18）
+
+CY 把 `deploy_improvements.md` 的 #1/#2/#4 列为边界扩张待 owner 放行。owner
+批 #4 驳回（lane preset 不得作为 `--production-safe` 默认），并要求先与顾问
+讨论 #1/#2 的**最小高收益**实现、太复杂则否决。裁定：两项都不复杂，各自
+独立成 commit，以便否决即一条 `git revert`。
+
+### CZ.0 顾问推翻自己上一轮的「另开子命令」建议
+
+CY 记录的方案是 deploy-doctor **另开子命令**，唯一理由是并入 `doctor` 会让
+README lane A（无 systemd 的临时目录跑 `memory-os doctor`）变吵。本轮提出
+**按面存在与否设条件**后该理由消失：没有 snapshot、没有 unit 文件的 profile
+一条 finding 都不发。这一改砍掉三样东西——新子命令、新证据等级
+（findings 直接走既有 `memory-os.doctor.v0`，**CLAUDE.md 的证据等级封闭集合
+无需扩充**）、独立 reason code 体系。同时按范围砍掉 resolved knob 值、
+config 段模式、cron job 分类三项检查（与 monitor 重叠，复杂度和噪音都在那里）。
+
+### CZ.1 `memory-os` CLI wrapper（`d6b9664`）
+
+`pyproject.toml` 声明了 `memory-os` console script，但那只对 `pip install`
+的人生效；主机安装走**源码复制**，于是部署主机上有完整 35 子命令 CLI 却
+无从敲起，每次诊断都要手写 `PYTHONPATH=... python3 -m ...`。
+
+写 `<HERMES_HOME>/memory-os/bin/memory-os`，与既有 heartbeat/cognitive-loop
+wrapper 同目录同 PYTHONPATH。**不采纳 `.pth`**：
+`test_memory_os_installed_layout_imports.py` 用 `-S` 隔离子解释器正是为了
+让 CI 的 editable 安装不使那批测试空转，放 `.pth` 会造成"测试被屏蔽、生产
+生效"的分叉，把一个已钉死的缺陷类重新变成盲区。
+
+与两个 cron wrapper 有一处**故意不同**：那些是定时任务，钉死 `HERMES_HOME`
+是对的；这个是交互式命令，装机 home 只作默认值，`HERMES_HOME=x memory-os
+status` 仍然生效。
+
+**实现中踩到并修掉一个真 bug**：默认值必须**单独一行赋值再展开**。
+显而易见的内联写法 `"${HERMES_HOME:-'/path'}"` 是错的——双引号内的单引号
+是字面量，`HERMES_HOME` 会变成 `'/path'`（**带引号**），由它派生的每条路径
+都错。更要命的是**子串断言 `"${HERMES_HOME:-" in body` 对错误写法一样通过**，
+所以测试改为**执行**那几行并双向断言解析结果。反事实：换回内联写法 → 执行
+型测试 FAIL，而两条子串型测试**照常 PASS**——这正是它存在的理由。
+
+### CZ.2 doctor 部署完整性两项检查（`<本节 commit>`）
+
+新增 `_deployment_integrity_checks(store)` 挂进 `build_doctor_result`，
+只做两条最高收益检查，各自按面设条件：
+
+**(a) `cron_registry_snapshot_missing_lanes`** —— 编译内注册的 lane 不在
+主机已装 snapshot 的 `member_keys` 里。CLAUDE.md 明载这是**静默失败且此前
+无任何探测器**：`_load_group` 优先读 snapshot 且 member 非空时不回落，于是
+新注册的 lane 在已 onboard 主机上直接从 tick 里消失——无 unknown key、无
+error record、无 WARN，envelope 干干净净地关闭却从未调用它。
+只在 snapshot **存在**时比对（无 snapshot 时 runner 回落编译内注册表，
+不存在缺口，故这不是买绿）；v0 snapshot 无 `groups` 数组时按设计回落，不发。
+**严重级 warning 而非 error**：从新 checkout 对旧主机 HOME 跑 doctor 会
+产生版本错位假漂移。注意 `.sh` 的 verify 跑 doctor 时是 `>/dev/null`，
+warning 在安装路径不可见——**"要不要让漂移挡安装"是毕业决策，记入待办
+由 owner 定，先影子跑**。
+
+**(b) `systemd_timer_unit_not_registered`** —— unit 文件在
+`memory-os/systemd/` 而 systemd 不认识（CY 复现的那个部署形态）。
+单元名**取自磁盘文件名**（per-profile 后缀已内嵌），**绝不重推导后缀**——
+重推导正是 CV 节修过的那类错探测。探测走 `systemctl --user list-unit-files`
+子进程（用户上下文天然正确）；systemctl 不可用/无 user bus 时**什么都不发**
+——那是"无样本"，不为它发明新严重级去扩 doctor 词表。
+**严重级必须 warning**：装而不启 + cron 兜底是 CY 刚刚显式支持的合法稳态，
+判 error 会让每台无 systemd 主机 doctor 失败。
+
+### 测试与反事实
+
+新增 **12 个测试**（wrapper 3、部署完整性 9）。两条按顾问要求必写：
+① `test_bare_profile_emits_no_deployment_findings` ——裸 HERMES_HOME 断言
+部署类 finding 为零，**这条钉的是"按面设条件"契约本身**，即推翻另开子命令
+的全部依据；没有它，以后谁去掉条件 lane A 就静默变吵。
+② snapshot 测试用**真实写入器** `write_cron_registry_snapshot` 构造再摘掉
+一个 lane，不手拼 JSON（`counterfactual-tests-must-use-real-producer`）。
+
+反事实实测：wrapper 换回内联写法 → 执行型测试 FAIL / 子串型照绿；
+漂移检测置空 → `test_snapshot_missing_a_registered_lane_is_reported` FAIL。
+
+### 待办（本节新增）
+
+`cron_registry_snapshot_missing_lanes` 目前是 warning 且安装路径 `>/dev/null`
+不可见。是否升级为 error（从而经 doctor 退出码挡住安装）需先在生产影子观察，
+确认无版本错位误报后由 owner 裁定。
+
+### 测试计数与门
+
+新增 **12 个测试函数**（CLI wrapper 3、部署完整性 9）。
+全量 3547 → **3559 passed / 13 skipped / 0 failed**（12:12）。
+四静态门（import_cycle / write_surface `unclassified_count=0` /
+static_hygiene / public_checkout_probe --strict）+ `git diff --check` 全绿。
+两项各自独立 commit（`d6b9664` / 本节），owner 否决任一项即一条 `git revert`。
+
+---
+
 ## 待办
 
 **`vector_edge_proposer` 无 `outcome`、无写失败计数（CW 登记，2026-08-15）。**
@@ -6621,3 +6715,13 @@ failed**（11:46），四静态门 + `git diff --check` 全绿。
   而非仅容忍（否则同一 envelope bug 搬到 shell 层）。自审否掉自己加的
   `--skip-verify` 透传（会静默取消每次生产部署的 smoke）。
   全量 3537→3547 passed（+10）/13 skipped，四门全绿。合入前另做一次**最终统一 diff** 顾问复审（此前只审过中间态与逐条 Edit），据其发现补生产端前缀断言、压缩失败框条目长度、修正测试分桶。
+
+- `80d144b..（CZ，本节）`：CY 列为待放行的 #1/#2 最小实现——顾问裁定两项均不
+  复杂并**推翻自己上一轮的「deploy-doctor 另开子命令」建议**：按面存在设条件
+  后，并入 `doctor` 不再有 lane A 噪音问题，顺带省掉新证据等级注册。
+  #1 写 `memory-os/bin/memory-os` wrapper（不采纳 `.pth`，理由见 CY.0；实现中
+  踩到并修掉内联 `${HERMES_HOME:-'...'}` 会带字面单引号的真 bug，测试改为执行
+  解析而非子串断言）；#2 新增 doctor 两条部署检查——registry snapshot 漏 lane
+  （CLAUDE.md 记载的无探测器静默失败）与 unit 文件未注册 systemd，均 warning、
+  均按面设条件、systemctl 不可用即无样本不发。#4 lane preset 按 owner 裁定驳回，
+  无相关代码。全量 3547→3559 passed（+12）/13 skipped，四门全绿。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4131,6 +4131,166 @@ CLI 参数直接报错。全仓库 **94 个 `fromisoformat` 调用点 / 53 个�
 （由 `_run_step` 捕获记 error），均非 CW 引入；根因是"缺键"而非"越界值"，
 需要时独立处理。
 
+## CY — 外部部署报告核实 + 安装器"完成即成功"三项修复（2026-08-18）
+
+Owner 转来一份外部主机（RK3399 aarch64 全新部署）写的 `deploy_improvements.md`，
+列 8 项问题。先逐条 grep 核实到 file:line，再按核实结果重排优先级实施。
+
+### CY.0 核实结论：8 项中 2 项证伪、3 项归因错、3 项属实
+
+**证伪 2 项——它建议的修复已经在代码里**：
+
+- **`config.json` 缺 `recall_arbitration` 段**：报告建议加
+  `_DEFAULT_PROVIDER_CONFIG` + deep_merge。`config.py:62` 的
+  `DEFAULT_CONFIG["recall_arbitration"]` 字段与其提议**逐字相同**，
+  `_merge_recall_arbitration_config`（`config.py:378`，经 `_merge_known`
+  `:297`）还多做取值域校验；provider 走 `load_config`（`__init__.py:113`），
+  构造函数 `:70` 直接以 `DEFAULT_CONFIG` 兜底。报告引用的
+  `_load_provider_config()` **全仓库不存在**。`mode` 默认 `"off"` 是毕业契约
+  的设计，写进文件而值不变则行为一字节不改。
+- **审批 token 未内联进 digest**：`_rendered_digest_item_lines` 逐条渲染
+  `会话回复示例: memory approve oa_...`（来自 `_review_action` 的 token），
+  普通 candidate 走 `_review_actions` 的 `candidate` 分支必得
+  approve/reject 两个 `oa_`，`_review_item_suppresses_actions` 只作用于
+  显式 `actions_suppressed` 与未成熟 `proposal`，**从不作用于普通 candidate**。
+  报告者大概率观测到的是**真现象、错归因**：`_rendered_digest_text` 的
+  Telegram 长度预算裁剪与分区上限会省略条目（`还有 N 项…被省略`）。
+
+**归因错 3 项**（症状真）：
+
+- **认知回路 timer 写盘却从未启用**：`.sh` 三种模式默认都 enable
+  （`554-555`/`145-164`）且 `785-825` 有 fail-loud 校验，走文档路径不会复现。
+  真机理是报告者直接调 `install_memory_os_plugin.py`：全部开关 `store_true`
+  默认 False，`440` 行 `install OR enable` 写单元文件，而
+  copy 到 `~/.config/systemd/user/` + `systemctl enable --now` **只在 enable
+  分支内**（`574-585`）→ 必然产出"单元文件在、软链不在"，与观测逐字吻合。
+- **`memory-os` CLI 不存在**：`pyproject.toml` **已有**
+  `[project.scripts] memory-os`（`b7d4476`）。报告称 `.sh` 多处
+  `command_exists memory-os` —— 全文 `command_exists` 仅 5 处，查的是
+  `hermes`/`systemctl`，**从未查过 memory-os**；`<HERMES_HOME>/memory-os/bin/memory-os`
+  全仓库只出现在报告自身。真缺口是源码复制安装不 pip install。
+- **运行时不在 `sys.path`**：报告称"仓库无任何打包元数据"为假。真实情况是
+  50 个第一方脚本各自 bootstrap，且
+  `tests/scripts/test_memory_os_installed_layout_imports.py` **已用测试钉死
+  该缺陷类**（记录 3.200 上 `deploy_l3_probe.py` 的真实事故）。该测试用
+  `-S -E` 隔离子解释器正是为了让 CI 的 editable 安装不使测试空转——**故报告
+  建议的 `.pth` 方案要驳回**：往 site-packages 放 `.pth` 会造成"测试被 `-S`
+  屏蔽、生产生效"的路径解析分叉，把已钉死的缺陷类重新变成盲区。
+
+**"冷启动图谱静默无解释"亦证伪**：`structural_edge_proposer.py:278-281`
+返回 `reason="need ≥2 crystallized records, got N"`，符合本项目
+「Completion Is Not Output」的封闭原因码要求；缺的是**呈现**不是记录。
+
+### CY.1（P1，报告未发现）安装器"跑到底"被当成"成功"
+
+`main()` 末尾无条件 `return 0`（原 `1890-1891`）。后果：`systemctl enable`
+抛 `CalledProcessError` 被吞进 `cognitive_loop_enable_error` 字符串
+（原 `585`）、smoke test FAIL 只打印 `INSTALL MAY BE BROKEN` —— **退出码全是 0**。
+这正是本项目自己写死的反模式：请求了 enable 却没 enable 成，等同于坏掉的
+lane 关闭一个干净的 ExecutionGate 信封。
+
+**同文件内已有相反先例**：`_enable_memory_provider` 经 `_run_required_command`
+直接抛异常（并有测试钉住），systemd 路径却静默——故本修复不是新政策，
+是**恢复一致性**。Rule 5 扫描：兄弟安装器
+`install_memory_os_monitor_dashboard_service.py` 用 `runner(command, check=True)`
+**同样硬失败**，本缺陷是孤例。
+
+修复：新增 `POST_CONDITION_EXIT_CODE = 3` 与 `_unmet_post_conditions(report)`。
+选 3 而非 1，是因为 1 已被未捕获异常占用、2 被 argparse 占用，`.sh` 需要区分
+"崩了"与"跑到底但没做到"。
+
+### CY.2 每个 timer 一个封闭 outcome，孤儿态必须自报家门
+
+新增 `_timer_enable_state()`，封闭取值
+`not_installed` / `artifacts_written_not_enabled` / `enabled` /
+`enable_skipped_systemctl_unavailable` / `enable_failed`，进报告
+`runtime_timer_state` / `cognitive_loop_timer_state`。
+`artifacts_written_not_enabled`（即 CY.0 复现的那个形态）额外向 stderr
+打一条指明"单元文件已写、systemd 从未见过"的警告——但**不判失败**，
+因为只装不启是合法用法（cron 兜底）。
+`systemctl_unavailable_skipped` 同样**不算未达成**：无 user systemd 主机
+回落 cron 是既定设计。
+
+### CY.3 smoke test：分开"探针没跑成"与"探针跑了且失败"
+
+实施中被自己的测试打脸：把 smoke FAIL 一律判致命，会让
+`test_installer_cli_hindsight_config_imports_when_run_by_absolute_path`
+挂掉——因为 `_verify_memory_os_hot_path` 在 **hermes-agent 不可导入**时
+也返回 `(False, ...)`，而"从没装 hermes-agent 的机器上安装"是合法场景。
+这与本项目「一个 lane 无产出必须说明是没有输入还是处理失败」是同一条要求。
+
+修复：加 `SMOKE_HOST_RUNTIME_UNAVAILABLE` 前缀标记与 `_smoke_status()`，
+封闭取值 `not_requested` / `passed` / `host_runtime_unavailable` / `failed`；
+`_unmet_post_conditions` **只判 `failed`**。
+
+### CY.4 `.sh` 侧：容忍 exit 3 但必须把它折进裁决
+
+顾问在方案评审时抓到我第一版的洞：若 `.sh` 仅"容忍" rc==3 就交给
+`verify_install`，则 smoke FAIL 而 timer 健康时——`verify_install` 从不重跑
+smoke → `verify_failures` 为空 → **退出 0**，我要修的 envelope bug 原样搬到
+shell 层。**报告可以归一到一个面，裁决不行。**
+
+修复：`run_installer` 捕获 rc（rc==3 记 `INSTALLER_POST_CONDITION_FAILED=1`
+并继续；其余非零仍按原样中止），`verify_install` 把该标志注入
+`verify_failures`；且 `SKIP_VERIFY`/`DRY_RUN` 早退分支**也**检查该标志
+（`--skip-verify` 静的是我们自己的探针，不是安装器已报告的事实）。
+
+**刻意不做**：不把 `--skip-verify` 透传给 plugin.py。自审时发现
+`deploy_memory_os.py:271` 每次 apply 都传 `--skip-verify`，透传会
+**静默取消每一次生产部署的 hot-path smoke** ——这是方案里没有的覆盖损失。
+已在原处留注释说明为何不传。
+
+### CY.5（P2）`_ensure_config_defaults` 在全新主机上整体跳过
+
+`config.json` 不存在时 `return {"status": "no_config"}` 早退，于是 CE 那条
+**唯一**自动纠偏（`memory_sources.enabled` False→True，存在理由是 CD.E
+四天生产披露断流）在**最需要它的全新 profile 上从不执行**。Section W 规则 4
+所指的"静默跳过型地雷"。
+
+影响面已界定：`.sh` 三种模式必传 `--memory-sources-preset`（`684`），
+preset 写入器先建 config.json，故只咬直调 plugin.py 的路径。
+
+修复：改为写最小骨架再套既有逻辑。三个细节：
+① 补 `config_path.parent.mkdir(parents=True, exist_ok=True)`——原写入分支
+从不需要 mkdir，因为早退保证了父目录存在，去掉早退就去掉了那个保证
+（顾问指出，否则恰好在目标主机上崩）；
+② 骨架显式写 `memory_sources.mode = "metadata_only"`——**这是我自己的测试
+抓出来的**：只靠 CE 那行 `ms_cfg["enabled"]=True` 会写出没有 `mode` 的
+半个 dict，隐私相关字段的安全性就寄托在另一个模块的读时默认上；
+③ 沿用既有 `updated`/`would_update` 词表不新增取值（无生产读者，遵守封闭集合）。
+
+**顺带修正一个既有测试的附带断言**：
+`test_installer_does_not_write_memory_sources_config_by_default` 原先断言
+`config.json` 根本不存在——那是上述缺陷的副产物，不是契约。改为断言其真实
+意图（未写入任何 preset 标记），并钉住守护产物。
+
+### 反事实覆盖
+
+三条修复各自 revert→实测 FAIL→restore→PASS（用 `cp` 备份，不用
+`git checkout --`）：
+- 退出码改回 `return 0` → `assert 0 == 3` FAIL；
+- 恢复 `no_config` 早退 → 两条骨架测试以 `'no_config' == 'updated'` FAIL；
+- `artifacts_written_not_enabled` 改回 `not_installed` → 孤儿态测试 FAIL。
+
+### 测试计数与门
+
+新增 **9 个测试函数**（骨架创建 2、timer 状态/孤儿告警 2、未达成判定 3、
+smoke 状态分级 1、退出码正反各 1 中的 1）；另修正 1 个既有测试的附带断言。
+全量 3537 → **3546 passed / 13 skipped / 0 failed**（12:03）。
+四静态门（import_cycle / write_surface `unclassified_count=0` /
+static_hygiene / public_checkout_probe --strict）+ `git diff --check` 全绿。
+
+### 未做（边界扩张，待 owner 放行）
+
+`memory-os` CLI wrapper（建议写进既有 `<HERMES_HOME>/memory-os/bin/`，
+**不采纳 `.pth`**，理由见 CY.0）、部署完整性 doctor（另开子命令而非并入
+`doctor`，因 README lane A 在无 systemd 的临时目录跑 `doctor`；且新证据
+等级必须同批注册进 CLAUDE.md 的封闭集合）、lane preset（仅接受显式
+`--lane-preset-owner-approved` + 仅 shadow 档，**驳回**"作为
+`--production-safe` 默认"——模式默认不是 owner 权威）。
+
+---
+
 ## 待办
 
 **`vector_edge_proposer` 无 `outcome`、无写失败计数（CW 登记，2026-08-15）。**
@@ -6434,3 +6594,17 @@ failed**（11:46），四静态门 + `git diff --check` 全绿。
   计数三层接线含 `if not facts` 早退、timeutil 25 点收敛）拒 2（event_stats
   排序反测经模糊测试证明不可构造、双排序 Timsort 下不成立）；
   另钉解析器取舍特征测试。
+
+- `5c2d9c0..（CY，本节）`：外部主机部署报告 `deploy_improvements.md` 8 项逐条
+  核实——2 项证伪（`recall_arbitration` 默认段与 digest 内联 `oa_` token 的
+  建议修复均已在代码中，且其引用的 `_load_provider_config`/
+  `command_exists memory-os`/`memory-os/bin/memory-os` 三处仓库内不存在）、
+  3 项归因错、3 项属实；另查出报告未发现的真 P1：`install_memory_os_plugin.py`
+  `main()` 无条件 `return 0`，吞掉 `systemctl enable` 失败与 smoke FAIL。
+  修 3 项——退出码诚实化（新 code 3 + `_unmet_post_conditions`）、每 timer
+  封闭 outcome 与孤儿态告警、`_ensure_config_defaults` 全新主机骨架（CE 守护
+  原本在最需要的主机上被整体跳过）；顺带把 smoke 的"探针没跑成"与"跑了且失败"
+  分级（否则合法环境被判失败），并在 `.sh` 把 exit 3 **折进** `verify_failures`
+  而非仅容忍（否则同一 envelope bug 搬到 shell 层）。自审否掉自己加的
+  `--skip-verify` 透传（会静默取消每次生产部署的 smoke）。
+  全量 3537→3546 passed（+9）/13 skipped，四门全绿。

--- a/plugins/memory/memory_os/cli.py
+++ b/plugins/memory/memory_os/cli.py
@@ -732,6 +732,151 @@ def _direct_hermes_provider_active(hermes_home: Path) -> bool:
     return str(memory.get("provider") or "") == "hindsight"
 
 
+def _systemctl_user_units() -> set[str] | None:
+    """Unit names systemd knows about for this user, or None if unknowable.
+
+    None means "no sample" -- systemctl absent, no user bus (containers, an
+    SSH session without a user session). The caller emits nothing in that
+    case rather than inventing a severity for it.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", "list-unit-files", "--no-legend", "--no-pager"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    names: set[str] = set()
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if parts:
+            names.add(parts[0])
+    return names
+
+
+def _cron_snapshot_drift_findings(store: MemoryOSStore) -> list[dict[str, Any]]:
+    """Lanes registered in code but absent from the host's installed snapshot.
+
+    ``cron_group_runner._load_group`` prefers
+    ``system/memory_os_cron_registry.json`` and returns its ``member_keys``
+    without falling back whenever that list is non-empty. So on an onboarded
+    host a newly registered lane is simply missing from its tick: no
+    unknown-key error, no WARN, a clean envelope closed having never invoked
+    it. CLAUDE.md documents this as silent and, until now, undetected.
+
+    Gated on the snapshot existing, which is not buying green: with no
+    snapshot the runner falls back to the compiled-in registry and there is
+    no gap to find. The failure is a snapshot that exists and omits a lane.
+    """
+    from .cron_registry import groups_from_snapshot, memory_os_cron_groups
+
+    snapshot_path = store.roots.memory_os_root / "system" / "memory_os_cron_registry.json"
+    if not snapshot_path.is_file():
+        return []
+    try:
+        raw = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [
+            _finding(
+                "cron_registry_snapshot_unreadable",
+                "warning",
+                f"Installed cron registry snapshot could not be read: {exc}. "
+                "Lane membership on this host cannot be verified.",
+                {"snapshot_path": str(snapshot_path)},
+            )
+        ]
+    if not isinstance(raw, dict):
+        return []
+    installed = {group.key: set(group.member_keys) for group in groups_from_snapshot(raw)}
+    if not installed:
+        # A v0 snapshot carries no groups array; callers fall back by design.
+        return []
+    findings: list[dict[str, Any]] = []
+    for group in memory_os_cron_groups():
+        if group.key not in installed:
+            continue
+        missing = sorted(set(group.member_keys) - installed[group.key])
+        if not missing:
+            continue
+        findings.append(
+            _finding(
+                "cron_registry_snapshot_missing_lanes",
+                "warning",
+                f"Cron group {group.key!r} is registered with lanes that the installed "
+                f"snapshot does not list: {', '.join(missing)}. Those lanes never run on "
+                "this host and close no envelope. Re-run owner cron onboarding (or the "
+                "installer) to regenerate the snapshot.",
+                {
+                    "group_key": group.key,
+                    "missing_lane_keys": missing,
+                    "registered_member_keys": list(group.member_keys),
+                    "installed_member_keys": sorted(installed[group.key]),
+                    "snapshot_path": str(snapshot_path),
+                },
+            )
+        )
+    return findings
+
+
+def _orphan_systemd_unit_findings(store: MemoryOSStore) -> list[dict[str, Any]]:
+    """Timer unit files written to disk that systemd has never been told about.
+
+    The installer writes units whenever ``install_*`` OR ``enable_*`` is set
+    but only registers them under ``enable_*``, so a partial flag set leaves
+    units that look installed and never fire. Warning, not error: install
+    without enable is a supported steady state (cron fallback).
+    """
+    systemd_dir = store.roots.memory_os_root / "systemd"
+    if not systemd_dir.is_dir():
+        return []
+    # Unit names come from the on-disk filenames -- the per-profile suffix is
+    # already baked in. Never re-derive that suffix here; doing so is how a
+    # probe ends up asking about a unit that was never installed.
+    timers = sorted(path.name for path in systemd_dir.glob("*.timer"))
+    if not timers:
+        return []
+    known = _systemctl_user_units()
+    if known is None:
+        return []
+    orphans = [name for name in timers if name not in known]
+    if not orphans:
+        return []
+    return [
+        _finding(
+            "systemd_timer_unit_not_registered",
+            "warning",
+            f"Timer unit files exist under {systemd_dir} but systemd does not know them: "
+            f"{', '.join(orphans)}. Those lanes never run. Enable them, or ignore this if "
+            "the host schedules Memory-OS through cron instead.",
+            {"systemd_dir": str(systemd_dir), "unregistered_units": orphans},
+        )
+    ]
+
+
+def _deployment_integrity_checks(store: MemoryOSStore) -> list[dict[str, Any]]:
+    """Deployment-surface findings, each gated on its surface being present.
+
+    These ride ``doctor`` rather than a separate ``deploy-doctor`` command.
+    The reason to split was noise on the README's blank-machine lane, where
+    ``doctor`` runs against a bare temp dir with no systemd and no cron --
+    and gating every check on the artifact it inspects removes that noise at
+    the source: a profile with no snapshot and no unit files produces no
+    findings here at all. Keeping them on ``memory-os.doctor.v0`` also means
+    no new evidence level enters the documented closed set.
+    """
+    return [
+        *_cron_snapshot_drift_findings(store),
+        *_orphan_systemd_unit_findings(store),
+    ]
+
+
 def _hermes_contract_checks() -> list[dict[str, Any]]:
     """Verify Memory-OS plugin conforms to Hermes agent memory provider contract.
 
@@ -850,8 +995,11 @@ def build_doctor_result(store: MemoryOSStore) -> dict[str, Any]:
     audit = meta_audit(store)
     has_error = any(finding["severity"] == "error" for finding in audit["findings"])
     contract_findings = _hermes_contract_checks()
-    all_findings = audit["findings"] + contract_findings
-    has_error = has_error or any(f["severity"] == "error" for f in contract_findings)
+    deployment_findings = _deployment_integrity_checks(store)
+    all_findings = audit["findings"] + contract_findings + deployment_findings
+    has_error = has_error or any(
+        f["severity"] == "error" for f in (*contract_findings, *deployment_findings)
+    )
     return {
         "schema_version": "memory-os.doctor.v0",
         "exit_code": 1 if has_error else 0,
@@ -861,6 +1009,10 @@ def build_doctor_result(store: MemoryOSStore) -> dict[str, Any]:
         "hermes_contract_checks": {
             "count": len(contract_findings),
             "findings": contract_findings,
+        },
+        "deployment_integrity_checks": {
+            "count": len(deployment_findings),
+            "findings": deployment_findings,
         },
     }
 

--- a/scripts/install_memory_os.sh
+++ b/scripts/install_memory_os.sh
@@ -14,6 +14,12 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 YES=0
 DRY_RUN=0
 SKIP_VERIFY=0
+# Set when install_memory_os_plugin.py exits 3: it ran to completion but did
+# not achieve something that was requested. Carried across functions so the
+# verdict is folded into verify_install's box instead of being tolerated --
+# tolerating the code without folding it in would move the very "exit 0 while
+# something requested did not happen" bug up into this wrapper.
+INSTALLER_POST_CONDITION_FAILED=0
 ALLOW_CREATE=0
 MODE="interactive"
 HERMES_HOME_INPUT="${HERMES_HOME:-}"
@@ -685,6 +691,11 @@ run_installer() {
   [[ -n "${LLM_JUDGE_PRESET}" ]] && args+=("--llm-judge-preset" "${LLM_JUDGE_PRESET}")
   args+=("--hindsight" "${HINDSIGHT_MODE}")
   [[ "${DRY_RUN}" == "1" ]] && args+=("--dry-run")
+  # NOTE: --skip-verify is deliberately NOT propagated. It silences this
+  # wrapper's own probes only; the Python installer still runs its hot-path
+  # smoke test. deploy_memory_os.py passes --skip-verify on every apply
+  # (it runs its own phased postcheck), so propagating would silently drop
+  # the smoke test from every production deploy.
 
   # ── Auto-detect gateway Python for package installs ──────────────────
   if [[ -z "${TARGET_PYTHON:-}" ]]; then
@@ -705,7 +716,19 @@ run_installer() {
   echo "Running installer:"
   printf '  %q' "${args[@]}"
   echo
-  "${args[@]}"
+  local installer_rc=0
+  "${args[@]}" || installer_rc=$?
+  if [[ "${installer_rc}" == "3" ]]; then
+    # Exit 3 = ran to the end, but a requested action did not happen. Keep
+    # going so verify_install can render one consolidated failure box rather
+    # than aborting here with a bare shell error; the flag guarantees the
+    # run still fails.
+    INSTALLER_POST_CONDITION_FAILED=1
+    echo "  [WARN] installer reported unmet post-conditions (exit 3) — continuing to verification"
+  elif [[ "${installer_rc}" != "0" ]]; then
+    # Anything else is a hard failure (uncaught exception / usage error).
+    exit "${installer_rc}"
+  fi
 
   # Install cleanup_expired_working.py script
   local cleanup_src="${REPO_ROOT}/scripts/cleanup_expired_working.py"
@@ -754,12 +777,24 @@ run_installer() {
 }
 
 verify_install() {
-  [[ "${SKIP_VERIFY}" == "1" || "${DRY_RUN}" == "1" ]] && return 0
+  if [[ "${SKIP_VERIFY}" == "1" || "${DRY_RUN}" == "1" ]]; then
+    # --skip-verify silences OUR probes, not the installer's own verdict: an
+    # unmet post-condition is something the installer reported as fact, so it
+    # still fails the run.
+    if [[ "${INSTALLER_POST_CONDITION_FAILED}" == "1" ]]; then
+      echo "Memory-OS install reported unmet post-conditions (exit 3); see the JSON report above." >&2
+      exit 1
+    fi
+    return 0
+  fi
   echo
   echo "Memory-OS install verification"
   echo "------------------------------"
 
   local verify_failures=()
+  if [[ "${INSTALLER_POST_CONDITION_FAILED}" == "1" ]]; then
+    verify_failures+=("installer reported unmet post-conditions (exit 3) — see JSON report above")
+  fi
 
   # ── Doctor check (always run) ──────────────────────────────────────
   HERMES_HOME="${HERMES_HOME}" hermes memory

--- a/scripts/install_memory_os.sh
+++ b/scripts/install_memory_os.sh
@@ -793,7 +793,8 @@ verify_install() {
 
   local verify_failures=()
   if [[ "${INSTALLER_POST_CONDITION_FAILED}" == "1" ]]; then
-    verify_failures+=("installer reported unmet post-conditions (exit 3) — see JSON report above")
+    # Kept under 54 chars: the box below renders each entry with %-54s.
+    verify_failures+=("installer post-conditions unmet (exit 3, see JSON)")
   fi
 
   # ── Doctor check (always run) ──────────────────────────────────────

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -471,6 +471,7 @@ def install_plugin(
         hermes_home,
         dry_run=dry_run,
     )
+    cli_wrapper_path = _write_cli_wrapper(hermes_home, dry_run=dry_run)
     v3_backup_exclusions_path = _write_v3_backup_exclusions(hermes_home, dry_run=dry_run)
     expired_cleanup_report = _run_expired_working_migration(
         hermes_home,
@@ -773,6 +774,8 @@ def install_plugin(
         "hindsight_mode": hindsight_mode,
         "hindsight_adoption": hindsight_adoption,
         "config_defaults": config_defaults_report,
+        "cli_wrapper_path": str(cli_wrapper_path),
+        "cli_wrapper_installed": not dry_run,
         "v3_backup_exclusions_path": str(v3_backup_exclusions_path),
         "expired_working_cleanup": expired_cleanup_report,
         "smoke_test": {
@@ -1280,6 +1283,42 @@ def _write_cognitive_loop_artifacts(hermes_home: Path, *, interval: str, dry_run
         encoding="utf-8",
     )
     return artifacts
+
+
+def _write_cli_wrapper(hermes_home: Path, *, dry_run: bool) -> Path:
+    """Put a runnable ``memory-os`` on disk for a source install.
+
+    ``pyproject.toml`` declares a ``memory-os`` console script, but that only
+    materialises for someone who ran ``pip install``. The host install copies
+    sources instead, so a deployed machine has the full 35-subcommand CLI and
+    no way to type it -- every diagnostic becomes a hand-written
+    ``PYTHONPATH=... python3 -m ...`` incantation.
+
+    Lives beside the heartbeat/cognitive-loop wrappers in ``memory-os/bin/``
+    and sets the same PYTHONPATH they do.  Unlike those two -- cron jobs,
+    where pinning HERMES_HOME is correct -- this is an interactive command,
+    so the installed home is only a DEFAULT: ``HERMES_HOME=/other memory-os
+    status`` still works.
+    """
+    wrapper = hermes_home / "memory-os" / "bin" / "memory-os"
+    if dry_run:
+        return wrapper
+    wrapper.parent.mkdir(parents=True, exist_ok=True)
+    # The default home is assigned on its own line and only then expanded.
+    # Inlining it as "${HERMES_HOME:-'/path'}" looks right and is not: inside
+    # double quotes those single quotes are literal, so HERMES_HOME comes out
+    # as "'/path'" -- quotes included -- and every path built from it is wrong.
+    wrapper.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"memory_os_default_home={_shell_quote(str(hermes_home))}\n"
+        "export HERMES_HOME=\"${HERMES_HOME:-$memory_os_default_home}\"\n"
+        "export PYTHONPATH=\"${HERMES_HOME}/memory-os/runtime/python:${HERMES_HOME}/plugins:${PYTHONPATH:-}\"\n"
+        "exec python3 -m plugins.memory.memory_os \"$@\"\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+    return wrapper
 
 
 def _write_owner_review_cron_helper(hermes_home: Path, *, dry_run: bool) -> dict[str, Path]:

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -1,5 +1,26 @@
 #!/usr/bin/env python3
-"""Install Memory-OS as a Hermes user memory provider plugin."""
+"""Install Memory-OS as a Hermes user memory provider plugin.
+
+LOW-LEVEL PLUMBING -- the supported entry point is
+``scripts/install_memory_os.sh``.  Every switch here is opt-in
+(``store_true``), so invoking this module directly with a partial flag set
+produces a partially-installed host: notably ``--install-cognitive-loop``
+WITHOUT ``--enable-cognitive-loop`` writes the systemd unit files under
+``<HERMES_HOME>/memory-os/systemd/`` but never links or enables them, which
+looks healthy from the artifact list alone.  The wrapper supplies the
+production defaults and the fail-loud verification pass; this module only
+owns being honest about what it did and did not achieve.
+
+Exit codes:
+  0  everything requested was achieved (or ``--dry-run``)
+  1  hard failure -- an uncaught exception (e.g. provider enable raised)
+  2  argparse usage error
+  3  install completed but a REQUESTED post-condition was not achieved
+     (a timer enable that failed, or a failing hot-path smoke test).
+     Code 3 exists so ``install_memory_os.sh`` can distinguish "crashed"
+     from "ran to the end without doing what was asked" and fold the
+     latter into its own verification verdict instead of aborting early.
+"""
 
 from __future__ import annotations
 
@@ -235,6 +256,27 @@ LLM_JUDGE_PRESETS: dict[str, dict[str, object]] = {
 }
 
 
+# Marker prefix on the one smoke-test failure that means "the probe could not
+# run here", not "the hot path is broken". Graded separately: see
+# _smoke_status() and _unmet_post_conditions().
+SMOKE_HOST_RUNTIME_UNAVAILABLE = "host_runtime_unavailable"
+
+
+def _smoke_status(*, requested: bool, ok: bool, detail: str) -> str:
+    """Closed status for the hot-path smoke test.
+
+    "not run" and "ran and failed" must not share an outcome -- that is the
+    same conflation that lets a broken lane and an idle lane look identical.
+    """
+    if not requested:
+        return "not_requested"
+    if ok:
+        return "passed"
+    if str(detail or "").startswith(SMOKE_HOST_RUNTIME_UNAVAILABLE):
+        return SMOKE_HOST_RUNTIME_UNAVAILABLE
+    return "failed"
+
+
 def _verify_memory_os_hot_path(hermes_home: str) -> tuple:
     """E2E smoke test: verify Hermes MemoryManager accepts and calls the provider.
 
@@ -252,8 +294,13 @@ def _verify_memory_os_hot_path(hermes_home: str) -> tuple:
         from agent.memory_manager import MemoryManager
         from agent.memory_provider import MemoryProvider as HostABC
     except ImportError as e:
+        # The probe could not RUN -- distinct from "it ran and the hot path is
+        # broken". Installing from a machine without hermes-agent importable is
+        # legitimate, so this must never be graded as a hot-path failure. The
+        # prefix is the contract with the single call site below.
         return False, (
-            f"Cannot import Hermes agent runtime — is hermes-agent installed? {e}"
+            f"{SMOKE_HOST_RUNTIME_UNAVAILABLE}: Cannot import Hermes agent runtime — "
+            f"is hermes-agent installed? {e}"
         )
 
     # 1. Verify provider class inherits from host ABC
@@ -591,6 +638,34 @@ def install_plugin(
                     file=sys.stderr,
                 )
 
+    # ── Per-timer closed outcome, and a loud word for the orphan shape ──
+    runtime_timer_state = _timer_enable_state(
+        artifacts_written=bool(runtime_artifacts) and not dry_run,
+        enable_requested=enable_runtime,
+        enabled=runtime_enabled,
+        start_method=runtime_start_method,
+    )
+    cognitive_loop_timer_state = _timer_enable_state(
+        artifacts_written=bool(cognitive_loop_artifacts) and not dry_run,
+        enable_requested=enable_cognitive_loop,
+        enabled=cognitive_loop_enabled,
+        start_method=cognitive_loop_start_method,
+    )
+    for _label, _flag, _state in (
+        ("heartbeat", "--enable-runtime", runtime_timer_state),
+        ("cognitive-loop", "--enable-cognitive-loop", cognitive_loop_timer_state),
+    ):
+        if _state != "artifacts_written_not_enabled":
+            continue
+        print(
+            f"memory-os-install: WARNING — {_label} systemd unit files were written to "
+            f"{hermes_home}/memory-os/systemd/ but NOT registered with systemd "
+            f"(no {_flag}). The units exist on disk and the lane will never run.\n"
+            f"  Re-run with {_flag}, or use the supported entry point: "
+            f"scripts/install_memory_os.sh",
+            file=sys.stderr,
+        )
+
     # E2E smoke test — verify hot path is actually working
     smoke_ok = True
     smoke_detail = ""
@@ -645,6 +720,7 @@ def install_plugin(
         "runtime_start_method": runtime_start_method,
         "runtime_enable_error": runtime_enable_error,
         "runtime_enable_command": runtime_enable_command,
+        "runtime_timer_state": runtime_timer_state,
         "cognitive_loop_artifacts_installed": bool(cognitive_loop_artifacts) and not dry_run,
         "cognitive_loop_artifacts": [str(path) for path in cognitive_loop_artifacts],
         "cognitive_loop_interval": cognitive_loop_interval,
@@ -653,6 +729,7 @@ def install_plugin(
         "cognitive_loop_start_method": cognitive_loop_start_method,
         "cognitive_loop_enable_error": cognitive_loop_enable_error,
         "cognitive_loop_enable_command": cognitive_loop_enable_command,
+        "cognitive_loop_timer_state": cognitive_loop_timer_state,
         "owner_review_cron_helper_install_requested": install_owner_review_cron_helper,
         "owner_review_cron_helper_installed": bool(owner_review_cron_helper.get("helper")) and not dry_run,
         "owner_review_cron_helper_path": str(owner_review_cron_helper.get("helper") or ""),
@@ -702,6 +779,11 @@ def install_plugin(
             "requested": not skip_verify and not dry_run,
             "passed": smoke_ok,
             "detail": smoke_detail,
+            "status": _smoke_status(
+                requested=not skip_verify and not dry_run,
+                ok=smoke_ok,
+                detail=smoke_detail,
+            ),
         },
         "dry_run": dry_run,
     }
@@ -867,6 +949,75 @@ def _ensure_embedder_package(*, dry_run: bool = False, target_python: str = "") 
             file=sys.stderr,
         )
         return result
+
+
+def _timer_enable_state(
+    *,
+    artifacts_written: bool,
+    enable_requested: bool,
+    enabled: bool,
+    start_method: str,
+) -> str:
+    """Closed reason code for what happened to one systemd timer.
+
+    "The unit files exist" is not "the timer runs": the copy into the user
+    unit directory and ``systemctl enable --now`` live inside the
+    ``enable_*`` branch, while the artifacts are written whenever EITHER
+    ``install_*`` or ``enable_*`` is set.  Installing without enabling
+    therefore leaves unit files on disk that systemd has never seen -- the
+    shape a real deployment hit -- and nothing in the artifact list says so.
+    This makes that state say its own name.
+    """
+    if not artifacts_written:
+        return "not_installed"
+    if not enable_requested:
+        return "artifacts_written_not_enabled"
+    if enabled:
+        return "enabled"
+    if start_method == "systemctl_unavailable_skipped":
+        return "enable_skipped_systemctl_unavailable"
+    return "enable_failed"
+
+
+# Install ran to completion but did not achieve something it was asked to do.
+# Distinct from 1 (uncaught exception) and 2 (argparse) so the shell wrapper
+# can fold it into its own verdict rather than aborting before it reports.
+POST_CONDITION_EXIT_CODE = 3
+
+
+def _unmet_post_conditions(report: dict[str, Any]) -> list[str]:
+    """Requested actions that did not actually happen.
+
+    Completion is judged from what the install ACHIEVED, never from the fact
+    that it reached the end -- an installer that exits 0 having not enabled
+    what was asked is the same defect shape as a broken lane closing a clean
+    ExecutionGate envelope.  ``_enable_memory_provider`` already fails hard
+    on this class; the systemd path used to swallow it into a string field
+    that only a JSON reader would ever see.
+
+    ``systemctl_unavailable_skipped`` is deliberately NOT unmet: falling back
+    to cron on a host without user systemd is documented behaviour.
+    """
+    if bool(report.get("dry_run")):
+        return []
+    unmet: list[str] = []
+    for label, state_key, error_key in (
+        ("heartbeat timer", "runtime_timer_state", "runtime_enable_error"),
+        ("cognitive-loop timer", "cognitive_loop_timer_state", "cognitive_loop_enable_error"),
+    ):
+        if str(report.get(state_key) or "") != "enable_failed":
+            continue
+        detail = str(report.get(error_key) or "") or "no error detail recorded"
+        unmet.append(f"{label}: enable was requested but the timer is not enabled ({detail})")
+    smoke = report.get("smoke_test") if isinstance(report.get("smoke_test"), dict) else {}
+    # Only a probe that RAN and failed counts. host_runtime_unavailable means
+    # the probe could not run at all (installing from a machine where
+    # hermes-agent is not importable is legitimate and pre-dates this change),
+    # so grading it would fail installs that are fine.
+    if str(smoke.get("status") or "") == "failed":
+        detail = str(smoke.get("detail") or "") or "no detail recorded"
+        unmet.append(f"hot-path smoke test: FAIL ({detail})")
+    return unmet
 
 
 def _systemctl_available() -> bool:
@@ -1888,7 +2039,21 @@ def main() -> int:
         skip_verify=args.skip_verify,
     )
     print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
-    return 0
+
+    unmet = _unmet_post_conditions(report)
+    if not unmet:
+        return 0
+    print(
+        "memory-os-install: INSTALL INCOMPLETE — requested actions that were not achieved:",
+        file=sys.stderr,
+    )
+    for item in unmet:
+        print(f"  ✗ {item}", file=sys.stderr)
+    print(
+        f"  (exit {POST_CONDITION_EXIT_CODE}: the install ran to the end; the items above did not happen)",
+        file=sys.stderr,
+    )
+    return POST_CONDITION_EXIT_CODE
 
 
 def _write_v3_backup_exclusions(hermes_home: Path, *, dry_run: bool) -> Path:
@@ -1920,16 +2085,34 @@ def _ensure_config_defaults(
     strips keys outside the schema (e.g. the ``preset`` markers other
     installer steps just wrote) -- the same key-laundering mechanism that let
     a config rewrite silently flip production switches (CD.E).
+
+    A missing config.json used to return early, which silently skipped the CE
+    guard on exactly the host that needs it most: a fresh profile.  Every
+    ``install_memory_os.sh`` mode passes a preset whose writer creates the
+    file first, so the gap only opened on the direct-``plugin.py`` path -- but
+    "the guard runs on every install" was the whole premise of CE, and an
+    early return that skips it silently is the trap Section W rule 4 names.
+    The skeleton is written from scratch instead; the provider merges
+    ``DEFAULT_CONFIG`` over whatever is on disk, so an empty base is safe.
     """
     config_path = hermes_home / "memory-os" / "config.json"
-    if not config_path.exists():
-        return {"status": "no_config", "reason": "config.json not found"}
-    cfg = _read_json_config(config_path)
+    created_skeleton = not config_path.exists()
+    cfg = {} if created_skeleton else _read_json_config(config_path)
     changed: list[str] = []
+    if created_skeleton:
+        # State metadata_only ON DISK rather than leaning on the provider's
+        # read-time merge. mode is the privacy-relevant field (never raw
+        # bodies); a config an auditor can read beats one whose safety
+        # depends on a default living in another module. enabled is left
+        # False here so the CE guard below is what flips it -- and therefore
+        # still reports the flip in `changes`.
+        cfg["memory_sources"] = {"enabled": False, "mode": "metadata_only"}
+        changed.append("config.json: created (was missing; core-switch guard would otherwise be skipped)")
 
     if cfg.get("prefetch_char_budget", 0) < 5500:
+        previous = cfg.get("prefetch_char_budget")
         cfg["prefetch_char_budget"] = 5500
-        changed.append("prefetch_char_budget: 2200 → 5500")
+        changed.append(f"prefetch_char_budget: {previous if previous is not None else 'unset'} → 5500")
 
     # CE: core observability must not ship dark on an upgraded host. The
     # disclosure ledger (memory_sources, metadata_only -- no raw bodies) is
@@ -1970,6 +2153,10 @@ def _ensure_config_defaults(
         }
 
     if not dry_run:
+        # The parent used to be guaranteed by the early return (the file
+        # existed, so its directory did). Creating the skeleton removes that
+        # guarantee on a fresh profile.
+        config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(
             json.dumps(cfg, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",

--- a/tests/scripts/test_memory_os_core_switch_guard.py
+++ b/tests/scripts/test_memory_os_core_switch_guard.py
@@ -63,6 +63,44 @@ def test_ensure_config_defaults_re_enables_core_disclosure_ledger(tmp_path: Path
     assert report_again["core_mode_report"]["memory_sources.enabled"] is True
 
 
+def test_ensure_config_defaults_creates_skeleton_on_a_fresh_profile(tmp_path: Path):
+    """Counterfactual: the missing-config early return skipped the CE guard.
+
+    A fresh profile is precisely the host that has never had the disclosure
+    ledger switched on, so returning ``no_config`` there meant the one
+    auto-corrected core switch was applied everywhere EXCEPT where it was
+    needed. Note the directory does not exist either -- the old write path
+    never needed a mkdir because the early return guaranteed a parent.
+    """
+    home = tmp_path / "home"
+    assert not (home / "memory-os").exists()
+
+    report = _ensure_config_defaults(home)
+
+    assert report["status"] == "updated"
+    saved = json.loads((home / "memory-os" / "config.json").read_text(encoding="utf-8"))
+    assert saved["memory_sources"]["enabled"] is True
+    assert saved["memory_sources"]["mode"] == "metadata_only"
+    assert saved["prefetch_char_budget"] == 5500
+    assert any("created" in change for change in report["changes"])
+    # Graduated modes are still only reported, never invented on disk.
+    assert "recall_arbitration" not in saved
+    assert report["core_mode_report"]["memory_sources.enabled"] is True
+
+    # Idempotent: a second pass finds nothing left to do.
+    assert _ensure_config_defaults(home)["status"] == "already_current"
+
+
+def test_ensure_config_defaults_dry_run_does_not_create_missing_config(tmp_path: Path):
+    """dry_run + missing config is a new combination -- it must not write."""
+    home = tmp_path / "home"
+
+    report = _ensure_config_defaults(home, dry_run=True)
+
+    assert report["status"] == "would_update"
+    assert not (home / "memory-os" / "config.json").exists()
+
+
 def test_ensure_config_defaults_dry_run_reports_without_writing(tmp_path: Path):
     home = tmp_path / "home"
     (home / "memory-os").mkdir(parents=True)

--- a/tests/scripts/test_memory_os_deployment_integrity.py
+++ b/tests/scripts/test_memory_os_deployment_integrity.py
@@ -1,0 +1,192 @@
+"""Deployment-integrity findings on `memory-os doctor`.
+
+These checks live on `doctor` instead of a separate `deploy-doctor`
+subcommand. The argument for splitting was noise on the README's
+blank-machine lane, where `doctor` runs against a bare temp dir; gating each
+check on the presence of the artifact it inspects removes that noise at the
+source. `test_bare_profile_emits_no_deployment_findings` is what pins that
+contract -- without it, someone can drop the gating and the blank-machine
+lane silently becomes noisy again.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+from plugins.memory.memory_os.cli import (
+    _cron_snapshot_drift_findings,
+    _deployment_integrity_checks,
+    _orphan_systemd_unit_findings,
+    build_doctor_result,
+)
+from plugins.memory.memory_os.cron_registry import (
+    memory_os_cron_groups,
+    memory_os_cron_specs,
+    write_cron_registry_snapshot,
+)
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.store import MemoryOSStore
+
+
+def _store(tmp_path: Path) -> MemoryOSStore:
+    store = MemoryOSStore(MemoryOSRoots.from_hermes_home(tmp_path / "home"))
+    store.initialize()
+    return store
+
+
+def _snapshot_path(store: MemoryOSStore) -> Path:
+    return store.roots.memory_os_root / "system" / "memory_os_cron_registry.json"
+
+
+# ── The gating contract itself ────────────────────────────────────────────
+
+
+def test_bare_profile_emits_no_deployment_findings(tmp_path, monkeypatch):
+    """A profile with no snapshot and no unit files must stay silent.
+
+    This is the whole justification for merging these checks into `doctor`
+    instead of a separate subcommand. If it ever fails, either restore the
+    gating or split the surface -- do not relax the assertion.
+    """
+    # Even where a real systemd exists, the answer must not depend on it.
+    monkeypatch.setattr(
+        "plugins.memory.memory_os.cli._systemctl_user_units", lambda: {"unrelated.timer"}
+    )
+    store = _store(tmp_path)
+
+    assert _deployment_integrity_checks(store) == []
+    assert build_doctor_result(store)["deployment_integrity_checks"]["count"] == 0
+
+
+# ── (a) cron registry snapshot drift ──────────────────────────────────────
+
+
+def test_snapshot_missing_a_registered_lane_is_reported(tmp_path):
+    """Counterfactual: this is the failure CLAUDE.md records as undetected.
+
+    The snapshot is produced by the REAL writer, then one lane is dropped --
+    hand-rolling the JSON would let the test pass even if the writer's shape
+    drifted away from what the runner reads.
+    """
+    store = _store(tmp_path)
+    group = next(g for g in memory_os_cron_groups() if len(g.member_keys) >= 2)
+    dropped = group.member_keys[0]
+
+    specs = tuple(spec for spec in memory_os_cron_specs() if spec.key != dropped)
+    trimmed_groups = tuple(
+        g if g.key != group.key
+        else dataclasses.replace(
+            g, member_keys=tuple(k for k in g.member_keys if k != dropped)
+        )
+        for g in memory_os_cron_groups()
+    )
+    path = _snapshot_path(store)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_cron_registry_snapshot(path, specs=specs, groups=trimmed_groups)
+
+    findings = _cron_snapshot_drift_findings(store)
+
+    assert len(findings) == 1
+    assert findings[0]["code"] == "cron_registry_snapshot_missing_lanes"
+    assert findings[0]["details"]["missing_lane_keys"] == [dropped]
+    assert findings[0]["details"]["group_key"] == group.key
+    # Warning, not error: a version-skewed checkout against an older host
+    # HOME is a real false-positive path, so this must not fail an install.
+    assert findings[0]["severity"] == "warning"
+
+
+def test_snapshot_matching_the_registry_is_silent(tmp_path):
+    """The dual -- a correct host must produce nothing."""
+    store = _store(tmp_path)
+    path = _snapshot_path(store)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_cron_registry_snapshot(path, specs=memory_os_cron_specs(), groups=memory_os_cron_groups())
+
+    assert _cron_snapshot_drift_findings(store) == []
+
+
+def test_absent_snapshot_is_not_a_finding(tmp_path):
+    """No snapshot means the runner falls back to the compiled-in registry."""
+    store = _store(tmp_path)
+
+    assert not _snapshot_path(store).exists()
+    assert _cron_snapshot_drift_findings(store) == []
+
+
+def test_unreadable_snapshot_is_reported_rather_than_swallowed(tmp_path):
+    store = _store(tmp_path)
+    path = _snapshot_path(store)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ not json", encoding="utf-8")
+
+    findings = _cron_snapshot_drift_findings(store)
+
+    assert len(findings) == 1
+    assert findings[0]["code"] == "cron_registry_snapshot_unreadable"
+
+
+# ── (b) orphan systemd units ──────────────────────────────────────────────
+
+
+def _write_timer(store: MemoryOSStore, name: str) -> None:
+    systemd_dir = store.roots.memory_os_root / "systemd"
+    systemd_dir.mkdir(parents=True, exist_ok=True)
+    (systemd_dir / name).write_text("[Timer]\n", encoding="utf-8")
+
+
+def test_unit_files_systemd_never_saw_are_reported(tmp_path, monkeypatch):
+    """The exact shape the fresh-host deployment hit."""
+    store = _store(tmp_path)
+    _write_timer(store, "hermes-memory-os-cognitive-loop.timer")
+    monkeypatch.setattr(
+        "plugins.memory.memory_os.cli._systemctl_user_units",
+        lambda: {"hermes-memory-os-heartbeat.timer"},
+    )
+
+    findings = _orphan_systemd_unit_findings(store)
+
+    assert len(findings) == 1
+    assert findings[0]["code"] == "systemd_timer_unit_not_registered"
+    assert findings[0]["details"]["unregistered_units"] == [
+        "hermes-memory-os-cognitive-loop.timer"
+    ]
+    # Install-without-enable plus cron fallback is a supported steady state.
+    assert findings[0]["severity"] == "warning"
+
+
+def test_registered_units_are_silent(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    _write_timer(store, "hermes-memory-os-heartbeat.timer")
+    monkeypatch.setattr(
+        "plugins.memory.memory_os.cli._systemctl_user_units",
+        lambda: {"hermes-memory-os-heartbeat.timer"},
+    )
+
+    assert _orphan_systemd_unit_findings(store) == []
+
+
+def test_no_systemctl_means_no_sample_not_a_finding(tmp_path, monkeypatch):
+    """Unknowable is not the same as broken -- and gets no invented severity."""
+    store = _store(tmp_path)
+    _write_timer(store, "hermes-memory-os-cognitive-loop.timer")
+    monkeypatch.setattr("plugins.memory.memory_os.cli._systemctl_user_units", lambda: None)
+
+    assert _orphan_systemd_unit_findings(store) == []
+
+
+def test_profile_suffixed_unit_names_are_taken_from_disk(tmp_path, monkeypatch):
+    """Unit names come from the filenames, never re-derived from the profile.
+
+    Re-deriving the per-profile suffix is how a probe ends up asking systemd
+    about a unit that was never installed (fixed once already in CV).
+    """
+    store = _store(tmp_path)
+    _write_timer(store, "hermes-memory-os-cognitive-loop-sannai.timer")
+    monkeypatch.setattr("plugins.memory.memory_os.cli._systemctl_user_units", lambda: set())
+
+    findings = _orphan_systemd_unit_findings(store)
+
+    assert findings[0]["details"]["unregistered_units"] == [
+        "hermes-memory-os-cognitive-loop-sannai.timer"
+    ]

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -3,6 +3,7 @@ import json
 import argparse
 import os
 import subprocess
+import shutil
 import sys
 from pathlib import Path
 
@@ -1460,6 +1461,72 @@ def test_smoke_probe_actually_emits_the_unavailable_prefix(tmp_path, monkeypatch
         installer._smoke_status(requested=True, ok=ok, detail=detail)
         == installer.SMOKE_HOST_RUNTIME_UNAVAILABLE
     )
+
+
+def test_installer_writes_a_runnable_memory_os_cli_wrapper(tmp_path):
+    """A source install must leave a typeable `memory-os` behind.
+
+    pyproject declares the console script, but that only materialises for a
+    pip install; the host install copies sources, so without this the
+    deployed machine has the whole CLI and no way to invoke it.
+    """
+    home = tmp_path / "home"
+
+    report = install_plugin(hermes_home=home, skip_verify=True)
+
+    wrapper = home / "memory-os" / "bin" / "memory-os"
+    assert report["cli_wrapper_path"] == str(wrapper)
+    assert wrapper.is_file()
+    body = wrapper.read_text(encoding="utf-8")
+    # Same PYTHONPATH the heartbeat/cognitive-loop wrappers set.
+    assert "memory-os/runtime/python" in body
+    assert "exec python3 -m plugins.memory.memory_os" in body
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_installer_cli_wrapper_resolves_hermes_home_correctly(tmp_path):
+    """Run the wrapper's resolution instead of grepping it.
+
+    A substring assertion on "${HERMES_HOME:-" passes for
+    "${HERMES_HOME:-'/path'}" too -- and that spelling puts LITERAL single
+    quotes into HERMES_HOME, breaking every path derived from it. Only
+    executing the lines catches that, so this asserts the resolved value in
+    both directions.
+    """
+    home = tmp_path / "home"
+    install_plugin(hermes_home=home, skip_verify=True)
+    wrapper = home / "memory-os" / "bin" / "memory-os"
+
+    # Everything up to the exec: the home/PYTHONPATH resolution under test.
+    prelude = "".join(
+        line for line in wrapper.read_text(encoding="utf-8").splitlines(keepends=True)
+        if not line.startswith("exec ")
+    )
+
+    def resolved(env_home: str | None) -> str:
+        env = dict(os.environ)
+        env.pop("HERMES_HOME", None)
+        if env_home is not None:
+            env["HERMES_HOME"] = env_home
+        return subprocess.run(
+            ["bash", "-c", prelude + '\nprintf "%s" "$HERMES_HOME"'],
+            capture_output=True, text=True, check=True, env=env,
+        ).stdout
+
+    # Installed home is the default -- with no stray quotes.
+    assert resolved(None) == str(home)
+    # ...and an explicit HERMES_HOME still wins: this is an interactive CLI,
+    # not a cron wrapper where pinning the home is correct.
+    assert resolved("/somewhere/else") == "/somewhere/else"
+
+
+def test_installer_cli_wrapper_is_not_written_on_dry_run(tmp_path):
+    home = tmp_path / "home"
+
+    report = install_plugin(hermes_home=home, dry_run=True)
+
+    assert report["cli_wrapper_installed"] is False
+    assert not (home / "memory-os" / "bin" / "memory-os").exists()
 
 
 def test_installer_main_exits_three_on_unmet_post_conditions(tmp_path, monkeypatch, capsys):

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -715,11 +715,27 @@ def test_installer_can_write_deep_reflection_test_host_preset(tmp_path):
 
 
 def test_installer_does_not_write_memory_sources_config_by_default(tmp_path):
+    """No preset means no PRESET is written -- not that no config exists.
+
+    This used to assert config.json was absent entirely. That assertion was
+    incidental to a defect: ``_ensure_config_defaults`` returned early when
+    the file was missing, so the CE core-switch guard (the one that keeps the
+    disclosure ledger from shipping dark) was skipped on exactly the fresh
+    profiles it exists for. The guard now creates the skeleton, so the file
+    exists; what this test actually pins -- that no memory_sources *preset*
+    was applied -- is unchanged and asserted below.
+    """
     report = install_plugin(hermes_home=tmp_path / "home")
 
     assert report["memory_sources_preset"] is None
     assert report["memory_sources_config_written"] is False
-    assert not (tmp_path / "home" / "memory-os" / "config.json").exists()
+
+    config_path = tmp_path / "home" / "memory-os" / "config.json"
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    # Guard output only -- no preset marker, which is what "by default" means.
+    assert "preset" not in saved.get("memory_sources", {})
+    assert saved["memory_sources"]["enabled"] is True
+    assert saved["memory_sources"]["mode"] == "metadata_only"
 
 
 def test_installer_can_write_memory_sources_test_host_preset(tmp_path):
@@ -1278,3 +1294,199 @@ def test_report_file_listings_are_posix_on_every_platform(tmp_path):
     # shell listing may legitimately be flat or empty).
     assert any("/" in entry for field in fields for entry in report[field])
     assert report["system_module_files"], "system modules listing must not be empty"
+
+
+# ── Install honesty: the exit code must reflect what was ACHIEVED ──────────
+#
+# Counterfactual target: main() used to `return 0` unconditionally. A
+# requested `systemctl enable --now` could raise, the error was swallowed
+# into a string field only a JSON reader would ever see, and the installer
+# still reported success -- the same shape as a broken lane closing a clean
+# ExecutionGate envelope. `_enable_memory_provider` in the same file has
+# always failed hard on this class; the systemd path did not.
+
+
+def _systemctl_run_fake(*, enable_fails: bool):
+    """A ``subprocess.run`` stand-in keyed on argv.
+
+    Keyed deliberately. A fake that raises for EVERY subprocess call also
+    breaks ``_systemctl_available()``, which sends the code down the
+    documented ``systemctl_unavailable_skipped`` branch and back to exit 0 --
+    the test would then fail WITH the fix present and send the reader
+    chasing a defect that is not there.  The availability probe must
+    succeed; only ``enable`` fails.
+    """
+
+    def fake_run(command, *args, **kwargs):
+        argv = list(command) if isinstance(command, (list, tuple)) else [str(command)]
+        if enable_fails and argv[:4] == ["systemctl", "--user", "enable", "--now"]:
+            raise subprocess.CalledProcessError(1, argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    return fake_run
+
+
+def test_cognitive_loop_timer_state_records_enable_failure(tmp_path, monkeypatch):
+    """A failed enable is a distinct, named state -- not an empty string."""
+    monkeypatch.setattr(
+        "scripts.install_memory_os_plugin.subprocess.run",
+        _systemctl_run_fake(enable_fails=True),
+    )
+
+    report = install_plugin(
+        hermes_home=tmp_path / "home",
+        install_cognitive_loop=True,
+        enable_cognitive_loop=True,
+        systemd_dir=tmp_path / "units",
+        skip_verify=True,
+    )
+
+    assert report["cognitive_loop_enabled"] is False
+    assert report["cognitive_loop_timer_state"] == "enable_failed"
+    from scripts.install_memory_os_plugin import _unmet_post_conditions
+
+    unmet = _unmet_post_conditions(report)
+    assert any("cognitive-loop timer" in item for item in unmet)
+
+
+def test_installer_warns_when_units_are_written_but_never_enabled(tmp_path, capsys):
+    """The exact deployed shape: unit files on disk, systemd never told.
+
+    Writing the artifacts is gated on ``install_* or enable_*`` while the
+    copy into the user unit directory lives inside ``enable_*`` only, so this
+    combination silently produced a lane that could never run.
+    """
+    report = install_plugin(
+        hermes_home=tmp_path / "home",
+        install_cognitive_loop=True,
+        skip_verify=True,
+    )
+
+    assert report["cognitive_loop_timer_state"] == "artifacts_written_not_enabled"
+    stderr = capsys.readouterr().err
+    assert "NOT registered with systemd" in stderr
+    assert "--enable-cognitive-loop" in stderr
+
+
+def test_unmet_post_conditions_ignores_documented_and_dry_run_paths():
+    """The duals. Each of these must NOT be reported as unmet."""
+    from scripts.install_memory_os_plugin import _unmet_post_conditions
+
+    # A host without user systemd falls back to cron by design.
+    assert _unmet_post_conditions({
+        "cognitive_loop_timer_state": "enable_skipped_systemctl_unavailable",
+        "smoke_test": {"requested": True, "passed": True, "status": "passed"},
+    }) == []
+    # Not asked to enable anything.
+    assert _unmet_post_conditions({
+        "cognitive_loop_timer_state": "artifacts_written_not_enabled",
+        "smoke_test": {"requested": False, "passed": False, "status": "not_requested"},
+    }) == []
+    # A dry run achieves nothing on purpose.
+    assert _unmet_post_conditions({
+        "dry_run": True,
+        "cognitive_loop_timer_state": "enable_failed",
+        "smoke_test": {"requested": True, "passed": False, "status": "failed"},
+    }) == []
+    # The probe could not RUN -- installing from a machine without
+    # hermes-agent importable is legitimate and must not fail the install.
+    assert _unmet_post_conditions({
+        "runtime_timer_state": "enabled",
+        "smoke_test": {
+            "requested": True,
+            "passed": False,
+            "status": "host_runtime_unavailable",
+            "detail": "host_runtime_unavailable: Cannot import Hermes agent runtime",
+        },
+    }) == []
+
+
+def test_unmet_post_conditions_reports_failing_smoke_test():
+    from scripts.install_memory_os_plugin import _unmet_post_conditions
+
+    unmet = _unmet_post_conditions({
+        "runtime_timer_state": "enabled",
+        "smoke_test": {
+            "requested": True,
+            "passed": False,
+            "status": "failed",
+            "detail": "initialize_all failed: boom",
+        },
+    })
+
+    assert len(unmet) == 1
+    assert "smoke test" in unmet[0]
+    assert "initialize_all failed: boom" in unmet[0]
+
+
+def test_smoke_status_separates_cannot_run_from_ran_and_failed():
+    """The conflation this replaces made a legitimate environment look broken."""
+    from scripts.install_memory_os_plugin import (
+        SMOKE_HOST_RUNTIME_UNAVAILABLE,
+        _smoke_status,
+    )
+
+    assert _smoke_status(requested=False, ok=False, detail="") == "not_requested"
+    assert _smoke_status(requested=True, ok=True, detail="") == "passed"
+    assert _smoke_status(
+        requested=True,
+        ok=False,
+        detail=f"{SMOKE_HOST_RUNTIME_UNAVAILABLE}: Cannot import Hermes agent runtime — ...",
+    ) == SMOKE_HOST_RUNTIME_UNAVAILABLE
+    assert _smoke_status(requested=True, ok=False, detail="initialize_all failed: boom") == "failed"
+
+
+def test_installer_main_exits_three_on_unmet_post_conditions(tmp_path, monkeypatch, capsys):
+    """The counterfactual proper: without the fix this returns 0.
+
+    ``install_plugin`` is stubbed so the assertion is about the exit-code
+    wiring alone and never touches the real user unit directory.
+    """
+    import scripts.install_memory_os_plugin as installer
+
+    monkeypatch.setattr(
+        installer,
+        "install_plugin",
+        lambda **kwargs: {
+            "dry_run": False,
+            "cognitive_loop_timer_state": "enable_failed",
+            "cognitive_loop_enable_error": "Command 'systemctl' returned non-zero exit status 1.",
+            "smoke_test": {"requested": True, "passed": True, "status": "passed"},
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_memory_os_plugin.py", "--hermes-home", str(tmp_path / "home")],
+    )
+
+    assert installer.main() == installer.POST_CONDITION_EXIT_CODE
+    assert installer.POST_CONDITION_EXIT_CODE == 3  # pinned: install_memory_os.sh keys on it
+
+    captured = capsys.readouterr()
+    assert "INSTALL INCOMPLETE" in captured.err
+    assert "cognitive-loop timer" in captured.err
+    # The JSON report still ships in full on stdout.
+    assert json.loads(captured.out)["cognitive_loop_timer_state"] == "enable_failed"
+
+
+def test_installer_main_still_exits_zero_when_everything_was_achieved(tmp_path, monkeypatch):
+    import scripts.install_memory_os_plugin as installer
+
+    monkeypatch.setattr(
+        installer,
+        "install_plugin",
+        lambda **kwargs: {
+            "dry_run": False,
+            "runtime_timer_state": "enabled",
+            "cognitive_loop_timer_state": "enabled",
+            "smoke_test": {"requested": True, "passed": True, "status": "passed"},
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_memory_os_plugin.py", "--hermes-home", str(tmp_path / "home")],
+    )
+
+    assert installer.main() == 0

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -1436,6 +1436,32 @@ def test_smoke_status_separates_cannot_run_from_ran_and_failed():
     assert _smoke_status(requested=True, ok=False, detail="initialize_all failed: boom") == "failed"
 
 
+def test_smoke_probe_actually_emits_the_unavailable_prefix(tmp_path, monkeypatch):
+    """Producer side of the prefix contract -- do not test it with a fixture.
+
+    The status test above builds its detail string from the constant, so it
+    would stay green even if _verify_memory_os_hot_path stopped emitting the
+    prefix. That drift is not cosmetic: every environment without
+    hermes-agent importable would start exiting 3 on a healthy install. This
+    asserts the real producer emits what the classifier keys on.
+    """
+    import scripts.install_memory_os_plugin as installer
+
+    # Deterministic on machines where `agent` IS importable: None in
+    # sys.modules makes the import raise, exercising the same branch.
+    monkeypatch.setitem(sys.modules, "agent.memory_manager", None)
+    monkeypatch.setitem(sys.modules, "agent.memory_provider", None)
+
+    ok, detail = installer._verify_memory_os_hot_path(str(tmp_path / "home"))
+
+    assert ok is False
+    assert detail.startswith(installer.SMOKE_HOST_RUNTIME_UNAVAILABLE)
+    assert (
+        installer._smoke_status(requested=True, ok=ok, detail=detail)
+        == installer.SMOKE_HOST_RUNTIME_UNAVAILABLE
+    )
+
+
 def test_installer_main_exits_three_on_unmet_post_conditions(tmp_path, monkeypatch, capsys):
     """The counterfactual proper: without the fix this returns 0.
 


### PR DESCRIPTION
Verifies an external fresh-host deployment report (`deploy_improvements.md`, 8 items) and fixes what it actually found — plus three defects it missed.

## Verification outcome

Of the 8 reported items: **2 disproved, 3 misattributed, 3 real.**

Two of its proposed fixes already exist in the codebase (`DEFAULT_CONFIG["recall_arbitration"]` with a deep merge; `oa_` tokens rendered inline in the owner digest), and three specific references in the report — `_load_provider_config()`, `command_exists memory-os`, `<HERMES_HOME>/memory-os/bin/memory-os` — do not exist in the repo at all.

The report's real value was confirming one failure path: invoking `install_memory_os_plugin.py` directly produces a half-installed host whose exit code claims success.

## Fixes

**`b2b5887` — installer exit code must reflect what was achieved.** `main()` returned 0 unconditionally: a requested `systemctl enable --now` that raised was swallowed into a string field, and a failing hot-path smoke test only printed a warning. Same defect shape as a broken lane closing a clean ExecutionGate envelope — and `_enable_memory_provider` in the same file has always failed hard on this class. Adds exit code 3 (distinct from 1/uncaught and 2/argparse) so `install_memory_os.sh` can tell "crashed" from "ran to the end without doing what was asked", plus closed per-timer outcome codes and a `_smoke_status()` that separates "the probe could not run" (no hermes-agent — legitimate) from "the probe ran and failed". `_ensure_config_defaults` no longer returns early on a missing `config.json`, which had been skipping the CE core-switch guard on exactly the fresh profiles it exists for.

**`80d144b` — final-diff review follow-ups.** A producer-side assertion for the smoke prefix contract (the fixture-based test would have stayed green if the producer stopped emitting it), and a `verify_failures` entry shortened to fit the failure box's `%-54s`.

**`d6b9664` — a runnable `memory-os` CLI wrapper.** `pyproject` declares the console script but only a `pip install` materialises it; the host install copies sources. Not a `.pth`: `test_memory_os_installed_layout_imports.py` isolates with `-S` precisely so a CI editable install cannot make it vacuous, so a `.pth` would be masked in tests and live in production.

**`93b72a0` — deployment-integrity findings on `doctor`.** Two checks, each gated on the artifact it inspects existing (so the README blank-machine lane stays silent, which is why they ride `doctor` instead of a new subcommand — and why no new evidence level enters the documented closed set): a lane registered in code but absent from the host's installed cron snapshot (documented in CLAUDE.md as silent and previously undetected), and unit files systemd was never told about. Both warnings, so no existing exit code changes.

**`f7db1ef` — owner ruling** that snapshot drift stays a warning, with graduation pinned to a concrete event, and two of my own earlier claims corrected in the record.

## Behaviour change to be aware of

`deploy_memory_os.py` passes `--skip-verify` on every apply, which is deliberately **not** propagated to the Python installer, so its hot-path smoke test still runs. A genuine smoke failure now exits 3 → 1, where it previously printed a warning and succeeded. `host_runtime_unavailable` does not trigger this.

## Verification

3537 → **3559 passed / 13 skipped / 0 failed**. Every fix has a counterfactual verified by revert → FAIL → restore → PASS. Four static gates (`import_cycle`, `write_surface` `unclassified_count=0`, `static_hygiene`, `public_checkout_probe --strict`) and `git diff --check` over the pushed range are green.

Not covered by automated tests: the `install_memory_os.sh` changes — the repo has no shell test harness, so they were verified by `bash -n` and by tracing all four control-flow paths.
