### PR TITLE
fix(memory-os): one event-corpus read per batch in the taint gate; stop reporting probe timeouts as an unhealthy doctor

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -6975,6 +6975,142 @@ gating (required=False)"是**假的**：`_require_cognitive_loop_timer_active`
 12 个反事实测试对 origin/main 预修复实现实测 revert→**12 FAIL**（每个都
 以预期原因失败）→restore→PASS。全量 **3408 passed / 13 skipped / 0
 failed**（11:46），四静态门 + `git diff --check` 全绿。
+### DB 部署与生产验证（2026-08-19，main+sannai 双 profile，`9824db2`）
+
+DB 本身标注"仅仓库验证"——prefetch/temporal/state_overlay 属 provider 侧，
+生效需重启 gateway。本节补上这一步并取得生产实证。
+
+- `/opt/Hermes-Memory-OS` ff `263c623 → 9824db2`（PR #70 merge）。
+- `deploy_memory_os.py` production-safe upgrade **×2 home**，逐阶段：
+  main `preflight pass(30/0/0) → dry-run pass → apply applied → postcheck pass`，
+  三探针（cron_adapter/boundary_runtime/manifest）pass，唯一 WARN
+  `llm_judge_probe=ambiguous`；sannai `preflight pass(29/0/0)` 起全绿，
+  `llm_judge_probe=pass`。**该 WARN 与 CN 节记载同型**：bounded_vote/
+  gpt-5.6-luna 对低线索探针 query `继续昨天那个。` 裁 `ask_choice`
+  （confidence 0.98），属合理裁决非故障。
+- **配置写入先核实为行为等价空操作**（安装器会整段替换 preset 子树，
+  不核实就部署等于拿 preset 覆盖线上手工值）：deep_reflection /
+  memory_sources / low_clue_recall 三处 preset 值与两 home 线上逐字段相同；
+  main 的 `session_mirror` 三个手工键（`auto_apply_after_owner_home_graduation`
+  / `auto_apply_max_sessions_per_run` / `platform_denylist`）被 preset 写掉后，
+  由 `config.py::_merge_session_mirror_config` 以同值默认（True/1/[]）原样补回，
+  判定无行为差；`--hindsight auto`：main 命中 `preserve_existing_active`
+  保住 active/retain/reflect，sannai 无 `hindsight/config.json` →
+  `not_configured` 不写。`config_defaults` 两 home 均 `already_current`。
+- **hash 核验（不信 manifest，逐文件 `git hash-object` 对
+  `git rev-parse 9824db2:<path>`）**：9 个 provider 文件 × 每 home 2 份副本
+  × 2 home = **36/36 一致**；modules `override_sweep.py` ×2、
+  `scripts/memory_os_3_200_monitor.py` ×2 一致。即**四份 provider + 两份
+  modules + scripts 全覆盖**，由 deploy 脚本两次调用（每 home 一次）完成——
+  `install_memory_os.sh` 的 `default_system_modules="yes"` 是覆盖
+  `memory-os/runtime/python/plugins` 那两份的前提。
+- gateway 重启（provider 侧进程内缓存，见 DA 同款要求）：
+  `hermes-gateway.service` 11:54:59、`hermes-gateway-sannai.service` 12:00:57，
+  均 active / NRestarts=0 / journal 无 traceback 无 memory_os 错误。
+- **DB 三项修复的生产实证**：
+  ① `runtime/event_stats.json` 两 home 均新增 `recall_event_summaries` /
+  `recall_summary_excluded_kind_counts` / `recall_summary_scanned_count` /
+  `recall_summary_scan_truncated`。main 扫 266 条排除 **261** 条
+  （conversation_turn_mirrored 195、governance_resolver_approved 30、
+  governance_resolver_invalidated 27、session_fact_extracted 6、
+  governance_evidence_scored 3）得 5 条真实 `conversation_turn`；
+  sannai 扫 35 排除 30 得 5 条。
+  ② overlay `recent_events` **1 → 6**（1 锚点 + 5 事件），两 home 一致；
+  `event_stats_health={freshness:fresh, reason:"produced", injected_count:5}`，
+  reason ∈ `EVENT_STATS_HEALTH_REASONS`；`quality.json`
+  `recent_events_count=6`、`sections.recent_events=ok`。
+  ③ 锚点条目仍在 → 尾读有界未误伤。
+  **并且直接证实了"只修路径会变差"这一判断**：同窗口未过滤的
+  `recent_event_summaries` 仍旧是 governance/mirror 行——允许表是必需的，
+  不是保险。
+- monitor 对照（关键：与**各自** profile 的历史基线比，不与对方比）：
+  main 部署前当夜 nightly FAIL 4 → 本次 **FAIL 2**，WARN 14 不变、PASS 83 不变；
+  消失的 `session_mirror_auto_apply_permit_integrity_invalid` /
+  `index_not_healthy_in_production` 记为"本次运行未出现"，**不记为已修**
+  （PR #70 未触及这两条路径，午间/02:30 时点差与重启重置 catchup 窗口都是
+  活着的解释，以今夜 nightly 为准）。sannai PASS **90**（历史最高：07-28 73、
+  08-12 87），FAIL 7 全部命中其自身历史既有码。**两 profile 均无新增 FAIL/WARN**。
+- 证据级别：`local_pass` 3607/13 skipped、`deploy_pass` ×2、
+  `live_monitor_fail`（被下节 DC 的先存 FAIL 挡住，非本批回归）。
+- **工具坑两条（都曾伪装成缺陷）**：① 从 Git Bash 调 deploy/monitor 必须带
+  `MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'`，否则 MSYS 把 `/root/.hermes`
+  改写成 `D:/Git/root/.hermes`——`--phase plan` 的 commands 里肉眼可见，
+  **plan 阶段存在的意义之一就是抓这个**；② 双 profile 主机跑 full monitor 必须
+  `--caller-timeout-seconds ≥600`，否则探针吃 300s 地板直接
+  `probe_script_timeout` FAIL 且全 section 为 None（CO 已把预算做成可声明，
+  但默认地板仍是 300）。
+
+### DC — doctor 45s 的真因：taint 谓词按项重读全量事件语料；顺带修掉 monitor 把"探针超时"误报成"doctor 不健康"（2026-08-19）
+
+DB 部署后 main+sannai 的 `doctor_not_ok` + `shell_alias_no_env_failed` 仍 FAIL，
+考古证实**连续 ≥4 夜同型**（08-15/16/17/18），先于本次部署。顺着查下去发现
+被举报的症状和真因隔着两层。
+
+**① 症状层：monitor 把两种事实塞进同一个 code。** 生产 `hermes
+memory-os-agent-os doctor` 实测 **rc=0 / exit_code=0 / findings=[]**，即健康；
+但它要跑 **45s**，而远端探针每命令上限 20s（`MEMORY_OS_MONITOR_COMMAND_
+TIMEOUT_SECONDS` 默认 20）。超时后 `load_json_cmd` 返回 `{_error, _code:124}`，
+而 doctor section 只摘 `status/exit_code/findings` 三个字段，**把 `_error`/
+`_code` 丢在快照边界外**——于是"探针没跑完"与"doctor 跑完了且有问题"都以
+`status=None` 抵达分类器，同判 `doctor_not_ok`。这正是本仓库 `_smoke_status`
+docstring 写死的那条禁令（"not run" 与 "ran and failed" 不得共用 outcome）
+在另一处复发。修法**不是抬高 20s**（那是跑步机，见 ②），而是让 outcome
+说实话：probe section 带上 `probe_error`/`probe_exit_code`，分类器新增
+`doctor_probe_timeout`（仍属 FAIL 级——丢失检查确实是可见性损失——只是不再
+诬告 doctor）。守卫测试钉住生产者/消费者这一对：探针不再带这两个字段时，
+分类分支即不可达。
+
+**② 真因层：与 PR #70 同族的"按项重读"缺陷，只是深了一层。** cProfile
+（生产 main home）：`build_doctor_result` 66.5s 中 **59.3s 在
+`_candidate_review_items`**，其下 `provenance.is_tainted` 被调 470 次、
+`store.read_events()` 被调 **242 次**、`schema.from_dict` **154 万次**、
+`json.loads` **187 万次**。根因是缓存作用域小了一层：`_load_events` 的
+docstring 明写"每次**顶层** is_tainted 调用读一次语料"，而热点 caller
+（`owner_actions.py` 的 `external_ref = candidate_external_ref(...) if
+is_tainted(...) else None`）是**按候选**调用的——两个谓词各读一遍全量语料，
+成本 O(候选 × 事件)，且 `_resolve_event_from_store` 还在其上做线性扫描。
+修法：`provenance` 暴露 `load_event_cache()` + `EventLookup`（id→event 索引，
+**首个 id 命中优先，与被替换的线性扫描逐字同义**），`is_tainted` 的私有
+`_events_cache` 提升为公开 `events_cache`（全仓 grep 确认无测试引用旧私有名），
+`candidate_external_ref` 补同款参数——**两个都要补**，只补一个等于语料照读。
+caller 在循环外建一次缓存。
+- **有意保留的行为差并写进 docstring**：共享缓存后，一次读失败会污染整批
+  而非逐项重试——方向是 fail-closed，且"整批语料读不出来"正是这道闸不该
+  放行的情形。
+- **Rule 5 扫描**：同型 caller 还有 `candidate_aggregation._skip_tainted_
+  external_evidence`，位于 `_cluster_and_promote` 的**三个**按候选循环里
+  （evidence tick 每小时付一次同样的 O(N×M)），一并接上同一缓存。
+  而 `crystallized.write_approved_record` / `_ensure_crystallized_approval`
+  的读**有意不缓存并加测试钉住**：结晶过程会追加事件，拿循环前的缓存回答
+  **写边界**问题就是拿陈旧语料放行——便宜不值得换错。
+- **反事实（copy 备份 revert，非 `git checkout --`）**：provenance 批
+  revert → 9 个新测试 **8 FAIL**（review build 读 6 次而非 1 次、lane 守卫读
+  8 次而非 1 次，另 6 个 ImportError），restore → PASS；monitor 批 revert →
+  4 FAIL（关键断言现形为 `'doctor_probe_timeout' in ['doctor_not_ok']`），
+  restore → PASS。**计数而非计时**：耗时断言天生 flaky，而本缺陷问的本就是
+  "语料被读了几次"。
+- 预期生产观测（**须待合入并部署后复核，本节不予认领**）：doctor 落到
+  20s 上限以内后 `doctor_not_ok` / `shell_alias_no_env_failed` 应一并消失；
+  若 doctor 仍超时，则应看到的是 `doctor_probe_timeout` 而不再是诬告。
+- **测试**：+17（provenance 事件缓存 11、monitor 归因 6）。全量
+  **3622 passed / 1 failed / 13 skipped**——唯一 FAIL 是已知 flaky 的
+  `test_execution_gate_runner_serializes_parallel_sidecar_updates`（并发
+  sidecar 用例，单独复跑 PASS，与本批无关，见 memory
+  `ci-flaky-sidecar-concurrency-test`）。四静态门（import cycle / write
+  surface / static hygiene / public checkout probe）+ `git diff --check` 全绿。
+- **Rule 5（归因族）扫描记账**：monitor 里"探针没跑成"与"跑完了有问题"
+  的混淆不止 doctor 一处，但形态**不同**，据实分开记：`shell_alias_no_env`
+  并列跑 ~22 条命令，**确实**把每条的 `_error` 透出（`doctor_error` /
+  `review_aging_error` 的 `command_timeout_seconds=20` 正是本次定位的证据来源），
+  它的弱点是**分类粒度**——超时与真失败共用一个 `shell_alias_no_env_failed`
+  FAIL 码。按"大文件最小改动"原则本批只动 doctor 段（它是**丢证据**那一类，
+  更严重），`shell_alias_no_env` 记录不改；且真因（①）修好后，这两个生产实例
+  预计一并消失，粒度问题届时不再有活样本，留待有真实样本时再动。
+- **本批自身踩坑并记账**：缓存第一版**提到循环外**，`build_status_report`
+  的 O(1) 路径（无候选 profile 不得碰事件语料）随即回归——
+  `test_build_status_report_uses_O1_index_health` 抓到。**只跑改动相关测试
+  不会发现**，是全量套件抓的；已改为惰性构建并补两个"无候选=0 次读取"
+  回归钉。这正是 Section W 第 1 条与"测试只证明做了的是对的"的又一次实证。
 
 - `26f4a80..d4bc158（CV，本节）`：PR #57 评审 14 项发现收口——dashboard
   `--profile main` 默认值 crash-loop（主场景级）、孤儿 day-count 键接上

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -7188,3 +7188,19 @@ caller 在循环外建一次缓存。
   `continuity_constants.py`，`cycle_count` 1→0）。7 项反事实实测 revert→FAIL→restore→PASS。
   **仅仓库验证**：prefetch/temporal/state_overlay 属 provider 侧，生效需重启 gateway（owner 步骤）。
   全量 3583→3607 passed（+24）/13 skipped，四门全绿。
+
+- `9824db2 部署 + 790bd76`：DB 部署与生产验证 + DC — PR #70 的 provider 侧修复
+  经 gateway 重启在 3.200 双 profile 落地并实证（四份 provider + 两份 modules +
+  scripts 逐文件 hash 全一致；`recent_events` 1→6、注入 5 条真实 conversation_turn、
+  main 排除 261 条记账行；两 profile 无新增 FAIL/WARN，sannai PASS 90 为历史最高）。
+  部署中暴露的 `doctor_not_ok` 经考古证实连续 ≥4 夜先存，剖析出真因是
+  `provenance` 的 taint 谓词**按候选**重读全量事件语料（doctor 66.5s 中 59.3s、
+  242 次 read_events、187 万次 json.loads）——改为 caller 持有的批级
+  `load_event_cache()` + `EventLookup` id 索引，`is_tainted` 私有
+  `_events_cache` 提为公开、`candidate_external_ref` 补同参（两个都补），
+  Rule-5 同步接上 `candidate_aggregation` 三个循环，结晶写路径**有意不缓存**
+  并加测试钉住；顺带把 monitor "探针超时"与"doctor 不健康"分成两个 code
+  （新增 `doctor_probe_timeout`，20s 默认**不抬**）。缓存第一版提到循环外
+  破坏了 `build_status_report` 的 O(1) 路径，由全量套件抓出并改为惰性构建。
+  +17 测试，全量 3622 passed/13 skipped（唯一 FAIL 为已知 flaky 并发用例，
+  单跑 PASS），四门全绿。

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -4869,12 +4869,32 @@ def _candidate_cluster_review_items(store: MemoryOSStore, closed: set[str]) -> l
 
 
 def _candidate_review_items(store: MemoryOSStore, closed: set[str]) -> list[dict[str, Any]]:
-    from .provenance import candidate_external_ref, is_tainted
+    from .provenance import candidate_external_ref, is_tainted, load_event_cache
 
     items: list[dict[str, Any]] = []
+    # Both predicates below resolve source_event_ids against the full event
+    # corpus, and store.read_events() re-reads and re-parses every event file on
+    # each call. Built per candidate that is O(candidates x events): measured on
+    # the production main profile at 240 corpus reads / 1.87M json.loads / 58s
+    # of doctor's 66s. The cache is per report build, never module-level — this
+    # feeds a write-boundary predicate (see EventLookup).
+    #
+    # Built lazily, and that is load-bearing rather than tidy: build_status_report
+    # reaches here on its O(1) path, where a profile with no pending candidates
+    # must not touch the event corpus at all
+    # (test_build_status_report_uses_O1_index_health pins zero reads). Hoisting
+    # this above the loop costs one full corpus read on exactly the path that
+    # exists to avoid one.
+    events_cache = None
     for effective in read_effective_candidates(store):
+        if events_cache is None:
+            events_cache = load_event_cache(store)
         candidate = effective.candidate
-        external_ref = candidate_external_ref(candidate, store=store) if is_tainted(candidate, store=store) else None
+        external_ref = (
+            candidate_external_ref(candidate, store=store, events_cache=events_cache)
+            if is_tainted(candidate, store=store, events_cache=events_cache)
+            else None
+        )
         external_review_eligible = bool(external_ref)
         if not effective.owner_review_eligible and not external_review_eligible:
             continue

--- a/plugins/memory/memory_os/provenance.py
+++ b/plugins/memory/memory_os/provenance.py
@@ -67,15 +67,65 @@ def _source_event_ids_of(obj: Any) -> list[str]:
 _UNKNOWN_EVENT = object()
 
 
-def _load_events(store: Any, *, error_records: list | None = None) -> list | object:
-    """Read events from store once, returning a list or _UNKNOWN_EVENT on failure.
+class EventLookup:
+    """Immutable ``event_id`` -> event index for a batch of provenance checks.
+
+    ``store.read_events()`` re-reads and re-parses the *whole* event corpus on
+    every call, and the resolver it feeds used to scan that list linearly. Both
+    costs are per-call, so checking a batch of candidates one at a time is
+    O(candidates x events) in file IO, JSON parsing and comparisons alike.
+
+    The first occurrence of an id wins, which is exactly what the linear scan
+    this replaces returned; the index is a cheaper spelling of the same answer,
+    never a different one.
+
+    Lifetime is deliberately one batch, owned by the caller that builds it: this
+    feeds a write-boundary predicate, so a cache that outlived the report build
+    could answer from events that no longer reflect the store.
+    """
+
+    __slots__ = ("_by_id",)
+
+    def __init__(self, events: Any) -> None:
+        by_id: dict[str, Any] = {}
+        for event in events:
+            event_id = str(getattr(event, "id", "") or "")
+            if event_id and event_id not in by_id:
+                by_id[event_id] = event
+        self._by_id = by_id
+
+    def get(self, event_id: str) -> Any | None:
+        return self._by_id.get(event_id)
+
+
+def _as_event_cache(events: Any) -> Any:
+    """Normalize a caller-supplied cache to an EventLookup (or a sentinel)."""
+    if events is None or events is _UNKNOWN_EVENT or isinstance(events, EventLookup):
+        return events
+    return EventLookup(events)
+
+
+def load_event_cache(store: Any, *, error_records: list | None = None) -> Any:
+    """Build the shared event cache for a batch of provenance checks.
+
+    Callers that check more than one object (owner review report builds, the
+    candidate aggregation lane) must build this once and pass it to every
+    ``is_tainted`` / ``candidate_external_ref`` call in the batch. Returns
+    ``_UNKNOWN_EVENT`` on read failure, which keeps those calls fail-closed.
+    """
+    return _load_events(store, error_records=error_records)
+
+
+def _load_events(store: Any, *, error_records: list | None = None) -> Any:
+    """Read events from store once, returning an EventLookup or _UNKNOWN_EVENT.
 
     The result is passed through the is_tainted() call tree so that
     store.read_events() is called exactly once per top-level is_tainted()
-    invocation, regardless of recursion depth.
+    invocation, regardless of recursion depth -- and, when the caller supplies
+    it via ``events_cache``, exactly once per batch rather than once per item.
     """
     try:
-        return list(store.read_events())
+        return EventLookup(store.read_events())
     except Exception:
         if error_records is not None:
             error_records.append(
@@ -94,16 +144,13 @@ def _resolve_event_from_store(
     store: Any,
     event_id: str,
     *,
-    events_cache: list | object | None = None,
+    events_cache: Any = None,
     error_records: list | None = None,
 ) -> Any | None:
     if not event_id:
         return None
     if events_cache is not None and events_cache is not _UNKNOWN_EVENT:
-        for event in events_cache:
-            if str(getattr(event, "id", "") or "") == event_id:
-                return event
-        return None
+        return _as_event_cache(events_cache).get(event_id)
     if events_cache is _UNKNOWN_EVENT:
         return _UNKNOWN_EVENT
     try:
@@ -131,7 +178,7 @@ def is_tainted(
     *,
     store: Any,
     error_records: list | None = None,
-    _events_cache: list | object | None = None,
+    events_cache: Any = None,
 ) -> bool:
     """Return True when obj carries or derives from tainted external evidence.
 
@@ -142,6 +189,13 @@ def is_tainted(
     On lookup failure the gate fails closed (tainted=True, spec §2.2).
     When *error_records* is provided, store read failures are recorded as
     bounded error records instead of being silently swallowed.
+
+    *events_cache* is the batch-shared lookup from ``load_event_cache``. Passing
+    it collapses one full corpus read per call into one per batch; omitting it
+    keeps the previous per-call behaviour. Note the deliberate consequence of
+    sharing: a failed load taints every item in the batch rather than being
+    retried per item. That is the fail-closed direction, and a batch whose
+    events cannot be read is exactly the case this gate must not wave through.
     """
     source_class = _source_class_of(obj)
     if source_class in TAINTED_SOURCE_CLASSES:
@@ -149,10 +203,11 @@ def is_tainted(
     provenance = _provenance_of(obj)
     if provenance.get("crystallization_allowed") is False:
         return True
-    # Load events once per call-tree — pass cached list through recursion
-    events_cache = _events_cache
+    # Load events once per call-tree — pass the cached lookup through recursion
     if events_cache is None:
         events_cache = _load_events(store, error_records=error_records)
+    else:
+        events_cache = _as_event_cache(events_cache)
     if events_cache is _UNKNOWN_EVENT:
         return True
     for event_id in _source_event_ids_of(obj):
@@ -162,19 +217,24 @@ def is_tainted(
         if event is _UNKNOWN_EVENT:
             return True
         if event is not None and is_tainted(
-            event, store=store, error_records=error_records, _events_cache=events_cache
+            event, store=store, error_records=error_records, events_cache=events_cache
         ):
             return True
     return False
 
 
-def candidate_external_ref(candidate: Any, *, store: Any) -> str | None:
-    """Return the first external_ref on a candidate or its tainted source chain."""
+def candidate_external_ref(candidate: Any, *, store: Any, events_cache: Any = None) -> str | None:
+    """Return the first external_ref on a candidate or its tainted source chain.
+
+    *events_cache* has the same batch-sharing contract as ``is_tainted``. The
+    hot caller checks both predicates per candidate, so passing the cache to
+    only one of them would leave the corpus being re-read anyway.
+    """
     provenance = _provenance_of(candidate)
     direct = str(provenance.get("external_ref") or "").strip()
     if direct:
         return direct
-    events_cache = _load_events(store)
+    events_cache = _load_events(store) if events_cache is None else _as_event_cache(events_cache)
     if events_cache is _UNKNOWN_EVENT:
         return None
     for event_id in _source_event_ids_of(candidate):

--- a/plugins/modules/governance/candidate_aggregation.py
+++ b/plugins/modules/governance/candidate_aggregation.py
@@ -711,11 +711,17 @@ def _skip_tainted_external_evidence(
     cluster_size: int = 0,
     envelope_id: str = "",
     now: datetime | None = None,
+    events_cache: Any = None,
 ) -> bool:
-    """Fail-closed auto path guard: tainted candidates need explicit owner ack."""
+    """Fail-closed auto path guard: tainted candidates need explicit owner ack.
+
+    *events_cache* is the per-run lookup built by the caller. This guard runs in
+    three per-candidate loops of one lane run, and without a shared cache each
+    call re-reads and re-parses the whole event corpus.
+    """
     from plugins.memory.memory_os.provenance import candidate_external_ref, is_tainted
 
-    if not is_tainted(candidate, store=store):
+    if not is_tainted(candidate, store=store, events_cache=events_cache):
         return False
     append_candidate_triage(
         store,
@@ -735,7 +741,7 @@ def _skip_tainted_external_evidence(
         target=candidate.candidate_id,
         details={
             "reason": "external_evidence_tainted_blocked",
-            "external_ref": candidate_external_ref(candidate, store=store) or "",
+            "external_ref": candidate_external_ref(candidate, store=store, events_cache=events_cache) or "",
             "cluster_key": cluster_key,
             "cluster_size": cluster_size,
         },
@@ -786,6 +792,16 @@ def _cluster_and_promote(
         if c.candidate_id not in processed_ids
         and c.bridge_state in ("", "inner_drive_candidate")
     ]
+    # One corpus read for the whole run: _skip_tainted_external_evidence runs in
+    # three per-candidate loops below, and store.read_events() re-reads and
+    # re-parses every event file on each call (same defect family as the owner
+    # review report build). Built here, the cache lives exactly one lane run.
+    #
+    # Guarded on there being work: all three loops derive from
+    # candidates_for_promote, so an idle tick must not pay a full corpus read
+    # just to build a cache nothing will consult.
+    from plugins.memory.memory_os.provenance import load_event_cache
+    events_cache = load_event_cache(store) if candidates_for_promote else None
 
     # Build cluster map: cluster_key -> list of candidates
     clusters: dict[str, list[CrystallizedCandidate]] = {}
@@ -841,6 +857,7 @@ def _cluster_and_promote(
                 cluster_size=len(members),
                 envelope_id=envelope_id,
                 now=_now,
+                events_cache=events_cache,
             ):
                 continue
             # P2: Index-based near-duplicate dedup — bump+renew existing provisional
@@ -1019,6 +1036,7 @@ def _cluster_and_promote(
                 cluster_size=1,
                 envelope_id=envelope_id,
                 now=_now,
+                events_cache=events_cache,
             ):
                 continue
 
@@ -1163,6 +1181,7 @@ def _cluster_and_promote(
             c, store, processed_ids,
             cluster_key="", cluster_size=1,
             envelope_id=envelope_id, now=_now,
+            events_cache=events_cache,
         ):
             continue
 

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -97,6 +97,27 @@ FULL_MONITOR_MIN_CALLER_TIMEOUT_SECONDS = 300
 # budget from a caller-declared timeout (see collect_snapshot).
 FULL_MONITOR_PROBE_TIMEOUT_MARGIN_SECONDS = 30
 FAST_PROBE_RECOMMENDED_TIMEOUT_SECONDS = 120
+# Exit code the remote probe's run() returns when a single command exceeded its
+# per-command budget, and the marker it appends to that command's output.
+PROBE_COMMAND_TIMEOUT_EXIT_CODE = 124
+PROBE_COMMAND_TIMEOUT_MARKER = "command_timeout_seconds="
+
+
+def _probe_command_timed_out(section: Any) -> bool:
+    """True when a probe section is empty because its command ran out of budget.
+
+    A section that could not be collected and a section reporting a real problem
+    must not share an outcome -- that conflation is what let a 45s doctor read as
+    an unhealthy doctor. Both signals are checked because ``_code`` is the
+    authoritative one while the marker survives in text-shaped payloads.
+    """
+    if not isinstance(section, dict):
+        return False
+    if section.get("probe_exit_code") == PROBE_COMMAND_TIMEOUT_EXIT_CODE:
+        return True
+    return PROBE_COMMAND_TIMEOUT_MARKER in str(section.get("probe_error") or "")
+
+
 MEMORY_PROJECTION_55C_REQUIRED_PAYLOAD_FIELDS: dict[str, set[str]] = {
     "hindsight_provider_stats": {
         "operation_count",
@@ -1898,6 +1919,14 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
     doctor = doctor_raw if isinstance(doctor_raw, dict) else {}
     if doctor.get("status") == "ok":
         passed.append({"code": "doctor_ok"})
+    elif _probe_command_timed_out(doctor):
+        # "the probe ran out of budget" is not "doctor reported problems".
+        # Both used to land on doctor_not_ok with status=None/exit_code=None,
+        # so a merely slow doctor read as an unhealthy one -- production FAILed
+        # nightly on this while `hermes memory-os-agent-os doctor` returned
+        # exit_code 0 with zero findings. Still FAIL-class: losing the check is
+        # a real loss of visibility. It just has to say what actually happened.
+        fail.append({"code": "doctor_probe_timeout", "value": doctor})
     else:
         fail.append({"code": "doctor_not_ok", "value": doctor})
     for code, severity in doctor.get("findings", []) or []:
@@ -9299,6 +9328,13 @@ print(json.dumps({
     "status": doctor.get("status") if isinstance(doctor, dict) else None,
     "exit_code": doctor.get("exit_code") if isinstance(doctor, dict) else None,
     "findings": [(x.get("code"), x.get("severity")) for x in doctor.get("findings", [])] if isinstance(doctor, dict) else None,
+    # Carry *why* the section is empty. load_json_cmd() returns _error/_code
+    # when the command could not be run to completion, and dropping them here
+    # left a timed-out probe indistinguishable from a doctor that ran and
+    # reported problems -- both arrived as status=None. See the classifier's
+    # doctor_probe_timeout branch.
+    "probe_error": doctor.get("_error") if isinstance(doctor, dict) else None,
+    "probe_exit_code": doctor.get("_code") if isinstance(doctor, dict) else None,
   },
   "status_tool_contract": contract.get("validation") if isinstance(contract, dict) else contract,
   "shell_alias_no_env": shell_alias_no_env(),

--- a/tests/plugins/memory/test_memory_os_provenance_event_cache.py
+++ b/tests/plugins/memory/test_memory_os_provenance_event_cache.py
@@ -1,0 +1,399 @@
+"""DC — provenance event-cache sharing (owner review build + aggregation lane).
+
+``store.read_events()`` re-reads and re-parses the entire event corpus on every
+call, and ``provenance`` resolves ``source_event_ids`` against it. Both taint
+predicates used to load that corpus per *item*, so a batch cost
+O(items x events) in file IO, JSON parsing and comparisons.
+
+Measured on the production main profile before the fix: ``doctor`` took 45-72s,
+of which ``_candidate_review_items`` was ~59s across 240 corpus reads and
+1.87M ``json.loads`` calls. The monitor caps each probe command at 20s, so the
+production host reported ``doctor_not_ok`` every night for a lane that was
+merely slow, not unhealthy.
+
+The counterfactual here is a **call count**, never wall clock: timing
+assertions are flaky, and the defect is "how many times was the corpus read",
+which is exactly what a spy can state.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from plugins.memory.memory_os.crystallized import (
+    CrystallizedCandidate,
+    append_candidate_queue,
+)
+from plugins.memory.memory_os.roots import MemoryOSRoots
+from plugins.memory.memory_os.schema import EVENT_SCHEMA_VERSION, EventEnvelope
+from plugins.memory.memory_os.store import MemoryOSStore
+
+pytestmark = pytest.mark.usefixtures("crystallized_test_write_authority")
+
+
+_VALID_ENVELOPE_ID = "xgate_test_provenance_event_cache"
+
+
+def _store(tmp_path) -> MemoryOSStore:
+    roots = MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test")
+    store = MemoryOSStore(roots)
+    store.initialize()
+    return store
+
+
+def _grant_aggregation_envelope(store: MemoryOSStore) -> str:
+    """Write the ExecutionGate permit the aggregation lane's triage writes need."""
+    now = datetime.now(timezone.utc)
+    envelope = {
+        "schema_version": "memory-os.execution_gate_envelope.v0",
+        "stage": "permit",
+        "execution_gate_envelope_id": _VALID_ENVELOPE_ID,
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "expires_at": now.replace(year=now.year + 1).isoformat().replace("+00:00", "Z"),
+        "profile": "memoryos-test",
+        "lane_id": "candidate_aggregation",
+        "trigger_surface": "hermes_cron",
+        "risk_class": "bounded_reversible_queue",
+        "human_approval_required": False,
+        "why_no_human_approval": "test",
+        "scope": {"registry_key": "candidate_aggregation", "raw_script": "test"},
+        "boundary": {
+            "actual_send": False,
+            "actual_execute": False,
+            "actual_identity_write": False,
+            "actual_unapproved_crystallized_approval": False,
+        },
+        "boundary_true": False,
+        "precheck": {"helper_present": True},
+        "permit_decision": "allowed",
+        "permit_reason": "boundary_false",
+    }
+    gate_path = store.roots.hermes_home / "memory-os" / "system" / "execution_gate_envelopes.jsonl"
+    gate_path.parent.mkdir(parents=True, exist_ok=True)
+    with gate_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(envelope, sort_keys=True) + "\n")
+    return _VALID_ENVELOPE_ID
+
+
+def _append_event(store: MemoryOSStore, event_id: str, *, source_class: str = "", external_ref: str = "") -> EventEnvelope:
+    safe_ref: dict[str, str] = {}
+    if source_class:
+        safe_ref["source_class"] = source_class
+    if external_ref:
+        safe_ref["external_ref"] = external_ref
+    event = EventEnvelope(
+        schema_version=EVENT_SCHEMA_VERSION,
+        id=event_id,
+        ts="2026-06-18T00:00:00+00:00",
+        profile="memoryos-test",
+        source="test",
+        kind="conversation_turn",
+        summary="synthetic event",
+        safe_ref=safe_ref,
+        tags=[],
+        sensitivity="private",
+        body_policy="summary_only",
+        hashes={},
+        promotion_state="raw",
+    )
+    store.append_event(event)
+    return event
+
+
+def _candidate(candidate_id: str, *, source_event_ids=None, provenance=None) -> CrystallizedCandidate:
+    return CrystallizedCandidate(
+        candidate_id=candidate_id,
+        kind="moment",
+        body=f"记住：这是候选 {candidate_id} 的正文，用于验证事件缓存不改变判定结果",
+        source_event_ids=list(source_event_ids or []),
+        sensitivity="private",
+        tags=["test"],
+        bridge_state="inner_drive_candidate",
+        created_at="2026-06-18T00:00:01+00:00",
+        provenance=provenance or {},
+    )
+
+
+class _CountingStore:
+    """Wrap a real store, counting read_events() calls.
+
+    Delegates everything else so the code under test operates on genuine
+    canonical files written by the real producers.
+    """
+
+    def __init__(self, inner: MemoryOSStore) -> None:
+        self._inner = inner
+        self.read_events_calls = 0
+
+    def read_events(self):
+        self.read_events_calls += 1
+        return self._inner.read_events()
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def _seed_batch(store: MemoryOSStore, *, count: int = 4) -> None:
+    """Seed events + candidates through the real producers.
+
+    Hand-written fixtures are what let the event_stats path drift agree with
+    its own bug for a whole deployment; every row here goes through
+    ``store.append_event`` / ``append_candidate_queue``.
+    """
+    _append_event(store, "evt-clean-shared")
+    _append_event(
+        store,
+        "evt-tainted-shared",
+        source_class="external_evidence",
+        external_ref="external:dataset:doc:chunk",
+    )
+    for i in range(count):
+        # Alternate tainted/clean so the batch exercises both verdicts.
+        source_ids = ["evt-tainted-shared"] if i % 2 else ["evt-clean-shared"]
+        append_candidate_queue(store, _candidate(f"cand-batch-{i:03d}", source_event_ids=source_ids))
+
+
+# ── The counterfactual: one corpus read per batch, not per item ──────────────
+
+
+def test_candidate_review_items_reads_event_corpus_once_per_build(tmp_path):
+    """Without the shared cache this is >= 2 * N reads (is_tainted + external_ref)."""
+    from plugins.memory.memory_os.owner_actions import _candidate_review_items
+
+    real = _store(tmp_path)
+    _seed_batch(real, count=4)
+    spy = _CountingStore(real)
+
+    items = _candidate_review_items(spy, set())
+
+    assert spy.read_events_calls == 1, (
+        f"expected exactly one corpus read per report build, got {spy.read_events_calls}"
+    )
+    # Non-vacuous: the batch actually produced review items to check.
+    assert items, "fixture produced no review items — the counterfactual would be vacuous"
+
+
+def test_cluster_and_promote_taint_guard_reads_event_corpus_once_per_run(tmp_path):
+    """The aggregation lane screens every candidate through the taint guard.
+
+    Scoped deliberately to an all-tainted batch: those candidates are skipped
+    before any promotion, so the only corpus reads are the guard's. That
+    isolates what this fix owns. The crystallized *write* path
+    (``write_approved_record`` / ``_ensure_crystallized_approval``) reads again
+    per written record and is intentionally left uncached — see
+    ``test_crystallized_write_path_is_deliberately_not_batch_cached``.
+
+    Without the shared cache this is 2 * N reads (is_tainted + external_ref per
+    candidate); with it, one.
+    """
+    from plugins.modules.governance.candidate_aggregation import _cluster_and_promote
+    from plugins.memory.memory_os.crystallized import read_effective_candidates
+
+    real = _store(tmp_path)
+    _append_event(
+        real,
+        "evt-tainted-shared",
+        source_class="external_evidence",
+        external_ref="external:dataset:doc:chunk",
+    )
+    for i in range(4):
+        append_candidate_queue(
+            real,
+            _candidate(f"cand-tainted-{i:03d}", source_event_ids=["evt-tainted-shared"]),
+        )
+    envelope_id = _grant_aggregation_envelope(real)
+    candidates = [effective.candidate for effective in read_effective_candidates(real)]
+    assert len(candidates) >= 3, "counterfactual needs several candidates to be non-vacuous"
+    spy = _CountingStore(real)
+
+    _cluster_and_promote(candidates, spy, set(), envelope_id=envelope_id, min_cluster_size=1)
+
+    assert spy.read_events_calls == 1, (
+        f"expected exactly one corpus read per lane run, got {spy.read_events_calls}"
+    )
+
+
+def test_crystallized_write_path_is_deliberately_not_batch_cached(tmp_path):
+    """Pin the Rule-5 decision: the write boundary keeps reading fresh.
+
+    ``crystallized.write_approved_record`` / ``_ensure_crystallized_approval``
+    also call the taint predicates, and they were left uncached on purpose:
+    crystallization appends events, so a cache built before a promotion loop
+    could answer a *write-boundary* question from a stale corpus. Cheaper is
+    not worth wrong at that boundary. This test fails if someone threads a
+    batch cache through the signature without revisiting that reasoning.
+    """
+    import inspect
+
+    from plugins.memory.memory_os import crystallized
+
+    for name in ("write_approved_record", "_ensure_crystallized_approval"):
+        source = inspect.getsource(getattr(crystallized.CrystallizedMemoryService, name))
+        assert "events_cache" not in source, (
+            f"{name} now passes a batch event cache into the taint gate; "
+            "that is a write boundary — confirm freshness before allowing it"
+        )
+
+
+# ── Behaviour preservation: the cache is a cheaper spelling, not a new answer ─
+
+
+def test_shared_cache_verdicts_match_per_call_verdicts(tmp_path):
+    """Every taint verdict and external_ref is identical with and without cache."""
+    from plugins.memory.memory_os.crystallized import read_effective_candidates
+    from plugins.memory.memory_os.provenance import (
+        candidate_external_ref,
+        is_tainted,
+        load_event_cache,
+    )
+
+    store = _store(tmp_path)
+    _seed_batch(store, count=6)
+    candidates = [effective.candidate for effective in read_effective_candidates(store)]
+    assert candidates
+
+    cache = load_event_cache(store)
+    uncached = [(is_tainted(c, store=store), candidate_external_ref(c, store=store)) for c in candidates]
+    cached = [
+        (
+            is_tainted(c, store=store, events_cache=cache),
+            candidate_external_ref(c, store=store, events_cache=cache),
+        )
+        for c in candidates
+    ]
+
+    assert cached == uncached
+    # Non-vacuous in both directions: the batch contains tainted and clean rows.
+    assert any(verdict for verdict, _ in uncached), "no tainted candidate in fixture"
+    assert any(not verdict for verdict, _ in uncached), "no clean candidate in fixture"
+
+
+def test_event_lookup_first_occurrence_wins_like_the_linear_scan(tmp_path):
+    """The index must resolve duplicate ids the way the replaced scan did."""
+    from plugins.memory.memory_os.provenance import EventLookup
+
+    class _E:
+        def __init__(self, id_, tag):
+            self.id = id_
+            self.tag = tag
+
+    events = [_E("dup", "first"), _E("dup", "second"), _E("other", "x")]
+    lookup = EventLookup(events)
+
+    assert lookup.get("dup").tag == "first"
+    assert lookup.get("other").tag == "x"
+    assert lookup.get("absent") is None
+
+
+def test_events_without_ids_do_not_enter_the_index(tmp_path):
+    from plugins.memory.memory_os.provenance import EventLookup
+
+    class _E:
+        def __init__(self, id_):
+            self.id = id_
+
+    lookup = EventLookup([_E(""), _E(None), _E("real")])
+    assert lookup.get("") is None
+    assert lookup.get("real") is not None
+
+
+# ── Fail-closed semantics survive the cache ─────────────────────────────────
+
+
+def test_unreadable_store_still_fails_closed_through_shared_cache(tmp_path):
+    """A batch whose corpus cannot be read taints every item, never waves through."""
+    from plugins.memory.memory_os.provenance import is_tainted, load_event_cache
+
+    class _BrokenStore:
+        def read_events(self):
+            raise OSError("event corpus unreadable")
+
+    broken = _BrokenStore()
+    cache = load_event_cache(broken)
+    candidate = _candidate("cand-broken", source_event_ids=["evt-anything"])
+
+    # Both the uncached and the shared-cache path fail closed.
+    assert is_tainted(candidate, store=broken) is True
+    assert is_tainted(candidate, store=broken, events_cache=cache) is True
+
+
+def test_load_event_cache_records_bounded_error_record_on_failure(tmp_path):
+    from plugins.memory.memory_os.provenance import load_event_cache
+
+    class _BrokenStore:
+        def read_events(self):
+            raise OSError("event corpus unreadable")
+
+    error_records: list = []
+    load_event_cache(_BrokenStore(), error_records=error_records)
+
+    assert len(error_records) == 1
+    record = error_records[0]
+    assert record["component"] == "provenance"
+    assert record["error_code"] == "store_read_events_failed"
+
+
+def test_transitive_taint_still_resolves_through_shared_cache(tmp_path):
+    """The recursion must keep threading the same cache, not reload per hop."""
+    from plugins.memory.memory_os.provenance import is_tainted, load_event_cache
+
+    real = _store(tmp_path)
+    _append_event(
+        real,
+        "evt-tainted-root",
+        source_class="external_evidence",
+        external_ref="external:dataset:doc:chunk",
+    )
+    candidate = _candidate("cand-transitive", source_event_ids=["evt-tainted-root"])
+    spy = _CountingStore(real)
+    cache = load_event_cache(spy)
+    calls_after_build = spy.read_events_calls
+
+    assert is_tainted(candidate, store=spy, events_cache=cache) is True
+    assert spy.read_events_calls == calls_after_build, "recursion re-read the corpus"
+
+
+# -- The cache must stay lazy: no candidates => no corpus read ---------------
+
+
+def test_candidate_review_items_reads_nothing_when_there_are_no_candidates(tmp_path):
+    """Regression pin for a trap this fix walked into once.
+
+    ``build_status_report`` reaches ``_candidate_review_items`` on its O(1)
+    path, where a profile with no pending candidates must not touch the event
+    corpus at all (test_build_status_report_uses_O1_index_health asserts zero
+    reads). Hoisting the shared cache above the loop was correct for batches
+    and wrong here: it spent one full corpus read on exactly the path that
+    exists to avoid one. The full suite caught it; targeted runs did not.
+    """
+    from plugins.memory.memory_os.owner_actions import _candidate_review_items
+
+    real = _store(tmp_path)
+    _append_event(real, "evt-only-an-event")
+    spy = _CountingStore(real)
+
+    items = _candidate_review_items(spy, set())
+
+    assert items == []
+    assert spy.read_events_calls == 0, (
+        f"empty candidate set must not read the event corpus, "
+        f"got {spy.read_events_calls} read(s)"
+    )
+
+
+def test_cluster_and_promote_reads_nothing_when_there_is_no_work(tmp_path):
+    """Same guard for the lane: an idle evidence tick pays no corpus read."""
+    from plugins.modules.governance.candidate_aggregation import _cluster_and_promote
+
+    real = _store(tmp_path)
+    _append_event(real, "evt-only-an-event")
+    spy = _CountingStore(real)
+
+    _cluster_and_promote([], spy, set(), envelope_id="", min_cluster_size=1)
+
+    assert spy.read_events_calls == 0, (
+        f"idle lane run must not read the event corpus, got {spy.read_events_calls} read(s)"
+    )

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -9012,3 +9012,88 @@ def test_recall_shadow_empty_window_still_reports_no_sample():
         if item["code"] == "recall_arbitration_shadow_window"
     ]
     assert entries and entries[0]["value"]["sample_state"] == "healthy_no_sample"
+
+
+# -- DC: probe budget exhausted is not "doctor reported problems" ------------
+
+
+def test_doctor_probe_timeout_is_classified_apart_from_doctor_not_ok():
+    """Counterfactual for the misattribution fix.
+
+    A doctor command killed at the probe's per-command budget arrives with
+    status=None/exit_code=None -- byte-identical to a doctor that ran and
+    reported nothing. Before the fix both produced ``doctor_not_ok``, so the
+    production host FAILed nightly while `hermes memory-os-agent-os doctor`
+    itself returned exit_code 0 with zero findings (measured: 45s against a 20s
+    cap). The outcome must name what actually happened.
+    """
+    snapshot = _healthy_snapshot()
+    snapshot["doctor"] = {
+        "status": None,
+        "exit_code": None,
+        "findings": [],
+        "probe_error": "command_timeout_seconds=20",
+        "probe_exit_code": 124,
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    fail_codes = [item["code"] for item in classification["fail"]]
+    assert "doctor_probe_timeout" in fail_codes
+    assert "doctor_not_ok" not in fail_codes
+    assert "doctor_ok" not in [item["code"] for item in classification["pass"]]
+
+
+def test_doctor_probe_timeout_detected_from_marker_without_exit_code():
+    """The text marker alone is enough; _code is not always carried."""
+    snapshot = _healthy_snapshot()
+    snapshot["doctor"] = {
+        "status": None,
+        "exit_code": None,
+        "findings": [],
+        "probe_error": "some output\ncommand_timeout_seconds=20",
+        "probe_exit_code": None,
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    assert "doctor_probe_timeout" in [item["code"] for item in classification["fail"]]
+
+
+def test_genuinely_unhealthy_doctor_still_reports_doctor_not_ok():
+    """The new branch must not swallow real doctor failures."""
+    snapshot = _healthy_snapshot()
+    snapshot["doctor"] = {
+        "status": "error",
+        "exit_code": 1,
+        "findings": [],
+        "probe_error": None,
+        "probe_exit_code": None,
+    }
+
+    classification = classify_snapshot(snapshot)
+
+    fail_codes = [item["code"] for item in classification["fail"]]
+    assert "doctor_not_ok" in fail_codes
+    assert "doctor_probe_timeout" not in fail_codes
+
+
+def test_probe_command_timed_out_predicate_is_conservative():
+    """Only a real timeout signal counts; absence must never imply timeout."""
+    assert monitor._probe_command_timed_out({"probe_exit_code": 124}) is True
+    assert monitor._probe_command_timed_out({"probe_error": "command_timeout_seconds=20"}) is True
+    assert monitor._probe_command_timed_out({"probe_exit_code": 1}) is False
+    assert monitor._probe_command_timed_out({"probe_error": "boom"}) is False
+    assert monitor._probe_command_timed_out({}) is False
+    assert monitor._probe_command_timed_out(None) is False
+
+
+def test_remote_probe_doctor_section_carries_probe_failure_fields():
+    """The probe must emit the fields the classifier reads.
+
+    Guards the producer/consumer pair: the classifier branch is unreachable if
+    the remote probe stops carrying _error/_code into the doctor section.
+    """
+    script = monitor._remote_probe_script("/root/.hermes")
+    assert '"probe_error": doctor.get("_error")' in script
+    assert '"probe_exit_code": doctor.get("_code")' in script


### PR DESCRIPTION
Found while deploying PR #70 to 3.200. Both profiles kept FAILing the live monitor on `doctor_not_ok` + `shell_alias_no_env_failed`, and the symptom turned out to sit two layers above the cause. **Neither defect is a regression from #70** — the stored monitor artifacts show the same pair for at least four consecutive nights (08-15 → 08-18).

## 1. Real cause: the taint predicates re-read the whole event corpus per item

`provenance.is_tainted` / `candidate_external_ref` resolve `source_event_ids` against `store.read_events()`, which re-reads and re-parses **every event file on each call**. `_load_events` already cached that — but only "once per top-level `is_tainted` invocation", and the hot caller runs once per candidate:

```python
external_ref = candidate_external_ref(c, store=store) if is_tainted(c, store=store) else None
```

So each candidate paid **two** full corpus reads, and `_resolve_event_from_store` then scanned the result linearly.

cProfile, production main profile:

| metric | value |
|---|---|
| `build_doctor_result` | 66.5 s |
| └ `_candidate_review_items` | 59.3 s |
| `store.read_events()` calls | 242 |
| `schema.from_dict` calls | 1,540,572 |
| `json.loads` calls | 1,871,336 |

**Fix:** `provenance` exposes `load_event_cache()` returning an `EventLookup` (id→event index; **first occurrence wins**, exactly what the linear scan returned). `is_tainted`'s private `_events_cache` is promoted to a public `events_cache`, and `candidate_external_ref` gains the same parameter — **both**, because the caller checks both and patching one leaves the corpus being re-read anyway.

Deliberate behavioural consequence, documented in the docstring: with a shared cache **one failed load taints the whole batch** instead of being retried per item. That is the fail-closed direction, and a batch whose events cannot be read is precisely what this gate must not wave through.

The cache is built **lazily**, which is load-bearing rather than tidy: `build_status_report` reaches `_candidate_review_items` on its O(1) path, where a profile with no pending candidates must not touch the corpus at all. Hoisting the build above the loop broke `test_build_status_report_uses_O1_index_health` — **caught only by the full suite, not by targeted runs**. Two "no candidates ⇒ zero reads" regression pins were added.

**Rule 5 sweep:** `candidate_aggregation._skip_tainted_external_evidence` has the same shape in **three** per-candidate loops of `_cluster_and_promote` (an evidence tick pays it hourly) and is wired to the same per-run cache, also guarded on there being work. `crystallized.write_approved_record` / `_ensure_crystallized_approval` are **deliberately left uncached and pinned by a test**: crystallization appends events, so answering a write-boundary question from a cache built before the loop would be stale — cheaper is not worth wrong at that boundary.

## 2. Symptom: the monitor gave two different facts the same outcome

Production `doctor` returns `exit_code 0` with **zero findings**; it just takes **45 s**, against the probe's 20 s per-command cap. On timeout `load_json_cmd` returns `{_error, _code: 124}`, but the doctor section kept only `status`/`exit_code`/`findings` — so "the probe ran out of budget" and "doctor ran and reported problems" both arrived as `status=None` and were classified `doctor_not_ok`. That is the conflation this repo's own `_smoke_status` docstring forbids.

The probe now carries `probe_error`/`probe_exit_code` and the classifier emits a distinct `doctor_probe_timeout`. Still FAIL-class — losing the check is a real loss of visibility — it just says what actually happened. **The 20 s default is deliberately NOT raised**: that would be a treadmill, and (1) is the fix.

Rule-5 note recorded in the checklist: `shell_alias_no_env` has a *milder, different* form of this (it does surface each `_error`, but lumps timeout and real failure into one FAIL code). Left unchanged this batch under the large-file minimal-change rule; the production instances should disappear once (1) lands.

## Counterfactuals

Copy-backup revert (not `git checkout --`):

- provenance batch reverted → **8 of 9** new tests FAIL (review build read **6** times instead of 1, lane guard **8** instead of 1, plus 6 `ImportError`), restored → PASS.
- monitor batch reverted → **4** FAIL, the key assertion surfacing as `'doctor_probe_timeout' in ['doctor_not_ok']`, restored → PASS.

Counts, never wall clock: timing assertions are flaky and the defect is "how many times was the corpus read".

## Also in this PR

The **DB 部署与生产验证** checklist section. PR #70 shipped marked "仅仓库验证"; its provider-side fixes needed a gateway restart, which this deploy performed:

- `/opt` ff `263c623 → 9824db2`; `deploy_memory_os.py` production-safe upgrade ×2 home, all phases pass.
- Config writes verified as behavioural no-ops **before** applying (preset subtrees would otherwise overwrite live hand-tuned values).
- Hash-verified: 9 provider files × 2 copies × 2 profiles = **36/36**, plus modules ×2 and monitor ×2.
- Fix confirmed live: `recent_events` **1 → 6** on both profiles, 5 genuine `conversation_turn` rows injected, main excluding **261** bookkeeping rows (195 `conversation_turn_mirrored` + 60 governance + 6 session-fact); `event_stats_health.reason = "produced"`.
- No new FAIL/WARN on either profile; sannai PASS **90** (its historical best).

## Tests

+17 (11 provenance event-cache, 6 monitor attribution). Full suite **3622 passed / 1 failed / 13 skipped** — the single FAIL is the known-flaky `test_execution_gate_runner_serializes_parallel_sidecar_updates` concurrency case, which passes when re-run on its own. Four static gates + `git diff --check` green.

## Not claimed here

Merging does not deploy. The expected post-deploy observation is that `doctor` falls under the 20 s cap and takes `doctor_not_ok` / `shell_alias_no_env_failed` with it; if it ever times out again the report should read `doctor_probe_timeout` rather than accusing doctor.
