### PR TITLE
fix(memory-os): export HERMES_HOME in the remote probe so the monitor measures the profile it was asked to measure

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -7111,6 +7111,75 @@ caller 在循环外建一次缓存。
   `test_build_status_report_uses_O1_index_health` 抓到。**只跑改动相关测试
   不会发现**，是全量套件抓的；已改为惰性构建并补两个"无候选=0 次读取"
   回归钉。这正是 Section W 第 1 条与"测试只证明做了的是对的"的又一次实证。
+### DC 部署与生产验证（2026-08-19，main+sannai 双 profile，`8ad1baf`）
+
+- `/opt` ff `9824db2 → 8ad1baf`；`deploy_memory_os.py` production-safe upgrade
+  ×2 home，逐阶段全绿（main preflight 30/0/0、sannai 29/0/0；两 home
+  apply=applied、postcheck=pass、manifest `deployed_head=8ad1baf`），
+  唯一 WARN 仍是既有良性 `llm_judge_probe=ambiguous`。dry-run 显式确认
+  main `hindsight=preserved_active`、sannai `not_configured`，
+  `config_defaults=already_current`。
+- hash 核验：2 个改动 provider 文件 × 2 副本 × 2 home = **8/8**，
+  modules `candidate_aggregation.py` ×2、`scripts/memory_os_3_200_monitor.py`
+  ×2 全一致。
+- **DC 真因修复的生产实证（main profile，真实语料）**：
+  `_candidate_review_items` **59.3s → 0.28s**、`store.read_events()`
+  **242 次 → 1 次**、仍产出 192 条 review item（输出不变，只是便宜了）。
+  `doctor` **46s → 10–11s**（`status=ok`/`exit_code=0`，输出同构），
+  sannai `doctor` 7s → 5s。
+- monitor（`--caller-timeout-seconds 900`）：main PASS **83→99**、
+  WARN **14→7**、`doctor_not_ok` 与 `shell_alias_no_env_failed` **双双消失**；
+  doctor 段首次真正被读到（新出现 `doctor_warning_finding: index_stale`
+  ——此前探针超时，doctor 的 findings 从未进入过报告）。sannai 耗时
+  213s→131s。
+- **今晨记为"本次运行未出现"的两条 FAIL 已复现**
+  （`session_mirror_auto_apply_permit_integrity_invalid`、
+  `index_not_healthy_in_production`），证实当时拒绝把它们写成"已修"是对的。
+
+### DD — 远端探针 profile 失明：`--hermes-home` 指了谁，CLI 段就没在测谁（2026-08-19）
+
+DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
+`index_counts` **几乎逐字段相同**（audit ~99k、candidates 240、edges 6042），
+而两 home 的真实体量差一个量级。落盘核对坐实：sannai
+`candidates.jsonl` 实为 **60** 行、audit **53k**，monitor 却报 240 / 99k
+——报的是 **main** 的数。
+
+- **根因**：`_run_probe` 以 `ssh host "python3 -"` 投送脚本，**不转发任何
+  环境变量**，而非交互式 SSH 会话里 `HERMES_HOME` 实测为 unset。生成脚本
+  只把 `_hermes_home` 字面量用于 `sys.path` 与 `memory_os_cli()` 的显式
+  env，**从不写 `os.environ["HERMES_HOME"]`**；于是 8 处裸
+  `hermes ...` 调用（含驱动 index 健康的 `status` 与驱动
+  `doctor_ok/doctor_not_ok` 的 `doctor`）全部落回 CLI 默认 home = main。
+- **为什么一直没被发现**：本地 cron 通道的 lane env 自带 HERMES_HOME，
+  **夜间产物是对的**（sannai 最近一份 artifact 的 audit=45445、
+  candidates=15，是它自己的数）。失明只发生在**远端 SSH 调用**上——也就是
+  人工排障时用的那条路径。教训与 CLAUDE.md 的目录漂移族同构：
+  消费者解析到了另一个位置，而 `exists()`/默认值让它悄无声息。
+- **连带证实的两件事**：① 今日"sannai `doctor_not_ok` 已消失"实为
+  **main 的 doctor 变快后透过 sannai 的失明探针被观测到**；sannai 自身
+  doctor 已用显式 env 直测为 5s。② 生成脚本里读 ambient `HERMES_HOME` 的
+  seam host-capability 探针（`hermes_home_missing` bootstrap 码）在**每次
+  远端运行**都无法 bootstrap——同一根因，本次一并修好。
+- **修法**：在生成脚本顶部**一次性** `os.environ["HERMES_HOME"] =
+  _hermes_home`，而不是给 8 个调用点各打补丁——将来新增的裸 `hermes ...`
+  必须**默认正确**，而不是"作者记得才正确"。同时把
+  `shell_alias_no_env` 的"无 env"契约**显式化**（自建剔除 HERMES_HOME 的
+  env 副本）：它此前依赖环境恰好没定义该变量，SSH 下侥幸正确、本地 cron
+  下其实并非"无 env"——这本身就是一个潜伏缺陷，顺手钉住。
+- **反事实**：revert monitor → 3 个新测试中 2 个 FAIL（第 3 个钉的是既有
+  正确行为，两边都 PASS，如实记录），restore → PASS。
+- **部署后验收判据**：sannai monitor 的 `audit_entries` 应约 53k、
+  candidates 为 60/None 而非 99k/240；**预期 sannai 的 FAIL/WARN 集合会
+  变化**——那是它 CLI 侧的第一次诚实测量，不是本次修改引入的回归。
+  在此之前的所有 sannai monitor 数字（含 DB 节 PASS 90、DC 节 PASS 94）
+  都是 Python 段=sannai / CLI 段=main 的**混合值**，**不回改历史小节**，
+  由本节说明即可。
+- **另立不并入本批**：sannai doctor 的
+  `systemd_timer_unit_not_registered` 指名
+  `hermes-memory-os-sannai-heartbeat.timer`（profile 中缀），而磁盘与
+  systemd 里实为 `hermes-memory-os-heartbeat-sannai.timer`（profile 后缀，
+  CO 批次的约定）——doctor 自己拼的名字与安装器的约定漂移，属命名词表
+  drift 族，待独立立项核实后再修。
 
 - `26f4a80..d4bc158（CV，本节）`：PR #57 评审 14 项发现收口——dashboard
   `--profile main` 默认值 crash-loop（主场景级）、孤儿 day-count 键接上

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -7273,3 +7273,19 @@ DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
   破坏了 `build_status_report` 的 O(1) 路径，由全量套件抓出并改为惰性构建。
   +17 测试，全量 3622 passed/13 skipped（唯一 FAIL 为已知 flaky 并发用例，
   单跑 PASS），四门全绿。
+
+- `8ad1baf 部署 + 13dad46`：DC 部署与生产验证 + DD — PR #71 在 3.200 双 profile
+  落地并取得真因实证（main 真实语料：`store.read_events()` **242→1**、
+  `_candidate_review_items` **59.3s→0.28s**、`doctor` **46s→10s** 且输出同构；
+  monitor PASS **83→99**、WARN **14→7**，`doctor_not_ok` 与
+  `shell_alias_no_env_failed` 双双消失，doctor 的 findings 首次真正进入报告）。
+  验收中发现 DD：`_run_probe` 走 `ssh host "python3 -"` 不转发环境、生成脚本
+  从不写 `os.environ["HERMES_HOME"]`，致 8 处裸 `hermes ...` 调用（含驱动
+  index 健康的 `status` 与驱动 doctor 判定的 `doctor`）全部落回默认 home
+  ——sannai 实为 60 候选/53k audit，却被报成 main 的 240/99k。本地 cron 通道
+  自带该变量故夜间产物无恙，**失明只在远端 SSH 路径**。修法为脚本顶部一次性
+  导出（新增裸调用默认正确），并把 `shell_alias_no_env` 的"无 env"契约显式化
+  （此前靠环境恰好未定义，SSH 下侥幸成立）。此前所有 sannai monitor 数字
+  （含 PASS 90/94）均为 Python 段=sannai、CLI 段=main 的混合值，不回改历史小节。
+  +3 测试（2 个反事实成立、1 个钉既有正确行为如实记录），全量
+  **3626 passed / 13 skipped / 0 failed**，五门 + `git diff --check` 全绿。

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -5915,6 +5915,21 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 _hermes_home = ''' + _hh + r'''
+# Every `hermes ...` subprocess below inherits this process's environment, and
+# _run_probe ships this script over `ssh host "python3 -"`, which forwards no
+# environment at all. HERMES_HOME is unset in a non-interactive SSH session, so
+# without this line every CLI-derived section silently measured the CLI's
+# DEFAULT home instead of the one --hermes-home asked for. Measured on the dual
+# profile production host: a sannai run reported main's numbers (240 candidates
+# and ~99k audit entries against sannai's real 60 and ~53k), and main's slow
+# doctor was attributed to sannai. The local cron path was unaffected because
+# the lane env already carries HERMES_HOME -- which is exactly why this stayed
+# invisible: the nightly artifacts were correct.
+#
+# Set once here rather than per call site: a future bare `hermes ...` call must
+# be profile-correct by default, not correct only if its author remembered.
+# shell_alias_no_env deliberately strips it back out -- see its docstring.
+os.environ["HERMES_HOME"] = _hermes_home
 for _path in (
     os.path.join(_hermes_home, "memory-os/runtime/python"),
     os.path.join(_hermes_home, "plugins/memory_os"),
@@ -8642,6 +8657,13 @@ def _cron_schedule_interval(schedule):
     return timedelta(hours=1)
 
 def shell_alias_no_env():
+    # The whole point of this section is that the shell alias resolves WITHOUT
+    # HERMES_HOME, so it must strip the variable explicitly. It used to rely on
+    # the ambient environment happening not to define it, which made the
+    # contract depend on how the probe was launched: correct over SSH by
+    # accident, and quietly not "no env" under the local cron lane, which does
+    # export it. Now it holds either way.
+    _no_env = {k: v for k, v in os.environ.items() if k != "HERMES_HOME"}
     commands = {
       "status": ["hermes", "memory-os-agent-os", "status"],
       "doctor": ["hermes", "memory-os-agent-os", "doctor"],
@@ -8674,7 +8696,10 @@ def shell_alias_no_env():
     except (TypeError, ValueError):
         workers = 4
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        futures = {name: executor.submit(load_json_cmd, command) for name, command in commands.items()}
+        futures = {
+            name: executor.submit(load_json_cmd, command, _no_env)
+            for name, command in commands.items()
+        }
         results = {}
         for name, future in futures.items():
             try:

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -9097,3 +9097,46 @@ def test_remote_probe_doctor_section_carries_probe_failure_fields():
     script = monitor._remote_probe_script("/root/.hermes")
     assert '"probe_error": doctor.get("_error")' in script
     assert '"probe_exit_code": doctor.get("_code")' in script
+
+
+# -- DD: the remote probe must measure the profile it was asked to measure ---
+
+
+def test_remote_probe_script_exports_hermes_home_for_cli_subprocesses():
+    """Counterfactual for the profile-blind remote probe.
+
+    _run_probe ships this script over `ssh host "python3 -"`, which forwards no
+    environment, and HERMES_HOME is unset in a non-interactive SSH session. Every
+    bare `hermes ...` call in the probe therefore resolved to the CLI's DEFAULT
+    home rather than --hermes-home. Measured on the dual-profile production host:
+    a sannai run reported main's 240 candidates / ~99k audit entries against
+    sannai's real 60 / ~53k, and main's slow doctor was attributed to sannai.
+    """
+    script = monitor._remote_probe_script("/root/.hermes/profiles/sannai")
+
+    assert 'os.environ["HERMES_HOME"] = _hermes_home' in script
+    # ...and it must be exported before anything can shell out.
+    assert script.index('os.environ["HERMES_HOME"] = _hermes_home') < script.index("def run(")
+
+
+def test_remote_probe_script_bakes_the_requested_home_not_the_default():
+    """The baked literal must follow --hermes-home, per profile."""
+    sannai = monitor._remote_probe_script("/root/.hermes/profiles/sannai")
+    main = monitor._remote_probe_script("/root/.hermes")
+
+    assert '_hermes_home = "/root/.hermes/profiles/sannai"' in sannai
+    assert '_hermes_home = "/root/.hermes"' in main
+
+
+def test_shell_alias_no_env_section_strips_hermes_home_explicitly():
+    """Its "no env" contract must not depend on how the probe was launched.
+
+    Over SSH the variable happened to be absent, so the section was accidentally
+    correct; under the local cron lane (which exports HERMES_HOME) it was not.
+    Now that the probe exports it globally, relying on ambient absence would
+    silently turn this into a with-env check.
+    """
+    script = monitor._remote_probe_script("/root/.hermes")
+
+    assert '_no_env = {k: v for k, v in os.environ.items() if k != "HERMES_HOME"}' in script
+    assert "executor.submit(load_json_cmd, command, _no_env)" in script


### PR DESCRIPTION
Found while verifying the PR #71 deploy on 3.200. main and sannai reported nearly identical `store_counts` / `index_counts` — audit ~99k, 240 candidates, 6042 edges — even though the two homes differ by an order of magnitude. Checked against the canonical files:

| | sannai (real) | monitor reported for sannai |
|---|---|---|
| `candidates.jsonl` rows | **60** | 240 |
| audit entries | **~53k** | ~99k |

Those are main's numbers.

## Root cause

`_run_probe` ships the generated script over `ssh host "python3 -"`, which **forwards no environment**, and `HERMES_HOME` is unset in a non-interactive SSH session (verified on the host). The script bakes `_hermes_home` as a literal and uses it for `sys.path` and for `memory_os_cli()`'s explicit env — but **never sets `os.environ["HERMES_HOME"]`**.

So all eight bare `hermes ...` call sites fell back to the CLI's default home (main), including:
- `status` → drives `store_counts` / `index_counts` / index health
- `doctor` → drives `doctor_ok` / `doctor_not_ok`

**Why it stayed invisible:** the local cron lane exports `HERMES_HOME`, so the nightly artifacts were correct (sannai's latest shows audit 45445 / candidates 15 — its own). Only remote SSH invocations were blind — which is exactly the path used for hands-on investigation. Same shape as the producer/consumer directory-drift family already documented in CLAUDE.md: the consumer resolved somewhere else, and a default made it silent.

**Two things this also explains:**
1. "sannai's `doctor_not_ok` cleared" after PR #71 was really *main's* doctor getting fast, observed through sannai's blind probe. sannai's own doctor measures 5s under an explicit `HERMES_HOME`.
2. The seam host-capability probe reads ambient `HERMES_HOME` and returns a `hermes_home_missing` bootstrap code without it — so it failed to bootstrap on **every** remote run. Same root cause, fixed by the same line.

## Fix

One export at the top of the generated script rather than eight per-call-site patches: a future bare `hermes ...` call must be profile-correct **by default**, not correct only if its author remembered.

`shell_alias_no_env`'s "no env" contract is made explicit at the same time (it now builds an env copy with `HERMES_HOME` removed). It previously relied on the ambient environment happening not to define it — accidentally correct over SSH, and not actually "no env" under the local cron lane, which exports it. That latent bug would have become a live one the moment the export above landed.

## Counterfactual

Copy-backup revert: **2 of the 3** new tests FAIL without the fix. The third pins pre-existing correct behaviour and passes either way — recorded as such rather than dressed up as a counterfactual.

## Also in this PR: the DC deployment verification section

PR #71 deployed to both profiles, all phases green, 8/8 hash-exact, both gateways restarted. Production evidence on main's real corpus:

| metric | before | after |
|---|---|---|
| `store.read_events()` calls | 242 | **1** |
| `_candidate_review_items` | 59.3 s | **0.28 s** |
| `doctor` | 46 s | **10–11 s** |
| monitor PASS / WARN | 83 / 14 | **99 / 7** |

`doctor_not_ok` and `shell_alias_no_env_failed` both gone; doctor's findings became readable for the first time (a previously-invisible `index_stale` warning surfaced). The two FAILs recorded this morning as "absent in this run" have reproduced, confirming the decision not to call them fixed.

## Expected after deploying this — stated, not claimed

sannai's monitor should report `audit_entries` ~53k and candidates 60/None instead of 99k/240, and **its FAIL/WARN set should shift** — that shift is sannai's first honest CLI-side measurement, not a regression from this change. Every sannai monitor number before this fix (including the DB and DC sections' PASS 90 / PASS 94) is a blend of sannai's Python-side sections and main's CLI-side sections; the DD section says so rather than rewriting those numbers.

## Separate item, deliberately not bundled

sannai's doctor reports `systemd_timer_unit_not_registered` naming `hermes-memory-os-sannai-heartbeat.timer` (profile infix), while disk and systemd both carry `hermes-memory-os-heartbeat-sannai.timer` (profile suffix, the CO convention). doctor constructs that name itself — a naming-vocabulary drift, to be filed and verified on its own.

## Tests

+3 monitor tests. Full suite **3626 passed / 13 skipped / 0 failed**. Five gates (import cycle, write surface, static hygiene, public checkout probe, closure matrix) + `git diff --check` green.
