### PR TITLE
fix(memory-os): CJK 分词族缺陷 + 召回影子账本 v2（外部评审核查后的三批修复）

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -6891,3 +6891,14 @@ failed**（11:46），四静态门 + `git diff --check` 全绿。
   （CLAUDE.md 记载的无探测器静默失败）与 unit 文件未注册 systemd，均 warning、
   均按面设条件、systemctl 不可用即无样本不发。#4 lane preset 按 owner 裁定驳回，
   无相关代码。全量 3547→3559 passed（+12）/13 skipped，四门全绿。
+- `d4bd89b`：DA — 外部 agent 五条建议核查（2 伪报 / 1 改法不可实现 / 2 属实）后的三批修复。
+  CJK 分词族缺陷两处：`crystallization_gate` 的 FTS 查询按索引 `fts_tokenizer` 分派
+  （生产为 trigram，**双字实测 0 命中**，故发字符三元组），`recall_arbitration.
+  _token_jaccard` 改双类分词（非 CJK 段逐位不变）——此前中文改写句 jaccard 恒 0.0，
+  L3/L4 对中日韩**结构性不可达**。去重语义并入 matrix 取得纪元边界且代码从 matrix 取默认值；
+  影子账本 v2 同批上线（`evaluate_observation_window` 不看 schema_version，分两批会混纪元），
+  加 per-reason 封闭词表 + unknown 桶 + `ambiguous_pair_count` + `claim_keyed_input_count`，
+  并给这条 lane 接上**首个生产读者**（monitor INFO，故意不评级）。两次 revert 实测反事实，
+  其中批 B 第一版夹具"仅差标点"是空洞的（标点在旧正则本就是分隔符）——已换语气词变体并记入教训。
+  部署须重启 gateway（provider 侧进程内缓存），纪元重置使 451/96 条旧观测 invalidated 为预期。
+  全量 3559→3583 passed（+24）/13 skipped，四门全绿。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4427,6 +4427,143 @@ static_hygiene / public_checkout_probe --strict）+ `git diff --check` 全绿。
 
 ---
 
+## DA — CJK 分词族缺陷 + 召回影子账本 v2（2026-08-18，外部 agent 评审触发）
+
+**触发**：一个 Hermes agent 提交了 5 条"核心模块改进建议"。核查结论：2 条伪报
+（认知循环故障隔离早已实现，`_run_step:308-333` 逐步 try/except + `error_step_count`，
+生产 439 周期中 `deep_reflection` 报错 56 次而周期照常跑完；图边遗忘是 `invalidated`
+不是删除，`structural_edge_proposer` 的 `state != 'invalidated'` 已提供重连路径），
+1 条半真但改法不可实现（`_score_entry()` 函数不存在、evidence 以 `subject_ref` 为键
+与 recall 的内容 sha 无索引可连），2 条属实。其"75% LLM 失败率"实为 27.5%，且引的
+注释在 `clearance_cycle.py:458` 而非 `fact_judge.py`，本身还是**已落地修复的说明**。
+核查过程另发现 4 项原评审未提的问题，本批修其中 3 项。
+
+### DA.1 CJK 分词缺陷族（Rule-5 全项目扫描：2 处中招、3 处本来就对）
+
+根因一句话：`\w` 在 Python re 下**本就匹配 CJK**，所以 `[\w一-鿿]+` 这类字符类
+在中日韩文字之间**永不断开**，整段话变成一个 token。
+
+- **`recall_arbitration._token_jaccard`**：两个中文改写句 token 集合互不相交 → jaccard
+  恒为 0.0 → L3 近重复（阈值 0.88）与 L4 歧义带（0.70–0.88）对中文**结构性不可达**。
+  生产佐证：近重复在 7134 次召回输入中只命中 5 次（0.07%），确定性去重命中 257 次。
+  修法：拆成双类分词——非 CJK 段仍走原 `\w+`（英文/带重音拉丁**逐位不变**），CJK/假名/
+  谚文段落走双字。沿用仓库内已有的正确范式（`prefetch.py:3555-3561`）。
+- **`crystallization_gate._tokenize`**：产物是 FTS5 MATCH 查询，必须与**索引自身的**
+  分词器一致。生产两 home 的 `memory_fts` 均为 `tokenize='trigram'`（`index_metadata.
+  fts_tokenizer`），trigram 下**短于 3 字符的查询词永不匹配**。真实 trigram 表实测：
+  现状（整段一个 token）只命中自身；**双字 0 命中**；三字真正命中改写句。
+  修法：读 `index_metadata.fts_tokenizer` 分派，trigram 发字符三元组，`unicode61`
+  与未知一律走 legacy（该分词器下索引侧同为整段 token，查询侧无解，需重建索引才行——
+  显式定义而非猜测）。所有词加引号（裸 CJK 词可能被当 MATCH 语法解析）。
+- **本来就对的三处**（不动）：`prefetch` 查询分词、`recall_arbitration._cjk_bigrams`
+  （限表意文字，服务冷却逃逸，扩大范围会改到无关通道）、`candidate_clusters._trigrams`
+  + `_dice`（字符三元组，CJK 安全）。
+
+**"上报方言"与"实际方言"必须同源**：`_query_builder_for()` 一个函数同时返回
+`(mode, builder)`，两处分别推导会让报告在未来某次改动后开始说谎——即本仓库
+CC 记载的"词表与生产者漂移"同型。配守卫测试。
+
+### DA.2 纪元边界：去重语义并入 matrix
+
+`OBSERVATION_WINDOW_ID` 只对 `AUTHORITY_FRESHNESS_MATRIX` 取摘要，而分词器与阈值原本
+是代码私有的——只改分词器会让"结构性为零"的旧样本与修复后样本混在同一纪元里。
+新增 `near_duplicate: {tokenizer, threshold, ambiguity_floor}` 并入 matrix，**且代码
+从 matrix 取默认值**（`NEAR_DUPLICATE_THRESHOLD` / `_AMBIGUITY_JACCARD_FLOOR` /
+`build_recall_plan` 形参默认值）。守卫测试同时钉死两个失败模式：matrix 键无人读
+（即本报告点名的 `relevance_score` 缺陷），与代码常量不受 matrix 覆盖。
+
+### DA.3 影子账本 v2：per-reason 分解（与 DA.2 同批，不可拆）
+
+`evaluate_observation_window` **只按窗口 id 分代、不看 schema_version**，先上 DA.2
+后上 v2 会让 v1/v2 记录混在同一当代窗口里。一次合并变更 = 一次纪元重置 = 同质窗口。
+
+- v1 只记总数：生产 5022 条抑制**无原因分布**，抑制精度在数学上无法从账本算出；
+  `would_change_live_recall` 在 547/547 样本中恒为 true，作为毕业信号零信息量。
+- v2 新增 `suppressed_by_reason`（**完整封闭词表 8 项，恒全键**，0 与缺键必须可区分）、
+  `unknown_reason_count`（未登记原因不消失）、`ambiguous_pair_count`（L4 上线以来
+  算了但从未持久化，"算了没人读"）、`claim_keyed_input_count`（见 DA.4）。
+- 词表落在 `recall_policy.SUPPRESSION_REASONS`（放 `recall_arbitration` 会成环）。
+  普查测试**双向**：正向用真实 producer 驱动出全部 8 项（证明每项可达），反向扫源码
+  字面量与唯一的间接调用点（`_suppression(entry, status)`，`status` 在 `owner_conflict`
+  分支内恒为一值；注意 `lower_authority_suppressed` 只用于 `conflicts[].status`，
+  **不是**抑制原因，朴素 grep 会误收）。
+- **首个生产读者**：`recall_shadow_monitor_stats()` + 监控 INFO 条目
+  `recall_arbitration_shadow_window`（本地分支 + 远端子探针 `recall_shadow_probe` 双面
+  接线）。**故意不评级**——安静窗口本就零抑制，评级会在闲周误报（同
+  `exposure_rollup_lag_hours` 的定性）；采集失败仍 WARN 并已登记
+  `CLEAN_HOST_WARN_CLASSIFICATIONS`（`known_optional` / `warn_if_production`，
+  与 `v2_graph_injection_shadow_collection_failed` 同类），否则 clean-host 会因
+  `clean_host_warn_unclassified` 直接 FAIL。空窗口报 `healthy_no_sample`，不是静默 0。
+
+### DA.4 conflict 通道休眠：给永久零一个分母
+
+`claim_key` 唯一生产者是 crystallized frontmatter（`retrievers/crystallized.py:108`），
+生产上**0 条 crystallized 记录带它**，故 547 条样本 `conflict_count` 全为 0——而永久零
+读起来"无输入"与"分组坏了"完全同貌。新增 `claim_keyed_input_count` 作为分母，贯通
+plan → 账本 → 监控 INFO。这是"lane 无产出必须自述原因"规则的直接应用，不接生产者
+（`claim_key` 语义属 owner 裁定，越权）。
+
+### 反事实覆盖（两次 revert 实测，用 cp 备份而非 git checkout）
+
+- 批 A：回退分派 → `flagged_count=0`，`test_gate_finds_chinese_paraphrase_through_real_
+  trigram_index` FAIL。另配非空洞性检查：同 fixture 把矛盾边置 `candidate` 态 → 应 0 标记，
+  证明该 fixture 的边**确实承重**（否则姐妹测试可能因文本命中而空洞通过）。
+- 批 B：回退分词器 → 3 项 FAIL，其中普查测试报 `unreachable={'near_duplicate'}`。
+
+**教训（写进 W 的适用范围）：CJK 反事实夹具必须在 run *内部* 制造差异。**
+第一版夹具用"仅差句号"的两句——句号在旧正则里**本来就是分隔符**，旧分词器同样命中，
+测试在无修复时照样通过。是 revert 实测把这个空洞夹具抓了出来；换成语气词变体后
+（legacy 0.000 / fixed 0.947）才成立。**只跑新测试看到绿色，等于什么都没验证。**
+
+### 修复效果的诚实边界
+
+- 双字 jaccard 实测：同义改写 0.222 / 0.538（仍远低于 0.88），近似变体
+  （run 内语气词差异 0.923~0.947）才越阈值。**恢复的是近似变体去重，不是语义改写去重**；
+  后者是独立的 owner 设计决策，已配 `test_near_duplicate_still_does_not_collapse_a_
+  chinese_paraphrase` 钉住，防止将来当作分词器调优的副产品悄悄改掉。
+- **门修复不会带来标记量跳升**：生产 active `contradicts` 边只有 4（main）+ 1（sannai），
+  且多数历史边已被 60 天遗忘置为 invalidated——`flagged_count` 的上限由边的稀缺性封顶，
+  不由 FTS 召回封顶。预期变化"零到个位数"。它的价值是**高代价罕见路径上的正确性**：
+  中文候选此前根本走不到边检查那一步。验收看 reason_code 分布与 loop report 的
+  `fts_query_mode`，**不看数量**。边的产出属 proposer 领域（2026-08-06 owner 裁定），
+  本批不碰，仅登记观察。
+
+### 两项书面裁定（防将来重复提问）
+
+1. **`_FTS_LIMIT=5` 保留**。trigram 查询会返回更多候选行，是 BM25 rank 决定哪 5 条入选；
+   排名第 6 的矛盾记录现在"因排名不可见"而非"因分词不可见"——严格变好，加宽属越权。
+2. **门的分词器故意不进 matrix 身份**。它不在召回观测链上，其证据面是 loop report 的
+   `fts_query_mode`；耦合进去会让门内部改动重置召回纪元。
+
+### 一个差点漏掉的漏键（顾问审核抓出，阻断项）
+
+`cognitive_loop._crystallization_gate` 的 step summary 是**逐键挑选**后写进
+reports.jsonl 的，不是 gate 的完整返回值——最初 `fts_query_mode` / `fts_tokenizer`
+没有透传，即"在唯一的持久证据面上不存在"（同 `cognitive_loop.py:1177` 那条注释的
+警告）。全部新测试当时都直接调 `run_crystallization_gate`，无一经过 loop step，所以
+全绿。已透传并补 `test_cognitive_loop_crystallization_gate_step_carries_the_query_
+dialect`；同时把 gate 的三种 return 形态统一键集（无候选/开库失败路径报
+`fts_query_mode="not_queried"`），避免同族漏键。
+
+### 部署注意（必读）
+
+- **必须重启 gateway**：DA.2/DA.3 改的 `recall_arbitration` / `recall_policy` 跑在
+  gateway 进程内（prefetch 热路径），按既有记忆 gateway 会在进程内缓存 provider 模块，
+  **不重启则 v2 账本与新纪元永远不会开始写**。DA.1 的门在 cron 侧，不受此限。
+- **纪元重置是预期**：matrix 摘要变化会把 main 451 条 / sannai 96 条旧观测置为
+  `invalidated`，当代窗口归零重新积累——非回归。
+- 远端子探针 `recall_shadow_probe()` 的生成脚本路径无端到端测试；缺失或异常都会落到
+  已登记的 `recall_shadow_monitor_collection_failed` WARN 而非静默，部署后跑一次
+  full monitor 即闭环。
+
+### 测试数
+
+新增 24 项测试，全量 3559 → 3583 passed / 13 skipped。四静态门
+（import_cycle / write_surface `unclassified_count=0` / static_hygiene /
+public_checkout_probe --strict）+ `git diff --check` 全绿。
+
+---
+
 ## 待办
 
 **`vector_edge_proposer` 无 `outcome`、无写失败计数（CW 登记，2026-08-15）。**

--- a/plugins/memory/memory_os/cognitive_loop.py
+++ b/plugins/memory/memory_os/cognitive_loop.py
@@ -1008,6 +1008,15 @@ class CognitiveLoopRunner:
             "error_records": result.get("error_records", []),
             "duration_ms": result.get("duration_ms", 0),
             "error": result.get("error", ""),
+            # This summary -- not the gate's full return value -- is what
+            # _run_step persists into reports.jsonl, so a key omitted here
+            # does not exist for any reader (see the same warning at the
+            # edge_step_results block below). Without the query dialect a
+            # zero-flag run cannot be told apart from one whose queries could
+            # never match the index, which is the confusion that hid the CJK
+            # defect in the first place.
+            "fts_tokenizer": result.get("fts_tokenizer", ""),
+            "fts_query_mode": result.get("fts_query_mode", ""),
         }
 
     def _llm_edge_proposer(self, context: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/memory/memory_os/crystallization_gate.py
+++ b/plugins/memory/memory_os/crystallization_gate.py
@@ -19,7 +19,7 @@ import json
 import re
 import sqlite3
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Callable
 
 from .audit import append_audit
 
@@ -44,12 +44,96 @@ def _gate_error_result(code: str, *, component: str) -> dict[str, Any]:
         "flagged_count": 0,
         "flagged_candidates": [],
         "duration_ms": 0,
+        # Same key set on every return shape: a reader must never have to
+        # guess whether a missing dialect means "legacy" or "no query ran".
+        "fts_tokenizer": "",
+        "fts_query_mode": "not_queried",
     }
 
 
-def _tokenize(text: str) -> set[str]:
-    """Lowercase alpha-numeric token set for FTS5 query building."""
+# \u2500\u2500 FTS5 query-term builders \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+#
+# These tokens become an FTS5 MATCH query, so they MUST agree with the
+# tokenizer the index was actually built with (index.py records the choice in
+# ``index_metadata.fts_tokenizer``).  Getting this wrong is not a weaker
+# search -- it is a silently empty one:
+#
+#   * ``trigram`` (the preferred form, index.py:638) matches on character
+#     trigrams, so a query term shorter than 3 characters cannot match at all.
+#     ``_legacy_tokens`` below collapses a whole run of CJK into ONE token
+#     (the character-class ranges never break between Chinese characters), so
+#     on a trigram index a Chinese candidate degenerates to "the entire
+#     sentence must appear verbatim as a substring": measured against a real
+#     trigram table, such a query found only the row it came from and never a
+#     paraphrase, leaving the gate's edge check unreachable for Chinese
+#     content.  Character trigrams restore it.
+#     Bigrams do NOT -- on the same real trigram table a bigram OR-query
+#     returned ZERO rows, i.e. a bigram "fix" is indistinguishable from the
+#     defect it claims to repair, which is exactly how it would ship unnoticed.
+#   * ``unicode61`` (the fallback form, index.py:646) tokenizes indexed CJK
+#     into whole runs as well, so query and index agree there.  Recall is weak
+#     (no paraphrase matching) but self-consistent, and NO query-side change
+#     can improve it -- that needs an index rebuild, which is legitimate but
+#     out of this function's scope.  The legacy tokens are kept deliberately.
+#
+# Anything else, including a missing ``index_metadata`` table, is treated as
+# the fallback: never guess trigram semantics for an unknown index.
+_TRIGRAM_TOKENIZER = "trigram"
+
+# CJK ideographs + kana + hangul.  The defect is not Chinese-specific: every
+# script here is matched by the legacy class without any intra-run break.
+_CJK_RUN_PATTERN = r"[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]+"
+
+
+def _legacy_tokens(text: str) -> set[str]:
+    """Whole-run token set matching a ``unicode61``-shaped index."""
     return set(re.findall(r"[a-z\u4e00-\u9fff][a-z0-9\u4e00-\u9fff]*", text.lower()))
+
+
+def _trigram_tokens(text: str) -> set[str]:
+    """Query terms for a ``tokenize='trigram'`` index.
+
+    CJK/kana/hangul runs become character trigrams; ASCII alphanumeric tokens
+    are kept only at length >= 3, because a trigram index cannot match a
+    shorter term at all.  Dropping "ok"/"db" is that index's semantics, not a
+    regression introduced here.
+    """
+    lowered = text.lower()
+    terms: set[str] = set(re.findall(r"[a-z0-9]{3,}", lowered))
+    for run in re.findall(_CJK_RUN_PATTERN, lowered):
+        for start in range(max(0, len(run) - 2)):
+            terms.add(run[start:start + 3])
+    return terms
+
+
+def _fts_match_query(terms: set[str]) -> str:
+    """OR-join terms as quoted FTS5 phrases.
+
+    Quoting is not cosmetic: a bare CJK or mixed term can be parsed as MATCH
+    syntax rather than as text, which raises instead of searching.  Sorted for
+    a deterministic query string per candidate.
+    """
+    cleaned = sorted({term.replace('"', "").strip() for term in terms} - {""})
+    return " OR ".join(f'"{term}"' for term in cleaned)
+
+
+def _query_builder_for(fts_tokenizer: str) -> tuple[str, Callable[[str], set[str]]]:
+    """Return ``(reported_mode, term_builder)`` for an index tokenizer.
+
+    Deliberately ONE function: if the dialect that gets reported and the
+    dialect that actually builds the query were derived separately, a future
+    edit could change one and leave the other lying -- which is precisely the
+    "a gate whose vocabulary drifts from its producer checks nothing" failure
+    this codebase has already paid for once.
+    """
+    if fts_tokenizer == _TRIGRAM_TOKENIZER:
+        return "trigram", _trigram_tokens
+    return "legacy", _legacy_tokens
+
+
+def _tokenize(text: str) -> set[str]:
+    """Backwards-compatible alias for the legacy (unicode61-shaped) tokens."""
+    return _legacy_tokens(text)
 
 
 # ── Core gate logic ────────────────────────────────────────────────────────
@@ -101,15 +185,29 @@ def run_crystallization_gate(
             "flagged_count": 0,
             "flagged_candidates": [],
             "duration_ms": 0,
+            "fts_tokenizer": "",
+            "fts_query_mode": "not_queried",
         }
 
     # 2. For each candidate, search for similar crystallized records and check
     #    for contradicts edges.
     flagged: list[dict[str, Any]] = []
     error_records: list[dict[str, str]] = []
+    # Bound before the connection so the reported dialect is always defined,
+    # including on the `fts_query_failed` path below.
+    fts_tokenizer = ""
+    fts_query_mode, build_query_terms = _query_builder_for(fts_tokenizer)
     conn2 = sqlite3.connect(index_path)
     conn2.row_factory = sqlite3.Row
     try:
+        # Resolve the index's own tokenizer ONCE per run and build every query
+        # in its dialect.  ``_metadata_value`` returns "" for a database with
+        # no ``index_metadata`` table, which lands on the conservative legacy
+        # branch rather than guessing trigram semantics.
+        from .index import _metadata_value
+
+        fts_tokenizer = _metadata_value(conn2, "fts_tokenizer")
+        fts_query_mode, build_query_terms = _query_builder_for(fts_tokenizer)
         for cand in candidate_rows:
             cid = str(cand.get("candidate_id", ""))
             body = str(cand.get("body", ""))
@@ -123,9 +221,12 @@ def run_crystallization_gate(
                 continue
 
             # Search FTS5 for similar crystallized record bodies.
-            # Use the first 300 chars as query (FTS5 words).
-            query_words = " OR ".join(
-                _tokenize(body[:300])
+            # Use the first 300 chars as query, in the index's own dialect.
+            # A body that is a single 2-character CJK run yields no trigram at
+            # all -- that lands on the same empty-query skip as an empty body.
+            head = body[:300]
+            query_words = _fts_match_query(
+                build_query_terms(head)
             )
             if not query_words.strip():
                 continue
@@ -248,6 +349,11 @@ def run_crystallization_gate(
         "error_code": error_records[0]["error_code"] if error_records else "",
         "error_records": error_records,
         "duration_ms": elapsed_ms,
+        # Which dialect the queries were built in.  Without this a zero-flag
+        # run cannot be told apart from a run whose queries could never match
+        # the index -- the exact confusion that hid the CJK defect for months.
+        "fts_tokenizer": fts_tokenizer or "unknown",
+        "fts_query_mode": fts_query_mode,
     }
 
     if audit_path:

--- a/plugins/memory/memory_os/recall_arbitration.py
+++ b/plugins/memory/memory_os/recall_arbitration.py
@@ -537,10 +537,14 @@ def _similarity_tokens(text: str) -> set[str]:
     below -- and keep ASCII behaviour bit-identical, since the ASCII class is
     unchanged and the CJK class contributes nothing to a pure-ASCII string.
 
-    Scope note: this restores *near-identical variant* detection (particle or
-    punctuation edits score ~0.92-1.0).  Genuine paraphrases score ~0.22-0.54
-    and remain below both bands by design; semantic-equivalence dedup is a
-    separate decision, not a side effect of this fix.
+    Scope note: what this restores is detection of differences *inside* a CJK
+    run (a trailing particle scores ~0.95).  Differences at a run boundary --
+    punctuation, spaces -- were already detectable, because the old regex
+    treated those as separators too; the first counterfactual fixture written
+    for this fix used exactly such a pair and therefore passed with the defect
+    still in place.  Genuine paraphrases score ~0.22-0.54 and remain below
+    both bands by design; semantic-equivalence dedup is a separate decision,
+    not a side effect of this fix.
     """
     normalized = str(text or "").casefold()
     tokens: set[str] = set()

--- a/plugins/memory/memory_os/recall_arbitration.py
+++ b/plugins/memory/memory_os/recall_arbitration.py
@@ -23,12 +23,29 @@ _EXPLICIT_RECALL_PATTERN = re.compile(
     re.I,
 )
 
+# Dedup semantics are READ FROM the matrix, never restated here: the matrix
+# digest is the observation window's identity, so a threshold or tokenizer that
+# lived only in this module could change detection behaviour without ending the
+# window it invalidates.  A matrix key that the code does not actually read
+# would be the mirror defect (see `relevance_score` in `ranking_precedence`),
+# so `test_near_duplicate_config_is_sourced_from_the_matrix` asserts these
+# module constants and the runtime default equal the matrix values.
+# CJK ideographs + kana + hangul: the scripts whose runs `\w` swallows whole.
+# Deliberately NOT shared with `_cjk_bigrams` below, which serves the cooldown
+# escape path and is limited to ideographs; widening that helper would change
+# query-match behaviour in an unrelated lane.
+_SIMILARITY_CJK_RUN = re.compile(r"[㐀-鿿぀-ヿ가-힯]+")
+
+_NEAR_DUPLICATE_CONFIG = AUTHORITY_FRESHNESS_MATRIX["near_duplicate"]
+NEAR_DUPLICATE_TOKENIZER = str(_NEAR_DUPLICATE_CONFIG["tokenizer"])
+NEAR_DUPLICATE_THRESHOLD = float(_NEAR_DUPLICATE_CONFIG["threshold"])
+
 # FIX 5(b): L4 "ambiguous but not suppressed" band. Pairs at or above this
 # jaccard similarity but below `near_duplicate_threshold` are too similar to
 # ignore but not similar enough to collapse deterministically (no LLM on the
 # hot path per the dedup-ladder design doc). Both entries survive and are
 # cross-linked via `ambiguity_related` instead of one suppressing the other.
-_AMBIGUITY_JACCARD_FLOOR = 0.70
+_AMBIGUITY_JACCARD_FLOOR = float(_NEAR_DUPLICATE_CONFIG["ambiguity_floor"])
 
 
 def build_recall_plan(
@@ -39,7 +56,7 @@ def build_recall_plan(
     current_query: str = "",
     current_task_revision: str = "",
     session_ledger: dict[str, Any] | None = None,
-    near_duplicate_threshold: float = 0.88,
+    near_duplicate_threshold: float = NEAR_DUPLICATE_THRESHOLD,
     freshness_guard_mode: str = "shadow",
     conflict_resolution_mode: str = "shadow",
 ) -> dict[str, Any]:
@@ -166,9 +183,19 @@ def build_recall_plan(
                 ambiguous_pair_count += 1
         near_deduped.append(entry)
 
+    # Conflict resolution is gated entirely on `claim_key`, whose ONLY producer
+    # is crystallized frontmatter (retrievers/crystallized.py). On production
+    # no crystallized record carries one, so `conflict_count` has been 0 for
+    # every sample this lane ever took -- and a permanent zero is ambiguous:
+    # it reads identically whether no input was eligible or the grouping is
+    # broken. `claim_keyed_input_count` below is what separates the two, per
+    # the rule that a lane producing nothing must say why without anyone
+    # re-running it or reading this source.
     conflict_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    claim_keyed_input_count = 0
     for entry in near_deduped:
         if entry["claim_key"]:
+            claim_keyed_input_count += 1
             conflict_groups[entry["claim_key"]].append(entry)
     conflict_fingerprints: set[str] = set()
     conflicts: list[dict[str, Any]] = []
@@ -235,6 +262,9 @@ def build_recall_plan(
         "near_duplicate_count": near_duplicate_count,
         "ambiguous_pair_count": ambiguous_pair_count,
         "conflict_count": len(conflicts),
+        # Denominator for conflict_count: zero here means the conflict lane had
+        # nothing to work with, not that it failed to find conflicts.
+        "claim_keyed_input_count": claim_keyed_input_count,
         "unknown_authority_classes": sorted(unknown_authority_classes),
         "used_budget_chars": used_chars,
         "budget_chars": max(0, int(budget_chars)),
@@ -491,9 +521,45 @@ def _suppression(entry: dict[str, Any], reason: str, *, related: str = "") -> di
     }
 
 
+def _similarity_tokens(text: str) -> set[str]:
+    """Two-class token set: ASCII/word runs plus CJK character bigrams.
+
+    The previous single-class regex (``[\\w\\u4e00-\\u9fff]+``) never broke
+    between CJK characters -- ``\\w`` already matches them -- so an entire
+    Chinese sentence became ONE token.  Two paraphrases then shared no token
+    at all and scored 0.0, which made both L3 (>= threshold, suppress) and L4
+    (ambiguity band) structurally unreachable for Chinese, Japanese and Korean
+    content: measured on production, near-duplicate fired 5 times in 7134
+    recall inputs while deterministic dedup fired 257.
+
+    Bigrams for the CJK class follow the two implementations in this codebase
+    that already got it right -- ``prefetch`` query tokens and ``_cjk_bigrams``
+    below -- and keep ASCII behaviour bit-identical, since the ASCII class is
+    unchanged and the CJK class contributes nothing to a pure-ASCII string.
+
+    Scope note: this restores *near-identical variant* detection (particle or
+    punctuation edits score ~0.92-1.0).  Genuine paraphrases score ~0.22-0.54
+    and remain below both bands by design; semantic-equivalence dedup is a
+    separate decision, not a side effect of this fix.
+    """
+    normalized = str(text or "").casefold()
+    tokens: set[str] = set()
+    # Non-CJK segments keep the original ``\w+`` rule verbatim, so accented
+    # Latin, Cyrillic and every other word character tokenize exactly as they
+    # did before; only the CJK class changes.
+    for segment in re.split(_SIMILARITY_CJK_RUN, normalized):
+        tokens.update(re.findall(r"\w+", segment))
+    for run in re.findall(_SIMILARITY_CJK_RUN, normalized):
+        if len(run) == 1:
+            tokens.add(run)
+            continue
+        tokens.update(run[index:index + 2] for index in range(len(run) - 1))
+    return tokens
+
+
 def _token_jaccard(left: str, right: str) -> float:
-    left_tokens = set(re.findall(r"[\w\u4e00-\u9fff]+", str(left or "").casefold()))
-    right_tokens = set(re.findall(r"[\w\u4e00-\u9fff]+", str(right or "").casefold()))
+    left_tokens = _similarity_tokens(left)
+    right_tokens = _similarity_tokens(right)
     if not left_tokens or not right_tokens:
         return 0.0
     return len(left_tokens & right_tokens) / len(left_tokens | right_tokens)

--- a/plugins/memory/memory_os/recall_policy.py
+++ b/plugins/memory/memory_os/recall_policy.py
@@ -43,7 +43,41 @@ AUTHORITY_FRESHNESS_MATRIX: dict[str, Any] = {
         "relevance_score",
         "stable_input_order",
     ],
+    # Dedup semantics live in the matrix ON PURPOSE: the observation window is
+    # keyed by this dict's digest, so changing how near-duplicates are detected
+    # must invalidate every sample taken under the old rule.  Before this entry
+    # existed, the tokenizer and thresholds were code-only, and a CJK tokenizer
+    # fix would have silently joined "structurally could never fire" samples to
+    # post-fix ones inside one window -- the same era-mixing this project has
+    # already had to correct once for attribution.
+    #
+    # These values are the SOURCE of the runtime defaults (see
+    # recall_arbitration.NEAR_DUPLICATE_THRESHOLD / AMBIGUITY_JACCARD_FLOOR).
+    # They must never become documentation-only: a matrix key the code does not
+    # read is exactly the `relevance_score` defect -- listed in
+    # ranking_precedence above, implemented nowhere.
+    "near_duplicate": {
+        "tokenizer": "ascii_word_plus_cjk_bigram_v1",
+        "threshold": 0.88,
+        "ambiguity_floor": 0.70,
+    },
 }
+
+# Closed vocabulary of every reason `recall_arbitration._suppression` can emit.
+# The observation ledger buckets by these names, so a producer that invents a
+# reason without registering it here lands in `unknown_reason_count` rather
+# than vanishing -- and `test_recall_suppression_reason_census` fails in both
+# directions (unregistered producer / registered name with no producer).
+SUPPRESSION_REASONS: tuple[str, ...] = (
+    "budget_exceeded",
+    "exact_duplicate",
+    "exact_source_duplicate",
+    "lower_authority_conflict",
+    "near_duplicate",
+    "owner_conflict_requires_clarification",
+    "session_duplicate",
+    "stale_task_revision",
+)
 
 
 def authority_freshness_matrix_digest(matrix: Mapping[str, Any]) -> str:
@@ -137,7 +171,16 @@ def evaluate_observation_window(observations: Iterable[Mapping[str, Any]]) -> di
     }
 
 
-RECALL_OBSERVATION_SCHEMA_VERSION = "memory-os.recall_observation.v1"
+# v2 adds `suppressed_by_reason` (full closed vocabulary, always present so a
+# zero is distinguishable from an absent key), `unknown_reason_count` and
+# `ambiguous_pair_count`.  v1 recorded only totals, which made suppression
+# precision impossible to compute from the ledger at all: an owner asked to
+# decide "can this graduate to apply?" had 5022 suppressions and no way to see
+# what they were.  Shipped in the same change as the matrix `near_duplicate`
+# entry so the digest change resets the window and no v1 row can survive into
+# a v2 window (`evaluate_observation_window` keys on window id, not on
+# schema_version, so a separate deploy would have mixed the two).
+RECALL_OBSERVATION_SCHEMA_VERSION = "memory-os.recall_observation.v2"
 
 # Size-gated retention (P2 fix): append_recall_observation grew the ledger
 # forever. Once it exceeds RECALL_OBSERVATION_COMPACT_THRESHOLD records, it
@@ -195,6 +238,24 @@ def append_recall_observation(
         reason = str(entry.get("cooldown_escape_reason") or "")
         if reason:
             escape_counts[reason] = escape_counts.get(reason, 0) + 1
+    suppressed_value = plan.get("suppressed")
+    suppressed_rows: list[Any] = (
+        list(suppressed_value) if isinstance(suppressed_value, list) else []
+    )
+    # Full closed vocabulary every time: a reason that simply did not occur must
+    # read as 0, not as a missing key, or a reader cannot tell "never happened"
+    # from "this build does not report it".
+    suppressed_by_reason = {reason: 0 for reason in SUPPRESSION_REASONS}
+    unknown_reason_count = 0
+    for row in suppressed_rows:
+        if not isinstance(row, Mapping):
+            unknown_reason_count += 1
+            continue
+        reason = str(row.get("reason") or "")
+        if reason in suppressed_by_reason:
+            suppressed_by_reason[reason] += 1
+        else:
+            unknown_reason_count += 1
     observed_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     record = {
         "schema_version": RECALL_OBSERVATION_SCHEMA_VERSION,
@@ -208,7 +269,17 @@ def append_recall_observation(
         "suppressed_count": int(plan.get("suppressed_count") or 0),
         "exact_duplicate_count": int(plan.get("exact_duplicate_count") or 0),
         "near_duplicate_count": int(plan.get("near_duplicate_count") or 0),
+        # Computed by build_recall_plan since L4 shipped and read by nobody
+        # until v2 -- the "metric with no reader" shape this codebase keeps
+        # paying for.  Persisted here so the L4 band has evidence at all.
+        "ambiguous_pair_count": int(plan.get("ambiguous_pair_count") or 0),
         "conflict_count": int(plan.get("conflict_count") or 0),
+        # conflict_count's denominator. Without it a permanent 0 cannot be told
+        # apart from a broken grouping: on production no crystallized record
+        # carries a claim_key, so the conflict lane has never had an input.
+        "claim_keyed_input_count": int(plan.get("claim_keyed_input_count") or 0),
+        "suppressed_by_reason": suppressed_by_reason,
+        "unknown_reason_count": unknown_reason_count,
         "would_change_live_recall": bool(plan.get("would_change_live_recall")),
         "cooldown_escape_counts": dict(sorted(escape_counts.items())),
     }
@@ -230,3 +301,81 @@ def read_recall_observation_window(roots: Any) -> dict[str, Any]:
     status = evaluate_observation_window(read_jsonl(recall_observation_path(roots)))
     status.pop("current_observations", None)
     return status
+
+
+def recall_shadow_monitor_stats(roots: Any) -> dict[str, Any]:
+    """Aggregate the current observation window into monitor-readable state.
+
+    This function exists because the shadow lane had no production reader at
+    all: the plan counters were written to a ledger, and the only consumer was
+    the provider's own `status` call.  An owner asked "can recall arbitration
+    graduate to apply_canary?" had 5022 suppressions with no breakdown and a
+    `would_change_live_recall` flag that was true in 547 of 547 samples -- a
+    saturated boolean carries no information, so the decision had no evidence.
+
+    Deliberately UNGRADED (INFO): a quiet window legitimately produces zero
+    suppressions, so grading any of these would false-alarm on idle weeks --
+    the same reasoning that keeps `exposure_rollup_lag_hours` ungraded.  What
+    the reader gets instead is decomposition: which reasons fired, how many
+    rows are era-current, and whether the window is schema-homogeneous.
+    """
+    from .jsonl_io import read_jsonl
+
+    window = evaluate_observation_window(read_jsonl(recall_observation_path(roots)))
+    rows = [row for row in window.pop("current_observations", []) if isinstance(row, Mapping)]
+
+    by_reason = {reason: 0 for reason in SUPPRESSION_REASONS}
+    schema_versions: dict[str, int] = {}
+    totals = {
+        "input_total": 0,
+        "selected_total": 0,
+        "suppressed_total": 0,
+        "exact_duplicate_total": 0,
+        "near_duplicate_total": 0,
+        "ambiguous_pair_total": 0,
+        "conflict_total": 0,
+        "claim_keyed_input_total": 0,
+        "unknown_reason_total": 0,
+    }
+    would_change_true = 0
+    for row in rows:
+        schema = str(row.get("schema_version") or "unknown")
+        schema_versions[schema] = schema_versions.get(schema, 0) + 1
+        totals["input_total"] += int(row.get("input_count") or 0)
+        totals["selected_total"] += int(row.get("selected_count") or 0)
+        totals["suppressed_total"] += int(row.get("suppressed_count") or 0)
+        totals["exact_duplicate_total"] += int(row.get("exact_duplicate_count") or 0)
+        totals["near_duplicate_total"] += int(row.get("near_duplicate_count") or 0)
+        totals["ambiguous_pair_total"] += int(row.get("ambiguous_pair_count") or 0)
+        totals["conflict_total"] += int(row.get("conflict_count") or 0)
+        totals["claim_keyed_input_total"] += int(row.get("claim_keyed_input_count") or 0)
+        totals["unknown_reason_total"] += int(row.get("unknown_reason_count") or 0)
+        if row.get("would_change_live_recall"):
+            would_change_true += 1
+        reasons = row.get("suppressed_by_reason")
+        if isinstance(reasons, Mapping):
+            for reason, count in reasons.items():
+                if reason in by_reason:
+                    by_reason[reason] += int(count or 0)
+                else:
+                    totals["unknown_reason_total"] += int(count or 0)
+
+    # An empty window is reported as such rather than as a clean bill of
+    # health: zero samples is "no sample", never "nothing wrong".
+    sample_state = "healthy_no_sample" if not rows else "sampled"
+    return {
+        "schema_version": "memory-os.recall_shadow_monitor.v1",
+        "observation_window_id": window.get("observation_window_id", ""),
+        "window_reset_required": bool(window.get("window_reset_required")),
+        "current_observation_count": int(window.get("current_observation_count") or 0),
+        "invalidated_observation_count": int(window.get("invalidated_observation_count") or 0),
+        "sample_state": sample_state,
+        # A window holding more than one schema version means a deploy landed
+        # without an era boundary -- the per-reason keys would then be missing
+        # on part of the window and every ratio computed over it would be wrong.
+        "schema_version_counts": dict(sorted(schema_versions.items())),
+        "suppressed_by_reason": by_reason,
+        "would_change_live_recall_true_count": would_change_true,
+        "latest_observed_at": str(rows[-1].get("observed_at") or "") if rows else "",
+        **totals,
+    }

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -294,6 +294,11 @@ CLEAN_HOST_WARN_CLASSIFICATIONS: dict[str, dict[str, str]] = {
         "reason": "an output-affecting knob's effective value differs from its expected live value - owner decides; clean hosts have no overrides so the default resolves to the expected value and this stays silent",
         "production_behavior": "warn_if_production",
     },
+    "recall_shadow_monitor_collection_failed": {
+        "classification": "known_optional",
+        "reason": "recall arbitration shadow window could not be read - collection failure surfaced instead of a fabricated healthy-quiet window; the lane is output-neutral in shadow mode, so this degrades graduation evidence rather than behaviour (same class as v2_graph_injection_shadow_collection_failed)",
+        "production_behavior": "warn_if_production",
+    },
     "v2_graph_injection_shadow_collection_failed": {
         "classification": "known_optional",
         "reason": "graph injection shadow ledger could not be read - collection failure surfaced instead of a fabricated zero",
@@ -1628,6 +1633,60 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
             })
     if v2_exposure.get("downstream_clearance_closure_frozen") is True:
         passed.append({"code": "v2_downstream_clearance_frozen_by_evidence_gates", "reasons": v2_exposure.get("freeze_reasons")})
+
+    # Recall arbitration shadow window. INFO and deliberately ungraded: a quiet
+    # window legitimately suppresses nothing, so a threshold here would
+    # false-alarm on idle weeks (same reasoning as exposure_rollup_lag_hours).
+    # The point is that the window has a production reader AT ALL -- before
+    # this entry the ledger's only consumer was the provider's own status
+    # call, so the shadow->apply graduation decision it exists to inform had
+    # no evidence a monitor could show. Collection failure still WARNs: an
+    # empty dict must never read as a healthy quiet window.
+    raw_recall_shadow = snapshot.get("recall_shadow_monitor")
+    recall_shadow: dict[str, Any] = raw_recall_shadow if isinstance(raw_recall_shadow, dict) else {}
+    recall_sample_state = str(recall_shadow.get("sample_state") or "")
+    if recall_sample_state == "unavailable" or recall_shadow.get("error_code"):
+        warn.append({"code": "recall_shadow_monitor_collection_failed", "value": recall_shadow})
+    elif recall_shadow:
+        schema_counts = recall_shadow.get("schema_version_counts")
+        schema_counts = schema_counts if isinstance(schema_counts, dict) else {}
+        info.append({
+            "code": "recall_arbitration_shadow_window",
+            "value": {
+                "sample_state": recall_sample_state,
+                "current_observation_count": int(recall_shadow.get("current_observation_count") or 0),
+                "invalidated_observation_count": int(
+                    recall_shadow.get("invalidated_observation_count") or 0
+                ),
+                # More than one schema version in one window means a deploy
+                # landed without the era boundary it needed, and every ratio
+                # computed over the window is then mixing incompatible rows.
+                "schema_version_counts": schema_counts,
+                "input_total": int(recall_shadow.get("input_total") or 0),
+                "selected_total": int(recall_shadow.get("selected_total") or 0),
+                "suppressed_total": int(recall_shadow.get("suppressed_total") or 0),
+                # The decomposition v1 could not provide: which reasons the
+                # suppressions actually were.
+                "suppressed_by_reason": recall_shadow.get("suppressed_by_reason") or {},
+                "unknown_reason_total": int(recall_shadow.get("unknown_reason_total") or 0),
+                "near_duplicate_total": int(recall_shadow.get("near_duplicate_total") or 0),
+                "ambiguous_pair_total": int(recall_shadow.get("ambiguous_pair_total") or 0),
+                "conflict_total": int(recall_shadow.get("conflict_total") or 0),
+                # conflict_total's denominator. `claim_key`'s only producer is
+                # crystallized frontmatter, and no production record carries
+                # one, so a permanent conflict_total of 0 means "no eligible
+                # input" -- not "no conflicts found". Without this key the two
+                # are indistinguishable from the artifact alone.
+                "claim_keyed_input_total": int(recall_shadow.get("claim_keyed_input_total") or 0),
+                # Saturated at 100% for 547 of 547 pre-fix samples, which is
+                # why it is reported beside the decomposition rather than as a
+                # signal on its own.
+                "would_change_live_recall_true_count": int(
+                    recall_shadow.get("would_change_live_recall_true_count") or 0
+                ),
+                "latest_observed_at": str(recall_shadow.get("latest_observed_at") or ""),
+            },
+        })
 
     raw_clearance_freshness = snapshot.get("clearance_snapshot_freshness")
     clearance_freshness: dict[str, Any] = raw_clearance_freshness if isinstance(raw_clearance_freshness, dict) else {}
@@ -5060,6 +5119,22 @@ def collect_snapshot(
         except Exception as exc:
             raw["v2_exposure_monitor"] = {"schema_era_health": "unavailable", "error_code": type(exc).__name__}
             raw["clearance_snapshot_freshness"] = {"status": "unavailable", "error_code": type(exc).__name__}
+        # Recall arbitration shadow state: collected in its own try so an
+        # exposure-side failure cannot make this read "unavailable" and vice
+        # versa -- two unrelated lanes sharing one except block would report
+        # each other's outages.
+        try:
+            from plugins.memory.memory_os.recall_policy import recall_shadow_monitor_stats
+            from plugins.memory.memory_os.roots import MemoryOSRoots as _RecallRoots
+
+            raw["recall_shadow_monitor"] = recall_shadow_monitor_stats(
+                _RecallRoots.from_hermes_home(hermes_home, profile="default")
+            )
+        except Exception as exc:
+            raw["recall_shadow_monitor"] = {
+                "sample_state": "unavailable",
+                "error_code": type(exc).__name__,
+            }
     else:
         # Fix 1: collect exposure_monitor_stats / clearance_snapshot_freshness
         # on the remote host too, using the same SSH remote-execution pattern
@@ -5077,6 +5152,18 @@ def collect_snapshot(
         else:
             raw["v2_exposure_monitor"] = {"schema_era_health": "unavailable", "error_code": _v2_error_code}
             raw["clearance_snapshot_freshness"] = {"status": "unavailable", "error_code": _v2_error_code}
+
+        # Recall arbitration shadow window, same never-silent contract: a
+        # missing sub-probe reports "unavailable" with a code rather than an
+        # empty dict that would read as a quiet, healthy window.
+        _recall_payload, _recall_error_code = _consume_remote_probe(raw, "recall_shadow_probe")
+        if _recall_payload is not None:
+            raw["recall_shadow_monitor"] = _recall_payload.get("recall_shadow_monitor") or {}
+        else:
+            raw["recall_shadow_monitor"] = {
+                "sample_state": "unavailable",
+                "error_code": _recall_error_code,
+            }
 
         # BB.6-1: collect permanent-promotion ledger counts on the remote
         # host too. Without this, decision_recovery_failure_count and
@@ -5928,6 +6015,19 @@ def v2_exposure_and_clearance_probe():
             _roots, for_activation=_v2_exposure.get("v2c_unfreeze_ready") is True
         )
         return {"ok": True, "v2_exposure_monitor": _v2_exposure, "clearance_snapshot_freshness": _clearance}
+    except Exception as exc:
+        return {"ok": False, "error_code": type(exc).__name__, "error_detail": str(exc)[:200]}
+
+def recall_shadow_probe():
+    # Remote collection of the recall-arbitration shadow window, mirroring
+    # collect_snapshot()'s local branch. Before this probe the shadow lane had
+    # no production reader at all, so its evidence could not inform the
+    # shadow->apply graduation decision it exists to support.
+    try:
+        from plugins.memory.memory_os.recall_policy import recall_shadow_monitor_stats
+        from plugins.memory.memory_os.roots import MemoryOSRoots
+        _roots = MemoryOSRoots.from_hermes_home(_hermes_home, profile="default")
+        return {"ok": True, "recall_shadow_monitor": recall_shadow_monitor_stats(_roots)}
     except Exception as exc:
         return {"ok": False, "error_code": type(exc).__name__, "error_detail": str(exc)[:200]}
 
@@ -9136,6 +9236,7 @@ owner_review_proposal_followups = memory_os_cli(["review", "proposal-followups",
 owner_review_proposal_auto_route = memory_os_cli(["review", "proposal-followups", "--auto-route", "--limit", "10"])
 host_capability_probe = seam_host_probe()
 v2_exposure_and_clearance_probe_result = v2_exposure_and_clearance_probe()
+recall_shadow_probe_result = recall_shadow_probe()
 living_memory_promotion_probe_result = living_memory_promotion_probe()
 signal_source_requirements = memory_os_cli(["signal-sources", "--json"])
 memory_projection = memory_os_cli(["projection", "status"])
@@ -9207,6 +9308,7 @@ print(json.dumps({
   "owner_review_proposal_auto_route": owner_review_proposal_auto_route,
   "host_capability_probe": host_capability_probe,
   "v2_exposure_and_clearance_probe": v2_exposure_and_clearance_probe_result,
+  "recall_shadow_probe": recall_shadow_probe_result,
   "living_memory_promotion_probe": living_memory_promotion_probe_result,
   "signal_source_requirements": signal_source_requirements,
   "memory_projection": memory_projection,

--- a/tests/plugins/memory/test_memory_os_cognitive_loop.py
+++ b/tests/plugins/memory/test_memory_os_cognitive_loop.py
@@ -23,6 +23,41 @@ def test_cognitive_loop_rejects_apply_without_test_host(tmp_path):
     assert result["boundaries"]["actual_execute"] is False
 
 
+def test_cognitive_loop_crystallization_gate_step_carries_the_query_dialect(tmp_path):
+    """The step summary -- not the gate's return value -- is what persists.
+
+    `_run_step` writes this summary into reports.jsonl, so a key the summary
+    drops does not exist for any reader.  The gate's query dialect is the one
+    piece of evidence that separates "zero flags because nothing contradicts"
+    from "zero flags because the query could never match the index", which is
+    exactly how the CJK defect stayed invisible; asserting it on the gate's
+    own return value would not have caught the summary dropping it.
+    """
+    import sqlite3
+
+    store = _init_store(tmp_path)
+    from plugins.memory.memory_os.index import MemoryOSIndex
+
+    index = MemoryOSIndex(store.roots)
+    index.rebuild_from_store(store)
+    conn = sqlite3.connect(str(store.roots.index_path))
+    conn.execute(
+        """insert into crystallized_candidates
+           (candidate_id, kind, body, source_event_ids_json, tags_json, sensitivity, bridge_state)
+           values (?, ?, ?, ?, ?, ?, ?)""",
+        ("cand_dialect", "preference", "用户在书房安装了一个定时器", "[]", "[]", "private", "proposed"),
+    )
+    conn.commit()
+    conn.close()
+
+    result = CognitiveLoopRunner(store)._crystallization_gate({})
+
+    assert "fts_query_mode" in result, result
+    assert "fts_tokenizer" in result, result
+    assert result["fts_query_mode"] in {"trigram", "legacy"}, result
+    assert result["candidate_count"] == 1, result
+
+
 def test_cognitive_loop_crystallization_gate_preserves_bounded_error_metadata(
     tmp_path, monkeypatch
 ):

--- a/tests/plugins/memory/test_memory_os_graph_layer.py
+++ b/tests/plugins/memory/test_memory_os_graph_layer.py
@@ -5,6 +5,7 @@ Test IDs map to T1.x.y in graph-layer-roadmap.md §8.
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -1220,6 +1221,234 @@ def test_t2_2_2_gate_does_not_flag_non_contradicting_candidate(tmp_path):
     assert result["flagged_count"] == 0, (
         f"Candidate should NOT be flagged (no contradicts edge). Result: {result}"
     )
+
+
+def _cjk_gate_fixture(tmp_path, *, edge_state: str = "active"):
+    """Seed two contradicting Chinese records through the real producer path.
+
+    Bodies are deliberately NOT identical to the candidate written by the
+    caller: the whole point is paraphrase recall, and a fixture that reused
+    the same string would pass with the pre-fix tokenizer too.
+    """
+    store, index = _store(tmp_path)
+    conn = _conn(index)
+    _seed_canonical_crystallized(store, [
+        {"id": "cry_cjk_a", "kind": "preference",
+         "created_at": "2026-06-01T10:00:00Z",
+         "source_event_ids": ["evt_a"], "tags": [],
+         "body": "部署策略偏好灰度发布而不是金丝雀发布"},
+        {"id": "cry_cjk_b", "kind": "preference",
+         "created_at": "2026-06-01T12:00:00Z",
+         "source_event_ids": ["evt_b"], "tags": [],
+         "body": "部署策略偏好金丝雀发布而不是灰度发布"},
+    ])
+    index.rebuild_from_store(store)
+    _seed_contradicts_edge(
+        conn, index.roots, "cry_cjk_a", "cry_cjk_b", state=edge_state)
+    conn.close()
+    return store, index
+
+
+def _seed_cjk_candidate(index, body: str, candidate_id: str = "cand_cjk") -> None:
+    conn = _conn(index)
+    conn.execute(
+        """insert into crystallized_candidates
+           (candidate_id, kind, body, source_event_ids_json, tags_json, sensitivity, bridge_state)
+           values (?, ?, ?, ?, ?, ?, ?)""",
+        (candidate_id, "preference", body, "[]", "[]", "private", "proposed"),
+    )
+    conn.commit()
+    conn.close()
+
+
+# A paraphrase of cry_cjk_a: shares 3-character windows with it, but no whole
+# punctuation-delimited run of it is a substring of cry_cjk_a.  That asymmetry
+# is what separates the trigram query from the pre-fix whole-run one.
+_CJK_PARAPHRASE = "在部署策略上更偏好灰度发布，不采用金丝雀发布"
+
+
+def test_gate_finds_chinese_paraphrase_through_real_trigram_index(tmp_path):
+    """Counterfactual for the CJK query-dialect fix.
+
+    Pre-fix, ``_tokenize`` collapsed the whole Chinese run into ONE token,
+    which on a trigram index is a verbatim-substring search: the paraphrase
+    matched nothing, ``similar`` was empty, and the gate returned before it
+    ever reached its contradicts-edge check.  Reverting the tokenizer dispatch
+    makes this test fail with flagged_count == 0.
+    """
+    _store_obj, index = _cjk_gate_fixture(tmp_path)
+    _seed_cjk_candidate(index, _CJK_PARAPHRASE)
+
+    from plugins.memory.memory_os.crystallization_gate import run_crystallization_gate
+    result = run_crystallization_gate(str(index.roots.index_path), index=index)
+
+    if result["fts_query_mode"] != "trigram":
+        pytest.skip(
+            "index built with "
+            f"{result['fts_tokenizer']!r}; paraphrase recall is only reachable "
+            "on a trigram index (see _trigram_tokens docstring)"
+        )
+    assert result["status"] == "ok", result
+    assert result["flagged_count"] >= 1, (
+        "Chinese paraphrase must reach the contradicts-edge check. "
+        f"Result: {result}"
+    )
+
+
+def test_gate_cjk_flag_requires_an_active_edge_not_merely_a_text_match(tmp_path):
+    """Prove the sibling test is not passing vacuously.
+
+    The flag test asserts a conjunction: the trigram query found the records
+    AND an active contradicts edge joins them.  Verifying only the tokenizer
+    half would leave a fixture whose edge never mattered looking identical to
+    a working one.  Same fixture, edge in ``candidate`` state: the query still
+    matches, so a flag here would mean the edge was never load-bearing -- and
+    would also violate the rule that only active edges drive automation.
+    """
+    _store_obj, index = _cjk_gate_fixture(tmp_path, edge_state="candidate")
+    _seed_cjk_candidate(index, _CJK_PARAPHRASE)
+
+    from plugins.memory.memory_os.crystallization_gate import (
+        _fts_match_query,
+        _trigram_tokens,
+        run_crystallization_gate,
+    )
+
+    conn = _conn(index)
+    try:
+        matched = conn.execute(
+            "select record_id from memory_fts where memory_fts match ? "
+            "and record_type = 'crystallized_record'",
+            (_fts_match_query(_trigram_tokens(_CJK_PARAPHRASE)),),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    result = run_crystallization_gate(str(index.roots.index_path), index=index)
+    if result["fts_query_mode"] != "trigram":
+        pytest.skip("index is not trigram-tokenized")
+    assert matched, "fixture precondition: the trigram query must still match"
+    assert result["flagged_count"] == 0, (
+        "a candidate-state contradicts edge must not flag; a flag here means "
+        f"the sibling test's edge was never load-bearing. Result: {result}"
+    )
+
+
+def test_gate_bigram_terms_cannot_match_a_trigram_index(tmp_path):
+    """Pin WHY the fix emits trigrams and not the bigrams used elsewhere.
+
+    ``recall_arbitration._cjk_bigrams`` is the in-repo CJK helper, so the
+    obvious "reuse it here" refactor is a real hazard: on a trigram index a
+    bigram term can never match, and the resulting zero-flag behaviour is
+    byte-identical to the defect being fixed.  This test fails loudly if
+    anyone makes that swap.
+    """
+    _store_obj, index = _cjk_gate_fixture(tmp_path)
+
+    from plugins.memory.memory_os.crystallization_gate import (
+        _fts_match_query,
+        _trigram_tokens,
+    )
+    from plugins.memory.memory_os.index import _metadata_value
+
+    conn = _conn(index)
+    try:
+        if _metadata_value(conn, "fts_tokenizer") != "trigram":
+            pytest.skip("index is not trigram-tokenized")
+        bigrams = {
+            run[i:i + 2]
+            for run in re.findall(r"[㐀-鿿]+", _CJK_PARAPHRASE)
+            for i in range(len(run) - 1)
+        }
+
+        def _hits(query: str) -> int:
+            rows = conn.execute(
+                "select record_id from memory_fts where memory_fts match ? "
+                "and record_type = 'crystallized_record'",
+                (query,),
+            ).fetchall()
+            return len(rows)
+
+        assert _hits(_fts_match_query(bigrams)) == 0, (
+            "bigram terms unexpectedly matched a trigram index"
+        )
+        assert _hits(_fts_match_query(_trigram_tokens(_CJK_PARAPHRASE))) >= 1, (
+            "trigram terms must match the seeded Chinese records"
+        )
+    finally:
+        conn.close()
+
+
+def test_gate_query_dialect_follows_the_index_tokenizer(tmp_path):
+    """The dialect is chosen from index_metadata, never assumed.
+
+    An unknown or missing tokenizer must fall back to the legacy tokens
+    rather than guessing trigram semantics for an index that has none.
+    """
+    import plugins.memory.memory_os.index as index_module
+    from plugins.memory.memory_os.crystallization_gate import run_crystallization_gate
+
+    _store_obj, index = _cjk_gate_fixture(tmp_path)
+    _seed_cjk_candidate(index, _CJK_PARAPHRASE)
+
+    real_metadata_value = index_module._metadata_value
+    observed: dict[str, str] = {}
+    for reported, expected_mode in (
+        ("trigram", "trigram"),
+        ("unicode61", "legacy"),
+        ("", "legacy"),
+    ):
+        def _fake(conn, key, _reported=reported):
+            if key == "fts_tokenizer":
+                return _reported
+            return real_metadata_value(conn, key)
+
+        index_module._metadata_value = _fake
+        try:
+            result = run_crystallization_gate(str(index.roots.index_path), index=index)
+        finally:
+            index_module._metadata_value = real_metadata_value
+        observed[reported] = result["fts_query_mode"]
+        assert result["fts_query_mode"] == expected_mode, (reported, result)
+        assert result["fts_tokenizer"] == (reported or "unknown"), (reported, result)
+    assert observed == {"trigram": "trigram", "unicode61": "legacy", "": "legacy"}
+
+
+def test_gate_reported_dialect_cannot_drift_from_the_query_builder():
+    """Reported mode and query builder must come from one decision.
+
+    Two independent derivations would let a future edit change the query while
+    the run report keeps claiming the old dialect -- an unreadable artifact is
+    how the original defect survived.
+    """
+    from plugins.memory.memory_os.crystallization_gate import (
+        _legacy_tokens,
+        _query_builder_for,
+        _trigram_tokens,
+    )
+
+    assert _query_builder_for("trigram") == ("trigram", _trigram_tokens)
+    for unknown in ("unicode61", "", "porter", "some_future_tokenizer"):
+        assert _query_builder_for(unknown) == ("legacy", _legacy_tokens), unknown
+
+
+def test_gate_skips_candidate_whose_body_yields_no_query_term(tmp_path):
+    """A body too short to produce a trigram is skipped, not crashed on."""
+    from plugins.memory.memory_os.crystallization_gate import (
+        _fts_match_query,
+        _trigram_tokens,
+    )
+
+    assert _trigram_tokens("书房") == set()
+    assert _fts_match_query(set()) == ""
+
+    _store_obj, index = _cjk_gate_fixture(tmp_path)
+    _seed_cjk_candidate(index, "书房", candidate_id="cand_cjk_short")
+
+    from plugins.memory.memory_os.crystallization_gate import run_crystallization_gate
+    result = run_crystallization_gate(str(index.roots.index_path), index=index)
+    assert result["status"] == "ok", result
+    assert result["flagged_count"] == 0, result
 
 
 def test_t2_2_3_gate_allows_owner_override(tmp_path):

--- a/tests/plugins/memory/test_memory_os_recall_arbitration.py
+++ b/tests/plugins/memory/test_memory_os_recall_arbitration.py
@@ -662,3 +662,205 @@ def test_apply_recall_plan_ignores_ambiguity_related_and_still_returns_both_obje
     applied = apply_recall_plan(plan)
     refs = {obj.source_ref for obj in applied[RecallType.CRYSTALLIZED.value]}
     assert refs == {"amb-left-2", "amb-right-2"}
+
+
+# ── CJK similarity tokens, matrix-sourced config, reason census ────────────
+
+
+def _reason_probe_plans() -> list[dict]:
+    """Drive the real producer until every registered reason has fired.
+
+    A census built from hand-written fixtures would only prove the fixtures
+    are self-consistent; driving `build_recall_plan` proves each registered
+    reason is actually reachable, and equality against the vocabulary catches
+    any reason the producer emits without registering.
+    """
+    repeated = _obj("already injected", revision="rev-current", ref="repeat")
+    long_a = _obj("a body far longer than the budget allows", ref="big-a")
+    long_b = _obj("another body far longer than the budget", ref="big-b")
+    return [
+        build_recall_plan(
+            [_obj("old projection", recall_type=RecallType.STATE_OVERLAY.value,
+                  authority="state_projection", revision="rev-old", ref="overlay")],
+            current_task_revision="rev-current",
+        ),
+        build_recall_plan(
+            [repeated],
+            current_task_revision="rev-current",
+            session_ledger={content_fingerprint(repeated.content): _ledger_value("rev-current")},
+        ),
+        build_recall_plan([_obj("first body", ref="same"), _obj("second body", ref="same")]),
+        build_recall_plan([_obj("identical body", ref="a"), _obj("identical body", ref="b")]),
+        build_recall_plan([
+            _obj("用户在书房安装了一个定时器用于夜间断电", ref="cjk-a"),
+            _obj("用户在书房安装了一个定时器用于夜间断电吗", ref="cjk-b"),
+        ]),
+        build_recall_plan([
+            _obj("owner states A", authority="owner_confirmed", claim="c1", ref="oc-a"),
+            _obj("owner states B", authority="owner_confirmed", claim="c1", ref="oc-b"),
+        ]),
+        build_recall_plan([
+            _obj("derived A", authority="indexed_derived", claim="c2", ref="la-a"),
+            _obj("derived B", authority="external_unverified", claim="c2", ref="la-b"),
+        ]),
+        build_recall_plan([long_a, long_b], budget_chars=10),
+    ]
+
+
+def test_near_duplicate_detects_chinese_near_identical_variants():
+    """Counterfactual for the CJK similarity-token fix.
+
+    Pre-fix, ``[\\w\\u4e00-\\u9fff]+`` never split between Chinese characters,
+    so each of these bodies was ONE token, the two tokens differed, and
+    jaccard was 0.0 -- L3 could not fire on Chinese at all.  Reverting
+    ``_similarity_tokens`` to that single-class regex makes this test fail
+    with near_duplicate_count == 0.
+    """
+    plan = build_recall_plan([
+        _obj("用户在书房安装了一个定时器用于夜间断电", ref="cjk-keep", score=0.9),
+        _obj("用户在书房安装了一个定时器用于夜间断电吗", ref="cjk-drop", score=0.4),
+    ], budget_chars=4000)
+
+    assert plan["near_duplicate_count"] == 1, plan
+    assert [item["reason"] for item in plan["suppressed"]] == ["near_duplicate"], plan
+    assert plan["selected_count"] == 1
+
+
+def test_near_duplicate_still_does_not_collapse_a_chinese_paraphrase():
+    """Scope pin: this fix restores near-identical dedup, NOT paraphrase dedup.
+
+    Semantic-equivalence collapsing is a separate owner decision; if a later
+    change starts suppressing here, that decision must be made deliberately
+    rather than arriving as a side effect of a tokenizer tweak.
+    """
+    plan = build_recall_plan([
+        _obj("用户在书房安装了一个定时器", ref="para-a"),
+        _obj("书房的定时器是用户装的", ref="para-b"),
+    ], budget_chars=4000)
+
+    assert plan["near_duplicate_count"] == 0, plan
+    assert plan["ambiguous_pair_count"] == 0, plan
+
+
+def test_similarity_tokens_leave_non_cjk_text_bit_identical():
+    """The ASCII/Latin class must tokenize exactly as the old single-class rule.
+
+    Only the CJK class changed; an English or accented-Latin corpus must see
+    no behavioural difference at all, otherwise the fix silently re-tunes
+    every non-CJK deployment.
+    """
+    import re as _re
+
+    from plugins.memory.memory_os.recall_arbitration import _similarity_tokens
+
+    for text in (
+        "The user installed a timer in the study",
+        "café serves espresso at 07:30",
+        "snake_case and CamelCase and digits 12345",
+    ):
+        assert _similarity_tokens(text) == set(_re.findall(r"\w+", text.casefold())), text
+
+
+def test_near_duplicate_config_is_sourced_from_the_matrix():
+    """Dedup semantics must be matrix data the code reads, not a doc-only key.
+
+    Two failure modes are pinned at once: a matrix key nothing reads (the
+    ``relevance_score`` defect), and a code constant the matrix does not cover
+    (which would change detection without ending the observation window it
+    invalidates).
+    """
+    import inspect
+    from copy import deepcopy
+
+    from plugins.memory.memory_os.recall_arbitration import (
+        _AMBIGUITY_JACCARD_FLOOR,
+        NEAR_DUPLICATE_THRESHOLD,
+        NEAR_DUPLICATE_TOKENIZER,
+    )
+    from plugins.memory.memory_os.recall_policy import (
+        AUTHORITY_FRESHNESS_MATRIX,
+        AUTHORITY_FRESHNESS_MATRIX_DIGEST,
+        authority_freshness_matrix_digest,
+    )
+
+    config = AUTHORITY_FRESHNESS_MATRIX["near_duplicate"]
+    assert NEAR_DUPLICATE_THRESHOLD == config["threshold"]
+    assert NEAR_DUPLICATE_TOKENIZER == config["tokenizer"]
+    assert _AMBIGUITY_JACCARD_FLOOR == config["ambiguity_floor"]
+
+    default = inspect.signature(build_recall_plan).parameters["near_duplicate_threshold"].default
+    assert default == config["threshold"], (
+        "the runtime default must come from the matrix, or the matrix entry is "
+        "decorative and the era boundary it promises does not exist"
+    )
+
+    for key, new_value in (("threshold", 0.5), ("tokenizer", "other_v9"), ("ambiguity_floor", 0.1)):
+        changed = deepcopy(AUTHORITY_FRESHNESS_MATRIX)
+        changed["near_duplicate"][key] = new_value
+        assert authority_freshness_matrix_digest(changed) != AUTHORITY_FRESHNESS_MATRIX_DIGEST, (
+            f"changing near_duplicate.{key} must start a new observation window"
+        )
+
+
+def test_conflict_lane_reports_the_denominator_behind_a_zero():
+    """`conflict_count == 0` must be readable as input-or-failure.
+
+    Conflict grouping keys on `claim_key`, whose only producer is crystallized
+    frontmatter -- and no production record carries one, so this counter has
+    been 0 for every sample the lane ever took.  Without a denominator that
+    permanent zero looks the same whether nothing was eligible or the grouping
+    silently broke.
+    """
+    without_keys = build_recall_plan([_obj("no claim key at all", ref="nk")])
+    assert without_keys["conflict_count"] == 0
+    assert without_keys["claim_keyed_input_count"] == 0, (
+        "no eligible input -- the zero above is expected, not a finding"
+    )
+
+    with_key = build_recall_plan([_obj("single keyed claim", claim="profile.timezone", ref="k1")])
+    assert with_key["conflict_count"] == 0
+    assert with_key["claim_keyed_input_count"] == 1, (
+        "input existed and produced no conflict -- a genuinely different state"
+    )
+
+    conflicting = build_recall_plan([
+        _obj("timezone is UTC", authority="owner_confirmed", claim="profile.timezone", ref="c1"),
+        _obj("timezone is Asia Shanghai", authority="owner_confirmed", claim="profile.timezone", ref="c2"),
+    ])
+    assert conflicting["conflict_count"] == 1
+    assert conflicting["claim_keyed_input_count"] == 2
+
+
+def test_recall_suppression_reason_census():
+    """Two-direction census of the suppression vocabulary.
+
+    Direction 1: every registered reason is reachable from the real producer.
+    Direction 2: no ``_suppression`` call site emits an unregistered literal.
+    A vocabulary that drifts from its producer checks nothing, silently.
+    """
+    import inspect
+    import re as _re
+
+    from plugins.memory.memory_os import recall_arbitration
+    from plugins.memory.memory_os.recall_policy import SUPPRESSION_REASONS
+
+    observed: set[str] = set()
+    for plan in _reason_probe_plans():
+        observed.update(str(item["reason"]) for item in plan["suppressed"])
+    assert observed == set(SUPPRESSION_REASONS), (
+        f"unreachable={set(SUPPRESSION_REASONS) - observed} "
+        f"unregistered={observed - set(SUPPRESSION_REASONS)}"
+    )
+
+    literals: set[str] = set()
+    indirect: set[str] = set()
+    for line in inspect.getsource(recall_arbitration).splitlines():
+        if "_suppression(" not in line or line.lstrip().startswith("def "):
+            continue
+        literals.update(_re.findall(r'_suppression\([^,]+,\s*"([a-z_]+)"', line))
+        indirect.update(_re.findall(r"_suppression\([^,]+,\s*([a-z_]+)\s*[,)]", line))
+    assert literals <= set(SUPPRESSION_REASONS), literals - set(SUPPRESSION_REASONS)
+    assert indirect <= {"status"}, (
+        f"new indirect _suppression reason source(s): {indirect - {'status'}} -- "
+        "extend the census before merging"
+    )

--- a/tests/plugins/memory/test_memory_os_recall_policy.py
+++ b/tests/plugins/memory/test_memory_os_recall_policy.py
@@ -125,3 +125,195 @@ class TestRecallObservationRetention:
         status = read_recall_observation_window(roots)
         assert status["invalidated_observation_count"] == 1
         assert status["current_observation_count"] == 1
+
+
+class TestRecallShadowMonitorStats:
+    """The shadow window's first production reader.
+
+    Before this function the ledger's only consumer was the provider's own
+    `status` call, so a lane whose entire purpose is to produce graduation
+    evidence had no way to show that evidence to anyone.
+    """
+
+    def test_empty_window_reports_no_sample_rather_than_health(self, tmp_path):
+        from plugins.memory.memory_os.recall_policy import recall_shadow_monitor_stats
+
+        stats = recall_shadow_monitor_stats(FakeRoots(tmp_path))
+
+        assert stats["sample_state"] == "healthy_no_sample", (
+            "an empty window must say so on its face; a silent 0 reads as a clean bill of health"
+        )
+        assert stats["current_observation_count"] == 0
+        assert stats["suppressed_total"] == 0
+        assert stats["latest_observed_at"] == ""
+
+    def test_window_aggregates_reason_decomposition_and_saturation(self, tmp_path):
+        from plugins.memory.memory_os.recall_policy import (
+            SUPPRESSION_REASONS,
+            recall_shadow_monitor_stats,
+        )
+
+        roots = FakeRoots(tmp_path)
+        append_recall_observation(roots, _plan(
+            suppressed=[{"reason": "near_duplicate"}, {"reason": "budget_exceeded"}],
+            suppressed_count=2, near_duplicate_count=1, ambiguous_pair_count=2,
+            input_count=5, selected_count=3, would_change_live_recall=True,
+        ))
+        append_recall_observation(roots, _plan(
+            suppressed=[{"reason": "near_duplicate"}],
+            suppressed_count=1, near_duplicate_count=1,
+            input_count=4, selected_count=3, would_change_live_recall=True,
+        ))
+
+        stats = recall_shadow_monitor_stats(roots)
+
+        assert stats["sample_state"] == "sampled"
+        assert stats["current_observation_count"] == 2
+        assert set(stats["suppressed_by_reason"]) == set(SUPPRESSION_REASONS)
+        assert stats["suppressed_by_reason"]["near_duplicate"] == 2
+        assert stats["suppressed_by_reason"]["budget_exceeded"] == 1
+        assert stats["input_total"] == 9
+        assert stats["selected_total"] == 6
+        assert stats["suppressed_total"] == 3
+        assert stats["ambiguous_pair_total"] == 2
+        # Reported beside the decomposition precisely because it saturated at
+        # 100% on production and therefore decides nothing on its own.
+        assert stats["would_change_live_recall_true_count"] == 2
+        assert stats["schema_version_counts"] == {"memory-os.recall_observation.v2": 2}
+
+    def test_conflict_denominator_survives_into_the_window(self, tmp_path):
+        """A permanently-zero conflict_total needs its input count beside it."""
+        from plugins.memory.memory_os.recall_policy import recall_shadow_monitor_stats
+
+        roots = FakeRoots(tmp_path)
+        append_recall_observation(roots, _plan(conflict_count=0, claim_keyed_input_count=0))
+        append_recall_observation(roots, _plan(conflict_count=0, claim_keyed_input_count=3))
+
+        stats = recall_shadow_monitor_stats(roots)
+
+        assert stats["conflict_total"] == 0
+        assert stats["claim_keyed_input_total"] == 3, (
+            "without this the zero above cannot be told from a broken lane"
+        )
+
+    def test_mixed_schema_versions_in_one_window_are_visible(self, tmp_path):
+        """A window holding two schema versions means a deploy skipped its era
+        boundary; every ratio computed over it would mix incompatible rows, so
+        the mix must be readable rather than averaged away."""
+        from plugins.memory.memory_os.jsonl_io import append_jsonl_locked
+        from plugins.memory.memory_os.recall_policy import recall_shadow_monitor_stats
+
+        roots = FakeRoots(tmp_path)
+        append_jsonl_locked(recall_observation_path(roots), {
+            "schema_version": "memory-os.recall_observation.v1",
+            "observation_window_id": OBSERVATION_WINDOW_ID,
+            "observed_at": "2026-08-01T00:00:00Z",
+            "input_count": 2, "selected_count": 1, "suppressed_count": 1,
+        })
+        append_recall_observation(roots, _plan(
+            suppressed=[{"reason": "near_duplicate"}], suppressed_count=1))
+
+        stats = recall_shadow_monitor_stats(roots)
+
+        assert stats["schema_version_counts"] == {
+            "memory-os.recall_observation.v1": 1,
+            "memory-os.recall_observation.v2": 1,
+        }
+        # The v1 row contributes its totals but no reason breakdown; that
+        # asymmetry is exactly what the version counts warn the reader about.
+        assert stats["suppressed_total"] == 2
+        assert stats["suppressed_by_reason"]["near_duplicate"] == 1
+
+
+class TestRecallObservationV2Reasons:
+    """v2: the ledger must carry WHY things were suppressed, not just how many.
+
+    v1 recorded 5022 suppressions on production with no reason breakdown, so
+    suppression precision -- the one number a graduation decision needs -- was
+    not computable from the ledger at all.
+    """
+
+    def test_reason_buckets_are_always_complete_so_zero_differs_from_absent(self, tmp_path):
+        from plugins.memory.memory_os.recall_policy import SUPPRESSION_REASONS
+
+        roots = FakeRoots(tmp_path)
+        append_recall_observation(roots, _plan(
+            suppressed=[
+                {"reason": "near_duplicate"},
+                {"reason": "near_duplicate"},
+                {"reason": "budget_exceeded"},
+            ],
+            suppressed_count=3,
+            ambiguous_pair_count=4,
+        ))
+
+        record = read_jsonl(recall_observation_path(roots))[-1]
+        assert record["schema_version"] == "memory-os.recall_observation.v2"
+        assert set(record["suppressed_by_reason"]) == set(SUPPRESSION_REASONS), (
+            "a reason that did not occur must read as 0, never as a missing key"
+        )
+        assert record["suppressed_by_reason"]["near_duplicate"] == 2
+        assert record["suppressed_by_reason"]["budget_exceeded"] == 1
+        assert record["suppressed_by_reason"]["exact_duplicate"] == 0
+        assert record["unknown_reason_count"] == 0
+        assert record["ambiguous_pair_count"] == 4, (
+            "computed by build_recall_plan since L4 shipped and persisted by nobody until v2"
+        )
+
+    def test_unregistered_reason_is_counted_not_dropped(self, tmp_path):
+        """An unknown reason must be visible, not silently absorbed.
+
+        Bucketing by a closed vocabulary risks losing anything outside it;
+        the `unknown` counter is what turns that into a signal a reader can
+        act on (and what the census test then chases down).
+        """
+        roots = FakeRoots(tmp_path)
+        append_recall_observation(roots, _plan(
+            suppressed=[
+                {"reason": "near_duplicate"},
+                {"reason": "reason_invented_by_a_future_producer"},
+                {"not_a_mapping_row": True},
+                "malformed-row",
+            ],
+            suppressed_count=4,
+        ))
+
+        record = read_jsonl(recall_observation_path(roots))[-1]
+        assert record["suppressed_by_reason"]["near_duplicate"] == 1
+        assert record["unknown_reason_count"] == 3
+        total = sum(record["suppressed_by_reason"].values()) + record["unknown_reason_count"]
+        assert total == record["suppressed_count"], (
+            "every suppressed row must land in exactly one bucket"
+        )
+
+    def test_plan_produced_by_the_real_builder_round_trips_into_the_ledger(self, tmp_path):
+        """End-to-end: the producer's reasons must survive into the ledger.
+
+        Hand-built plan dicts would pass even if `build_recall_plan` renamed
+        every reason, so this drives the real builder.
+        """
+        from plugins.memory.memory_os.recall_arbitration import build_recall_plan
+        from plugins.memory.memory_os.recall_types import RecallObject, RecallType
+
+        def _object(content: str, ref: str, score: float) -> RecallObject:
+            return RecallObject(
+                recall_type=RecallType.INDEXED_FTS.value,
+                content=content,
+                score=score,
+                source_ref=ref,
+                authority_class="indexed_derived",
+            )
+
+        plan = build_recall_plan(
+            [
+                _object("用户在书房安装了一个定时器用于夜间断电", "cjk-keep", 0.9),
+                _object("用户在书房安装了一个定时器用于夜间断电吗", "cjk-drop", 0.4),
+            ],
+            budget_chars=4000,
+        )
+        roots = FakeRoots(tmp_path)
+        assert append_recall_observation(roots, plan) is True
+
+        record = read_jsonl(recall_observation_path(roots))[-1]
+        assert record["suppressed_by_reason"]["near_duplicate"] == 1
+        assert record["unknown_reason_count"] == 0

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -8891,3 +8891,124 @@ def test_edge_provenance_write_failed_count_survives_both_whitelists_end_to_end(
     evidence = namespace["cognitive_loop_step_evidence"]()
     surfaced = evidence["edge_step_results"]["edge_provenance"]
     assert surfaced["write_failed_count"] == 3
+
+
+def _recall_shadow_payload(**overrides) -> dict:
+    payload = {
+        "schema_version": "memory-os.recall_shadow_monitor.v1",
+        "sample_state": "sampled",
+        "observation_window_id": "memory-os.authority-freshness-matrix.v1:deadbeef",
+        "window_reset_required": False,
+        "current_observation_count": 12,
+        "invalidated_observation_count": 451,
+        "schema_version_counts": {"memory-os.recall_observation.v2": 12},
+        "suppressed_by_reason": {"near_duplicate": 3, "session_duplicate": 9},
+        "unknown_reason_total": 0,
+        "input_total": 40,
+        "selected_total": 20,
+        "suppressed_total": 12,
+        "near_duplicate_total": 3,
+        "ambiguous_pair_total": 1,
+        "conflict_total": 0,
+        "would_change_live_recall_true_count": 12,
+        "latest_observed_at": "2026-08-18T10:25:21Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_recall_arbitration_shadow_window_is_reported_as_ungraded_info():
+    """The shadow window must have a production reader, ungraded.
+
+    Grading any of these would false-alarm on a legitimately quiet window
+    (the exposure_rollup_lag_hours precedent); the value delivered is the
+    per-reason decomposition, which v1 of the ledger could not express at all.
+    """
+    snapshot = _healthy_snapshot()
+    snapshot["recall_shadow_monitor"] = _recall_shadow_payload()
+
+    classification = classify_snapshot(snapshot)
+
+    entries = [
+        item for item in classification["info"]
+        if item["code"] == "recall_arbitration_shadow_window"
+    ]
+    assert len(entries) == 1, classification["info"]
+    value = entries[0]["value"]
+    assert value["suppressed_by_reason"] == {"near_duplicate": 3, "session_duplicate": 9}
+    assert value["schema_version_counts"] == {"memory-os.recall_observation.v2": 12}
+    assert value["would_change_live_recall_true_count"] == 12
+    assert value["ambiguous_pair_total"] == 1
+    # Ungraded: it must not move the run's verdict in either direction.
+    assert not any(
+        item["code"].startswith("recall_arbitration_shadow")
+        for item in classification["fail"] + classification["warn"] + classification["pass"]
+    )
+
+
+def test_recall_shadow_collection_failure_warns_instead_of_reading_as_quiet():
+    """An unreadable window must never look like a healthy quiet one."""
+    snapshot = _healthy_snapshot()
+    snapshot["recall_shadow_monitor"] = {
+        "sample_state": "unavailable",
+        "error_code": "ImportError",
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    assert any(
+        item["code"] == "recall_shadow_monitor_collection_failed"
+        for item in classification["warn"]
+    ), classification["warn"]
+    assert not any(
+        item["code"] == "recall_arbitration_shadow_window"
+        for item in classification["info"]
+    )
+
+
+def test_recall_shadow_collection_failure_is_classified_on_clean_host():
+    """A new WARN code must be registered, or clean-host runs FAIL on it.
+
+    `clean_host_warn_unclassified` turns any unregistered WARN into a FAIL --
+    the registry is not optional bookkeeping for a lane that emits one.
+    """
+    snapshot = _healthy_snapshot()
+    snapshot["monitor_profile"] = "clean_host"
+    snapshot["recall_shadow_monitor"] = {
+        "sample_state": "unavailable",
+        "error_code": "OSError",
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    assert not any(
+        item.get("warn_code") == "recall_shadow_monitor_collection_failed"
+        for item in classification["fail"]
+    ), classification["fail"]
+    assert any(
+        item["code"] == "recall_shadow_monitor_collection_failed"
+        and item["classification"] == "known_optional"
+        for item in classification["clean_host_warn_classification"]
+    ), classification.get("clean_host_warn_classification")
+
+
+def test_recall_shadow_empty_window_still_reports_no_sample():
+    """A window with no rows reports `healthy_no_sample`, not silence."""
+    snapshot = _healthy_snapshot()
+    snapshot["recall_shadow_monitor"] = _recall_shadow_payload(
+        sample_state="healthy_no_sample",
+        current_observation_count=0,
+        schema_version_counts={},
+        suppressed_by_reason={},
+        input_total=0, selected_total=0, suppressed_total=0,
+        near_duplicate_total=0, ambiguous_pair_total=0,
+        would_change_live_recall_true_count=0, latest_observed_at="",
+    )
+
+    classification = classify_snapshot(snapshot)
+
+    entries = [
+        item for item in classification["info"]
+        if item["code"] == "recall_arbitration_shadow_window"
+    ]
+    assert entries and entries[0]["value"]["sample_state"] == "healthy_no_sample"


### PR DESCRIPTION
## 起因

一个 Hermes agent 提交了 5 条"核心模块改进建议"。核查结论：**2 条伪报、1 条半真但改法不可实现、2 条属实**，另在核查中发现 4 项它没提的问题。本 PR 修其中 3 项。完整核查裁定见 checklist 的 DA 节。

伪报两条（附反证）：认知循环"无故障隔离"——`_run_step:308-333` 早已逐步 try/except 并统计 `error_step_count`，生产 439 周期中 `deep_reflection` 报错 56 次而周期照常跑完；图边 TTL"彻底删除"——实为 `invalidated`，且 `structural_edge_proposer` 的 `state != 'invalidated'` 已提供重连路径。其引用的"75% LLM 失败率"实为 **27.5%**，注释在 `clearance_cycle.py:458` 而非 `fact_judge.py`，且那段注释本身是**已落地修复的说明**。

## 根因（一句话）

`\w` 在 Python re 下**本就匹配 CJK**，所以 `[\w一-鿿]+` 这类字符类在中日韩文字之间**永不断开**——整段话变成一个 token。全项目扫描：2 处中招，3 处本来就对。

## 批 A — 结晶门的查询方言

门的 token 会变成 FTS5 MATCH 查询，**必须与索引自身的分词器一致**。生产两 home 均为 `tokenize='trigram'`，而 trigram 下短于 3 字符的词永不匹配。真实 trigram 表实测：

| 查询形态 | 命中 |
|---|---|
| 现状（整段一个 token） | 只命中自身，找不到改写句 |
| **双字 bigram** | **0 命中** |
| **三字 trigram** | 真正命中改写句 |

即"复用仓库里已有的 `_cjk_bigrams`"这个看似自然的改法会得到零命中，**失败特征与缺陷本身完全一致**。现按 `index_metadata.fts_tokenizer` 分派；`unicode61` 与未知一律走 legacy 并显式说明理由（该分词器下索引侧同为整段 token，查询侧无解）。

`_query_builder_for` 用一个函数同时返回 `(mode, builder)`，让"上报的方言"与"实际用的方言"结构上无法漂移。

## 批 B — 召回相似度 + 影子账本 v2

同族根因：中文改写句 jaccard 恒 0.0，L3 近重复与 L4 歧义带对 CJK **结构性不可达**（生产：7134 次输入中近重复只命中 5 次，确定性去重 257 次）。非 CJK 段保留原 `\w+` 规则，英文与带重音拉丁**逐位不变**。

去重语义并入 `AUTHORITY_FRESHNESS_MATRIX` 且**代码从 matrix 取默认值**——否则改分词器会让"结构性为零"的旧样本与修复后样本混在同一观测纪元里。守卫测试同时钉死两个失败模式：matrix 键无人读（即本仓库 `relevance_score` 的老毛病），与代码常量不受 matrix 覆盖。

账本 v2 **必须与之同批**（`evaluate_observation_window` 只看窗口 id、不看 schema_version，分两批会混纪元）。v1 只记总数：生产 5022 条抑制无原因分布，抑制精度在数学上算不出；`would_change_live_recall` 在 547/547 样本中恒为 true，作为毕业信号零信息量。v2 加 per-reason 封闭词表（恒全键，0 与缺键可区分）、unknown 桶、`ambiguous_pair_count`（L4 上线以来算了但从未持久化）。并给这条 lane 接上**首个生产读者**——monitor INFO 条目，**故意不评级**（安静窗口本就零抑制，评级会在闲周误报）。

## 批 C — conflict 通道的分母

`claim_key` 唯一生产者是 crystallized frontmatter，生产上 0 条记录带它，故 `conflict_count` 恒为 0——而永久零"无输入"与"分组坏了"同貌。新增 `claim_keyed_input_count` 贯通 plan → 账本 → 监控。

## 验证

- **两次 revert 实测反事实**。批 B 第一版夹具是**空洞的**：用"仅差句号"的两句，而中文标点在旧正则里本来就是分隔符，回退修复后测试照样通过。是 revert 实测把它抓出来的，换成 run 内语气词变体（legacy `0.000` / fixed `0.947`）后才成立。
- 门的反事实另配**非空洞性检查**：同 fixture 把矛盾边置 `candidate` 态应 0 标记，证明该边确实承重。
- 顾问审核抓出一个漏键阻断项：`fts_query_mode` 最初没透传到 loop step summary，而 reports.jsonl 存的是 summary——即"在唯一持久证据面上不存在"。已透传并补测试，同时统一 gate 三种 return 形态的键集。
- 全量 **3559 → 3583 passed（+24）/ 13 skipped**，四静态门 + `git diff --check` 全绿。

## 诚实边界

- 恢复的是**近似变体去重，不是语义改写去重**（改写句 0.22–0.54，仍在两条带之外）。后者是独立的 owner 设计决策，已配测试钉住防止被当作调优副产品悄悄改掉。
- **门修复不会带来标记量跳升**：生产 active `contradicts` 边仅 4（main）+ 1（sannai），上限由边的稀缺性封顶而非 FTS 召回。价值在于**高代价罕见路径上的正确性**——中文候选此前根本走不到边检查那一步。验收看 reason_code 分布与 loop report 的 `fts_query_mode`，不看数量。

## 部署注意

- **必须重启 gateway**：批 B 跑在 gateway 进程内的 prefetch 热路径，provider 模块进程内缓存，不重启则 v2 账本与新纪元**永远不会开始写**。批 A 在 cron 侧，不受此限。
- **纪元重置是预期**：matrix 摘要变化会把 main 451 条 / sannai 96 条旧观测置为 `invalidated`，当代窗口归零重新积累。
