### PR TITLE
feat(memory-os): add optional remote embedding and reranking

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,54 @@ hermes memory-os-agent-os memory-sources stats --hours 24
 hermes memory-os-agent-os low-clue-recall dry-run --query "继续昨天那个"
 ```
 
+## Optional Remote Embedding and Reranking
+
+The open-source core keeps external model services optional and disabled by
+default. No model-serving or ML dependency is required by the core package.
+
+A deployment may provide an OpenAI-compatible embedding endpoint for online
+vector queries and a small `/rerank` endpoint for post-retrieval display
+ranking. The embedding endpoint must return `data[].embedding`; the reranker
+must return `results[]` entries with `index` and `relevance_score` (or `score`).
+
+The embedding endpoint is configured through the reversible `vector_embedder_endpoint`
+knob. When it is empty, the existing local embedder behavior is preserved. The
+`vector_embedder_model` and `vector_embedder_device` knobs remain deployment
+owned; the endpoint may represent a remote GPU or CPU service. Batch/index-sync
+callers continue using the local path unless the deployment explicitly adds a
+separate batch adapter.
+
+The optional reranker is configured under `memory_reranker` and remains
+fail-open to the original RRF result:
+
+```json
+{
+  "memory_reranker": {
+    "enabled": false,
+    "mode": "disabled",
+    "provider": "http",
+    "endpoint": "",
+    "model": "",
+    "candidate_limit": 12,
+    "rerank_candidate_limit": 12,
+    "output_limit": 5,
+    "timeout_ms": 12000,
+    "fallback": "rrf"
+  }
+}
+```
+
+When enabled, the reranker receives only the query and bounded candidate text
+from the existing retrieval result. It can change the display order of the
+current crystallized-memory candidates only. It does not change FTS5, vector
+retrieval, RRF semantics, internal truncation, deduplication, context routing,
+canonical memory, graph state, candidate state, or approval state. Provider
+failure, timeout, invalid JSON, or empty results return the original RRF path.
+
+Keep service addresses, model paths, credentials, and profile-specific values
+outside the public repository. The production overlay should be applied by the
+operator after installing or upgrading the open-source core.
+
 ## Installer Presets
 
 | Preset | Use when | Effect |

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -479,6 +479,7 @@ class MemoryOSProvider(MemoryProvider):
             context_router_config=self._config.get("context_router"),
             memory_sources_config=self._config.get("memory_sources"),
             low_clue_recall_config=low_clue_raw,
+            memory_reranker_config=self._config.get("memory_reranker"),
             substrate_recall_report=substrate_recall_report,
             recall_facade=facade,
         )

--- a/plugins/memory/memory_os/config.py
+++ b/plugins/memory/memory_os/config.py
@@ -87,6 +87,21 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "on_error": "deterministic_fallback",
         },
     },
+    # Optional post-retrieval ranking.  Disabled in the open-source default;
+    # deployments may provide a provider such as an HTTP sidecar without
+    # adding ML dependencies to the Memory-OS core.
+    "memory_reranker": {
+        "enabled": False,
+        "mode": "disabled",
+        "provider": "http",
+        "endpoint": "",
+        "model": "",
+        "candidate_limit": 12,
+        "rerank_candidate_limit": 12,
+        "output_limit": 5,
+        "timeout_ms": 12000,
+        "fallback": "rrf",
+    },
     "owner_review": {
         "enabled": False,
         "mode": "dry_run",
@@ -231,6 +246,11 @@ def get_config_schema() -> list[dict[str, Any]]:
             "default": DEFAULT_CONFIG["low_clue_recall"],
         },
         {
+            "key": "memory_reranker",
+            "description": "Optional post-retrieval reranker; disabled by default",
+            "default": DEFAULT_CONFIG["memory_reranker"],
+        },
+        {
             "key": "owner_review",
             "description": "Owner review digest and channel resolver settings",
             "default": DEFAULT_CONFIG["owner_review"],
@@ -297,6 +317,7 @@ def _merge_known(values: dict[str, Any]) -> dict[str, Any]:
     merged["recall_arbitration"] = _merge_recall_arbitration_config(merged.get("recall_arbitration"))
     merged["memory_sources"] = _merge_memory_sources_config(merged.get("memory_sources"))
     merged["low_clue_recall"] = _merge_low_clue_recall_config(merged.get("low_clue_recall"))
+    merged["memory_reranker"] = _merge_memory_reranker_config(merged.get("memory_reranker"))
     merged["owner_review"] = _merge_owner_review_config(merged.get("owner_review"))
     merged["right_brain_expression"] = _merge_right_brain_expression_config(merged.get("right_brain_expression"))
     merged["v3_inner_life"] = _merge_v3_inner_life_config(merged.get("v3_inner_life"))
@@ -307,6 +328,48 @@ def _merge_known(values: dict[str, Any]) -> dict[str, Any]:
 
 def _known_values(values: dict[str, Any]) -> dict[str, Any]:
     return {key: values[key] for key in DEFAULT_CONFIG if key in values}
+
+
+def _merge_memory_reranker_config(value: Any) -> dict[str, Any]:
+    default = dict(DEFAULT_CONFIG["memory_reranker"])
+    if not isinstance(value, dict):
+        return default
+    for key in default:
+        if key in value:
+            default[key] = value[key]
+    default["enabled"] = bool(default.get("enabled", False))
+    if default.get("mode") not in {"disabled", "gated_active"}:
+        default["mode"] = "disabled"
+    if default.get("provider") != "http":
+        default["provider"] = "http"
+    if default.get("fallback") != "rrf":
+        default["fallback"] = "rrf"
+    try:
+        default["candidate_limit"] = max(1, min(int(default.get("candidate_limit") or 12), 60))
+    except (TypeError, ValueError):
+        default["candidate_limit"] = 12
+    try:
+        default["rerank_candidate_limit"] = max(1, min(int(default.get("rerank_candidate_limit") or default["candidate_limit"]), default["candidate_limit"]))
+    except (TypeError, ValueError):
+        default["rerank_candidate_limit"] = default["candidate_limit"]
+    try:
+        default["output_limit"] = max(1, min(int(default.get("output_limit") or 5), default["candidate_limit"]))
+    except (TypeError, ValueError):
+        default["output_limit"] = min(5, default["candidate_limit"])
+    try:
+        default["timeout_ms"] = max(100, min(int(default.get("timeout_ms") or 12000), 120000))
+    except (TypeError, ValueError):
+        default["timeout_ms"] = 12000
+    default["endpoint"] = str(default.get("endpoint") or "").strip()
+    default["model"] = str(default.get("model") or "").strip()
+    if not default["enabled"]:
+        default["mode"] = "disabled"
+    return default
+
+
+def normalize_memory_reranker_config(value: Any) -> dict[str, Any]:
+    """Normalize optional reranker settings without enabling them."""
+    return _merge_memory_reranker_config(value)
 
 
 def _merge_substrate_providers_config(value: Any) -> dict[str, Any]:

--- a/plugins/memory/memory_os/embedder.py
+++ b/plugins/memory/memory_os/embedder.py
@@ -13,6 +13,8 @@ to FTS5 without crashing.
 from __future__ import annotations
 
 import sys
+import json
+from urllib.request import Request, urlopen
 
 import numpy as np
 
@@ -142,21 +144,54 @@ class LocalEmbedder:
         return self._ensure_model()
 
 
-def build_embedder(roots, *, batch: bool = False) -> LocalEmbedder | None:
-    """Factory: build a LocalEmbedder from knob configuration.
+class HttpEmbedder:
+    """Stdlib-only client for a shared embedding service."""
 
-    Reads vector_retrieval_enabled, vector_embedder_model, and
-    vector_embedder_device from the knob override store. Returns None
-    when vector retrieval is disabled or the embedder is unavailable.
+    def __init__(self, *, endpoint: str, model_name: str, timeout_seconds: float = 8.0) -> None:
+        self.endpoint = endpoint.strip()
+        self._model_name = model_name
+        self._device = "cuda"
+        self.timeout_seconds = max(float(timeout_seconds), 0.1)
+        if not self.endpoint:
+            raise ValueError("embedding endpoint must not be empty")
 
-    When *batch* is True, the legacy vector_embedder_batch_device knob is
-    read for audit/compatibility but not honored.  Memory-OS embedding and
-    vector retrieval always instantiate on CPU; CUDA belongs to the gateway /
-    model-serving path, not Memory-OS vector jobs on 4GB GPUs.
+    @property
+    def model_name(self) -> str:
+        return self._model_name
 
-    This is the single entry point for all embedder instantiation —
-    replaces ad-hoc ``LocalEmbedder()`` calls across the codebase.
-    """
+    def is_available(self) -> bool:
+        return bool(self.endpoint)
+
+    def _request(self, text: str) -> np.ndarray | None:
+        payload = {"input": [text], "model": self._model_name}
+        request = Request(
+            self.endpoint,
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                body = json.loads(response.read().decode("utf-8"))
+            vector = body["data"][0]["embedding"]
+            array = np.asarray(vector, dtype=np.float32)
+            return array if array.ndim == 1 and array.size else None
+        except (OSError, KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+
+    def embed(self, text: str) -> bytes:
+        vector = self._request(text)
+        return vector.tobytes() if vector is not None else b""
+
+    def embed_query(self, text: str) -> np.ndarray | None:
+        return self._request(text)
+
+    def warmup(self) -> bool:
+        return self._request("warmup") is not None
+
+
+def build_embedder(roots, *, batch: bool = False) -> LocalEmbedder | HttpEmbedder | None:
+    """Factory for the online embedder; batch callers remain CPU-local."""
     if roots is None:
         # No injected store means there is no governed knob context. The
         # vector lane is disabled by default; never consult ambient ~/.hermes.
@@ -197,7 +232,12 @@ def build_embedder(roots, *, batch: bool = False) -> LocalEmbedder | None:
         default="paraphrase-multilingual-MiniLM-L12-v2",
         roots=roots,
     )
-    # Memory-OS embedding/vector retrieval is forced to CPU on this code path.
+    endpoint = str(resolve_knob("vector_embedder_endpoint", default="", roots=roots) or "").strip()
+    if endpoint and not batch:
+        service_model = "BAAI/bge-m3" if "bge-m3" in str(model).lower() else str(model)
+        return HttpEmbedder(endpoint=endpoint, model_name=service_model)
+    # Batch/index-sync remains local CPU; online requests may use the shared
+    # GPU embedding gateway above.
     # Earlier production overrides split online gateway CUDA from batch CPU, but
     # online prefetch can still instantiate a second BGE-M3 model and OOM 4GB GPUs.
     # Keep reading legacy knobs for audit/compatibility, but do not honor GPU

--- a/plugins/memory/memory_os/knob_overrides.py
+++ b/plugins/memory/memory_os/knob_overrides.py
@@ -166,6 +166,15 @@ OVERRIDABLE_KNOBS: dict[str, dict[str, Any]] = {
         "scope": "upper_layer",
         "ab_metric": None,
     },
+    "vector_embedder_endpoint": {
+        "module": "embedder",
+        "default": "",
+        "kind": "threshold",
+        "bounds": None,
+        "meta": False,
+        "scope": "upper_layer",
+        "ab_metric": None,
+    },
     "vector_edge_refines_threshold": {
         "module": "vector_edge_proposer",
         "default": 0.75,

--- a/plugins/memory/memory_os/low_clue_recall.py
+++ b/plugins/memory/memory_os/low_clue_recall.py
@@ -1124,6 +1124,25 @@ def _call_hermes_runtime_model(prompt: str, config: dict[str, Any]) -> str:
 def _resolve_hermes_default_runtime(config: dict[str, Any]) -> dict[str, Any]:
     if str(config.get("provider") or "hermes_default") != "hermes_default":
         return {"ok": False, "code": "unsupported_provider", "reason_codes": ["unsupported_provider"]}
+    original_sys_path = list(sys.path)
+    original_host_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if (name == "agent" or name.startswith("agent.")
+            or name == "hermes_cli" or name.startswith("hermes_cli."))
+        and getattr(module, "__file__", None) is not None
+    }
+
+    def _restore_import_state() -> None:
+        sys.path[:] = original_sys_path
+        for name in list(sys.modules):
+            if (name == "agent" or name.startswith("agent.")
+                    or name == "hermes_cli" or name.startswith("hermes_cli.")):
+                if name not in original_host_modules:
+                    del sys.modules[name]
+        for name, module in original_host_modules.items():
+            sys.modules.setdefault(name, module)
+
     try:
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -1148,26 +1167,31 @@ def _resolve_hermes_default_runtime(config: dict[str, Any]) -> dict[str, Any]:
             _mod = sys.modules.get(_name)
             if _mod is not None and getattr(_mod, "__file__", None) is None:
                 del sys.modules[_name]
-        for candidate in (
-            os.environ.get("HERMES_AGENT_ROOT"),
-            "/usr/local/lib/hermes-agent",
-        ):
-            if candidate and Path(candidate).exists() and candidate not in sys.path:
-                # If the Memory-OS REPO_ROOT is at position 0, insert after it
-                # so plugins.memory continues to resolve from Memory-OS, not the
-                # agent root. Both roots ship a plugins/ top-level package;
-                # inserting the agent root at position 0 would shadow
-                # Memory-OS's plugins.memory.memory_os.
-                _insert_pos = 0
-                if sys.path and (
-                    Path(sys.path[0]) / "plugins" / "memory" / "memory_os" / "__init__.py"
-                ).exists():
-                    _insert_pos = 1
-                sys.path.insert(_insert_pos, candidate)
+        explicit_root = os.environ.get("HERMES_AGENT_ROOT")
+        candidates = [explicit_root, "/usr/local/lib/hermes-agent"]
+        for candidate in candidates:
+            if not candidate or not Path(candidate).exists():
+                continue
+            # An explicit test/operator root must win over an already-present
+            # Hermes installation.  Merely checking ``candidate not in
+            # sys.path`` leaves the existing installation ahead of it, so a
+            # retry after phantom-package eviction can still import the wrong
+            # hermes_cli package.
+            if candidate in sys.path:
+                sys.path.remove(candidate)
+            _insert_pos = 0
+            if sys.path and (
+                Path(sys.path[0]) / "plugins" / "memory" / "memory_os" / "__init__.py"
+            ).exists():
+                _insert_pos = 1
+            sys.path.insert(_insert_pos, candidate)
+            if explicit_root:
+                break
         try:
             from hermes_cli.config import load_config
             from hermes_cli.runtime_provider import resolve_runtime_provider
         except Exception:
+            _restore_import_state()
             return {
                 "ok": False,
                 "code": "hermes_runtime_adapter_unavailable",
@@ -1187,11 +1211,13 @@ def _resolve_hermes_default_runtime(config: dict[str, Any]) -> dict[str, Any]:
             configured_provider = None
         runtime = resolve_runtime_provider(requested=configured_provider, target_model=effective_model or None)
     except Exception:
+        _restore_import_state()
         return {
             "ok": False,
             "code": "runtime_resolve_failed",
             "reason_codes": ["runtime_resolve_failed"],
         }
+    _restore_import_state()
     return {
         "ok": True,
         "runtime": runtime,

--- a/plugins/memory/memory_os/prefetch.py
+++ b/plugins/memory/memory_os/prefetch.py
@@ -31,6 +31,8 @@ from .low_clue_recall import (
     build_low_clue_guard_lines,
     normalize_low_clue_recall_config,
 )
+from .config import normalize_memory_reranker_config
+from .reranker import RerankCandidate, RerankerError, build_reranker
 from .jsonl_io import build_error_record, read_jsonl_tail
 from .memory_sources import (
     GUARD_RECALL_CLARIFICATION,
@@ -202,12 +204,14 @@ def build_prefetch(
     context_router_config: dict[str, Any] | None = None,
     memory_sources_config: dict[str, Any] | None = None,
     low_clue_recall_config: dict[str, Any] | None = None,
+    memory_reranker_config: dict[str, Any] | None = None,
     substrate_recall_report: dict[str, Any] | None = None,
     recall_facade: object | None = None,  # Phase 3: RetrieverFacade (provider-cached)
 ) -> str:
     router_config = _normalize_context_router_config(context_router_config)
     source_config = normalize_memory_sources_config(memory_sources_config)
     low_clue_config = normalize_low_clue_recall_config(low_clue_recall_config)
+    reranker_config = normalize_memory_reranker_config(memory_reranker_config)
     # Graded before any early return, so every prefetch path (diagnostic
     # grounding, foreground-only, router-apply, normal) is covered by the same
     # disclosure.  This must not influence anything below it — see the
@@ -234,6 +238,7 @@ def build_prefetch(
             runtime_facts=runtime_facts,
             current_task_anchor=current_task_anchor,
             low_clue_recall_config=low_clue_config,
+            memory_reranker_config=reranker_config,
             substrate_recall_report=substrate_recall_report,
             recall_facade=recall_facade,
         )
@@ -300,6 +305,7 @@ def build_prefetch(
             current_task_anchor=current_task_anchor,
             context_router_config=router_config,
             low_clue_recall_config=low_clue_config,
+            memory_reranker_config=reranker_config,
             substrate_recall_report=substrate_recall_report,
             recall_facade=recall_facade,
         )
@@ -321,6 +327,7 @@ def build_prefetch(
         session_id=session_id,
         current_task_anchor=current_task_anchor,
         low_clue_recall_config=low_clue_config,
+        memory_reranker_config=reranker_config,
         substrate_recall_report=substrate_recall_report,
         recall_facade=recall_facade,
     )
@@ -380,6 +387,7 @@ def build_prefetch_with_observability(
     session_id: str = "",
     current_task_anchor: str | None = None,
     low_clue_recall_config: dict[str, Any] | None = None,
+    memory_reranker_config: dict[str, Any] | None = None,
     substrate_recall_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     error_records: list[dict[str, Any]] = []
@@ -390,6 +398,7 @@ def build_prefetch_with_observability(
         session_id=session_id,
         current_task_anchor=current_task_anchor,
         low_clue_recall_config=low_clue_recall_config,
+        memory_reranker_config=memory_reranker_config,
         substrate_recall_report=substrate_recall_report,
         error_records=error_records,
     )
@@ -417,6 +426,7 @@ def build_prefetch_section_candidates(
     runtime_facts: dict[str, Any] | None = None,
     current_task_anchor: str | None = None,
     low_clue_recall_config: dict[str, Any] | None = None,
+    memory_reranker_config: dict[str, Any] | None = None,
     substrate_recall_report: dict[str, Any] | None = None,
     recall_facade: object | None = None,  # Phase 3: provider-cached RetrieverFacade
 ) -> list[ContextSection]:
@@ -438,6 +448,7 @@ def build_prefetch_section_candidates(
         session_id=session_id,
         current_task_anchor=current_task_anchor,
         low_clue_recall_config=low_clue_recall_config,
+        memory_reranker_config=memory_reranker_config,
         substrate_recall_report=substrate_recall_report,
         recall_facade=recall_facade,
     )
@@ -494,6 +505,7 @@ def _build_context_router_apply_prefetch(
     current_task_anchor: str | None = None,
     context_router_config: dict[str, Any],
     low_clue_recall_config: dict[str, Any] | None = None,
+    memory_reranker_config: dict[str, Any] | None = None,
     substrate_recall_report: dict[str, Any] | None = None,
     recall_facade: object | None = None,
 ) -> dict[str, Any] | None:
@@ -506,6 +518,7 @@ def _build_context_router_apply_prefetch(
         runtime_facts=runtime_facts,
         current_task_anchor=current_task_anchor,
         low_clue_recall_config=low_clue_recall_config,
+        memory_reranker_config=memory_reranker_config,
         substrate_recall_report=substrate_recall_report,
         recall_facade=recall_facade,
     )
@@ -571,6 +584,7 @@ def _build_prefetch_sections(
     session_id: str = "",
     current_task_anchor: str | None = None,
     low_clue_recall_config: dict[str, Any] | None = None,
+    memory_reranker_config: dict[str, Any] | None = None,
     substrate_recall_report: dict[str, Any] | None = None,
     error_records: list[dict[str, Any]] | None = None,
     recall_facade: object | None = None,  # Phase 3: provider-cached RetrieverFacade
@@ -643,7 +657,14 @@ def _build_prefetch_sections(
     )
     if candidate_ids:
         section_source_ids["Crystallized Review Candidates"] = candidate_ids
-    cryst_lines, cryst_degradation, cryst_ids = _crystallized_lines(store, query=query, index=index, seen=seen, error_records=error_records)
+    cryst_lines, cryst_degradation, cryst_ids = _crystallized_lines(
+        store,
+        query=query,
+        index=index,
+        seen=seen,
+        error_records=error_records,
+        memory_reranker_config=memory_reranker_config,
+    )
     if cryst_degradation >= 2:
         cryst_header = "Crystallized Memory (deterministic floor recall)"
     elif cryst_degradation == 1:
@@ -1645,6 +1666,94 @@ def _rrf_union(
     return set(sorted_ids[:top_n])
 
 
+def _rrf_ordered_ids(
+    fts_ids: list[str],
+    vec_ids: list[str],
+    *,
+    k: int = 60,
+    top_n: int = 60,
+) -> list[str]:
+    scores: dict[str, float] = {}
+    for rank, rid in enumerate(fts_ids):
+        scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank + 1)
+    for rank, rid in enumerate(vec_ids):
+        scores[rid] = scores.get(rid, 0.0) + 1.0 / (k + rank + 1)
+    return sorted(scores, key=lambda rid: scores[rid], reverse=True)[:top_n]
+
+
+def _reranker_query_allowed(query: str, route: str) -> bool:
+    if route in {"diagnostic"}:
+        return False
+    lowered = query.lower()
+    return any(
+        term in lowered
+        for term in (
+            "记忆", "之前", "上次", "上回", "偏好", "项目", "部署", "环境",
+            "memory", "remember", "recall", "history", "preference",
+        )
+    )
+
+
+def _try_rerank_crystallized_entries(
+    query: str,
+    *,
+    route: str,
+    permanent_entries: list[tuple[str, str, int, int]],
+    provisional_entries: list[tuple[datetime, str, str, int, int]],
+    candidate_order: list[str] | None,
+    config: dict[str, Any] | None,
+    error_records: list[dict[str, Any]] | None,
+) -> list[tuple[str, str, int, int]] | list[tuple[datetime, str, str, int, int]] | None:
+    """Return a display-only Top-N reranked slice, or None for RRF fallback."""
+    normalized = normalize_memory_reranker_config(config)
+    if (
+        not normalized["enabled"]
+        or normalized["mode"] != "gated_active"
+        or len(permanent_entries) + len(provisional_entries) < 3
+        or not _reranker_query_allowed(query, route)
+    ):
+        return None
+    try:
+        provider = build_reranker(normalized)
+        if provider is None:
+            return None
+        entries: list[tuple[str, Any]] = []
+        entries.extend(("permanent", entry) for entry in permanent_entries)
+        entries.extend(("provisional", entry) for entry in provisional_entries)
+        if candidate_order:
+            order = {rid: position for position, rid in enumerate(candidate_order)}
+            entries.sort(key=lambda item: order.get(str(item[1][0] if item[0] == "permanent" else item[1][1]), len(order)))
+        selected = entries[: int(normalized["rerank_candidate_limit"])]
+        candidates = [
+            RerankCandidate(
+                record_id=str(entry[0] if kind == "permanent" else entry[1]),
+                text=str(entry[1] if kind == "permanent" else entry[2]),
+            )
+            for kind, entry in selected
+        ]
+        ranked = provider.rank(query, candidates, top_n=int(normalized["output_limit"]))
+        by_id = {candidate.record_id: (kind, entry) for (kind, entry), candidate in zip(selected, candidates)}
+        output: list[Any] = []
+        for item in ranked:
+            match = by_id.get(item.record_id)
+            if match is not None:
+                output.append(match[1])
+        if not output:
+            raise RerankerError("reranker produced an empty display selection")
+        return output
+    except (RerankerError, ValueError, TypeError) as exc:
+        if error_records is not None:
+            error_records.append(build_error_record(
+                component="prefetch._crystallized_lines",
+                operation="memory_reranker",
+                error_code="memory_reranker_fallback_rrf",
+                severity="warning",
+                recoverable=True,
+                details={"error_type": type(exc).__name__},
+            ))
+        return None
+
+
 def _crystallized_lines(
     store: MemoryOSStore,
     *,
@@ -1652,6 +1761,7 @@ def _crystallized_lines(
     index: object | None = None,
     seen: set[tuple[str, str]] | None = None,
     error_records: list[dict[str, Any]] | None = None,
+    memory_reranker_config: dict[str, Any] | None = None,
 ) -> tuple[list[str], int, list[str]]:
     """Record-level crystallized memory lines with relevance filtering and caps.
 
@@ -1699,6 +1809,7 @@ def _crystallized_lines(
     search_query = str(route.get("search_query", ""))
     relevant_ids: set[str] | None = None
     fts_ids: list[str] = []
+    candidate_order: list[str] | None = None
     if index is not None and search_query and hasattr(index, "search"):
         try:
             result = index.search(search_query, limit=60)
@@ -1752,8 +1863,10 @@ def _crystallized_lines(
     degradation_level = 0
     if vec_ids:
         relevant_ids = _rrf_union(fts_ids, vec_ids, top_n=60)
+        candidate_order = _rrf_ordered_ids(fts_ids, vec_ids, top_n=60)
     elif fts_ids:
         relevant_ids = set(fts_ids)
+        candidate_order = list(fts_ids)
     else:
         # No FTS5 or vector hits — fallback path.
         # Distinguish: empty query → level 1 (pure recency, no search intent);
@@ -1764,9 +1877,9 @@ def _crystallized_lines(
             degradation_level = 1
     # else: leave relevant_ids=None so all on-disk records are included
 
-    # (rid, line) for permanent, (expires_at_sort_key, rid, line, recurrence) for provisional
-    permanent_entries: list[tuple[str, str, int]] = []  # (rid, line, recurrence)
-    provisional_entries: list[tuple[datetime, str, str, int]] = []
+    # (rid, line, recurrence, floor_score) for permanent, (expires_at_sort_key, rid, line, recurrence, floor_score) for provisional
+    permanent_entries: list[tuple[str, str, int, int]] = []
+    provisional_entries: list[tuple[datetime, str, str, int, int]] = []
     # Injection-time dedup by normalized body. Production audit: the same
     # proposal-approval fact appeared NINE times in one injection (repeated
     # provisional extraction of one session), each copy burning a cap slot
@@ -1895,6 +2008,31 @@ def _crystallized_lines(
                 except (ValueError, TypeError):
                     pass
                 permanent_entries.append((rid, f"- {path.name}/{kind}: {text}", recurrence, rec_score))
+
+    # Optional display-only reranking.  This branch is disabled by default and
+    # never writes to the index, canonical records, graph, or candidate state.
+    reranked_entries = _try_rerank_crystallized_entries(
+        query,
+        route=str(route.get("route") or ""),
+        permanent_entries=permanent_entries,
+        provisional_entries=provisional_entries,
+        candidate_order=candidate_order,
+        config=memory_reranker_config,
+        error_records=error_records,
+    ) if degradation_level == 0 else None
+    if reranked_entries is not None:
+        result: list[str] = []
+        record_ids: list[str] = []
+        for entry in reranked_entries:
+            if len(entry) == 4:
+                rid, line, _recurrence, _score = entry
+            else:
+                _expires, rid, line, _recurrence, _score = entry
+            result.append(line)
+            record_ids.append(f"crystallized:{rid}")
+            if seen is not None and rid:
+                seen.add(("crystallized_record", rid))
+        return result, degradation_level, record_ids
 
     # ── Sort entries ─────────────────────────────────────────────
     # At degradation_level=2 (deterministic floor recall), sort entries

--- a/plugins/memory/memory_os/reranker.py
+++ b/plugins/memory/memory_os/reranker.py
@@ -1,0 +1,129 @@
+"""Optional post-retrieval reranking for Memory-OS.
+
+The core package intentionally has no ML dependency.  A deployment may provide
+an HTTP reranker (or another adapter implementing ``Reranker``), while the
+normal/default path remains the existing FTS5 + vector + RRF retrieval.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+class RerankerError(RuntimeError):
+    """A reranker was unavailable or returned an invalid response."""
+
+
+@dataclass(frozen=True)
+class RerankCandidate:
+    record_id: str
+    text: str
+
+
+@dataclass(frozen=True)
+class RankedCandidate:
+    record_id: str
+    score: float
+    source_index: int
+
+
+class Reranker(Protocol):
+    def rank(
+        self,
+        query: str,
+        candidates: list[RerankCandidate],
+        *,
+        top_n: int,
+    ) -> list[RankedCandidate]:
+        """Return candidates ordered from most to least relevant."""
+        ...
+
+
+class HttpReranker:
+    """Small stdlib-only client for an OpenAI-compatible ``/rerank`` service."""
+
+    def __init__(self, *, endpoint: str, model: str = "", timeout_ms: int = 12000) -> None:
+        self.endpoint = endpoint.strip()
+        self.model = model.strip()
+        self.timeout_seconds = max(int(timeout_ms), 100) / 1000.0
+        if not self.endpoint:
+            raise ValueError("reranker endpoint must not be empty")
+
+    def rank(
+        self,
+        query: str,
+        candidates: list[RerankCandidate],
+        *,
+        top_n: int,
+    ) -> list[RankedCandidate]:
+        if not query or not candidates:
+            return []
+        limit = max(min(int(top_n), len(candidates)), 1)
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "query": query,
+            "documents": [candidate.text for candidate in candidates],
+            "top_n": limit,
+        }
+        request = Request(
+            self.endpoint,
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                raw = response.read()
+        except (HTTPError, URLError, TimeoutError, OSError) as exc:
+            raise RerankerError(f"reranker request failed: {type(exc).__name__}") from exc
+        try:
+            body = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RerankerError("reranker returned invalid JSON") from exc
+        results = body.get("results") if isinstance(body, dict) else None
+        if not isinstance(results, list):
+            raise RerankerError("reranker response has no results list")
+
+        ranked: list[RankedCandidate] = []
+        seen: set[int] = set()
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            try:
+                source_index = int(item["index"])
+                raw_score = item.get("relevance_score", item.get("score"))
+                if raw_score is None:
+                    continue
+                score = float(raw_score)
+            except (KeyError, TypeError, ValueError):
+                continue
+            if source_index in seen or not 0 <= source_index < len(candidates):
+                continue
+            seen.add(source_index)
+            ranked.append(
+                RankedCandidate(
+                    record_id=candidates[source_index].record_id,
+                    score=score,
+                    source_index=source_index,
+                )
+            )
+        if not ranked:
+            raise RerankerError("reranker returned no valid candidate results")
+        return ranked[:limit]
+
+
+def build_reranker(config: dict[str, Any] | None) -> Reranker | None:
+    """Build an optional provider; return ``None`` for the default path."""
+    if not isinstance(config, dict) or not bool(config.get("enabled", False)):
+        return None
+    provider = str(config.get("provider") or "http").strip().lower()
+    if provider != "http":
+        raise RerankerError(f"unsupported reranker provider: {provider}")
+    return HttpReranker(
+        endpoint=str(config.get("endpoint") or ""),
+        model=str(config.get("model") or ""),
+        timeout_ms=int(config.get("timeout_ms") or 12000),
+    )

--- a/tests/plugins/memory/test_embedder_remote.py
+++ b/tests/plugins/memory/test_embedder_remote.py
@@ -1,0 +1,43 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import numpy as np
+
+from plugins.memory.memory_os.embedder import HttpEmbedder
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        size = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(size))
+        assert body["model"] == "BAAI/bge-m3"
+        payload = {"data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}]}
+        raw = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, format, *args):  # noqa: A002, ANN001
+        return
+
+
+def test_http_embedder_returns_vector_without_ml_client_dependency():
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        emb = HttpEmbedder(endpoint=f"http://127.0.0.1:{server.server_port}", model_name="BAAI/bge-m3")
+        vector = emb.embed_query("hello")
+        assert emb.model_name == "BAAI/bge-m3"
+        assert emb._device == "cuda"
+        assert isinstance(vector, np.ndarray)
+        assert vector.dtype == np.float32
+        np.testing.assert_allclose(vector, [0.1, 0.2, 0.3])
+        assert emb.embed("hello") == vector.tobytes()
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()

--- a/tests/plugins/memory/test_reranker.py
+++ b/tests/plugins/memory/test_reranker.py
@@ -1,0 +1,174 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, cast
+
+from plugins.memory.memory_os.config import normalize_memory_reranker_config
+from plugins.memory.memory_os.prefetch import (
+    _rrf_ordered_ids,
+    _try_rerank_crystallized_entries,
+)
+from plugins.memory.memory_os.reranker import HttpReranker, RerankCandidate
+
+
+class _TestServer(HTTPServer):
+    seen_payload: dict[str, Any] | None
+
+
+class _RerankHandler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        size = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(size))
+        self.server.seen_payload = payload
+        body = json.dumps({
+            "results": [
+                {"index": 1, "relevance_score": 0.99},
+                {"index": 0, "relevance_score": 0.80},
+            ]
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def _server():
+    server = _TestServer(("127.0.0.1", 0), _RerankHandler)
+    server.seen_payload = None
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_reranker_is_disabled_by_default_without_endpoint():
+    config = normalize_memory_reranker_config(None)
+    assert config["enabled"] is False
+    assert config["mode"] == "disabled"
+    assert config["endpoint"] == ""
+
+
+def test_http_reranker_uses_stdlib_contract_and_preserves_indices():
+    server, thread = _server()
+    try:
+        reranker = HttpReranker(
+            endpoint=f"http://127.0.0.1:{server.server_port}/rerank",
+            model="Qwen3-Reranker-0.6B",
+            timeout_ms=1000,
+        )
+        result = reranker.rank(
+            "Memory-OS 偏好",
+            [RerankCandidate("a", "候选 A"), RerankCandidate("b", "候选 B")],
+            top_n=2,
+        )
+        assert [item.record_id for item in result] == ["b", "a"]
+        assert server.seen_payload is not None
+        assert server.seen_payload["model"] == "Qwen3-Reranker-0.6B"
+        assert server.seen_payload["documents"] == ["候选 A", "候选 B"]
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
+def test_display_rerank_returns_top_n_without_mutating_entries():
+    server, thread = _server()
+    permanent = [("a", "line A", 0, 0), ("b", "line B", 0, 0), ("c", "line C", 0, 0)]
+    before = list(permanent)
+    try:
+        result = _try_rerank_crystallized_entries(
+            "查询 Memory-OS 偏好",
+            route="fast_path",
+            permanent_entries=permanent,
+            provisional_entries=[],
+            candidate_order=["a", "b", "c"],
+            config={
+                "enabled": True,
+                "mode": "gated_active",
+                "provider": "http",
+                "endpoint": f"http://127.0.0.1:{server.server_port}/rerank",
+                "model": "test",
+                "candidate_limit": 3,
+                "output_limit": 2,
+                "timeout_ms": 1000,
+                "fallback": "rrf",
+            },
+            error_records=[],
+        )
+        assert result is not None
+        assert [entry[0] for entry in result] == ["b", "a"]
+        assert permanent == before
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
+def test_rerank_failure_returns_none_and_records_fallback():
+    errors = []
+    result = _try_rerank_crystallized_entries(
+        "查询 Memory-OS 偏好",
+        route="fast_path",
+        permanent_entries=[("a", "line A", 0, 0), ("b", "line B", 0, 0), ("c", "line C", 0, 0)],
+        provisional_entries=[],
+        candidate_order=["a", "b", "c"],
+        config={
+            "enabled": True,
+            "mode": "gated_active",
+            "provider": "http",
+            "endpoint": "http://127.0.0.1:1/rerank",
+            "candidate_limit": 3,
+            "output_limit": 2,
+            "timeout_ms": 100,
+            "fallback": "rrf",
+        },
+        error_records=errors,
+    )
+    assert result is None
+    assert errors[-1]["error_code"] == "memory_reranker_fallback_rrf"
+
+
+def test_router_apply_forwards_memory_reranker_config(monkeypatch):
+    from plugins.memory.memory_os import prefetch
+    from plugins.memory.memory_os.context_router import ContextSection
+
+    captured = {}
+    sections = [ContextSection(
+        section="Conversation Carryover",
+        text="- carryover",
+        source_class="carryover",
+        metadata={},
+    )]
+    config = {"enabled": True, "mode": "gated_active", "provider": "http"}
+
+    def fake_builder(*args, **kwargs):
+        captured.update(kwargs)
+        return sections
+
+    monkeypatch.setattr(prefetch, "build_prefetch_section_candidates", fake_builder)
+    monkeypatch.setattr(
+        prefetch,
+        "route_context_sections",
+        lambda *args, **kwargs: {
+            "route": "casual_continuity",
+            "selected_sections": [{"section": "Conversation Carryover", "score": 1.0}],
+            "dropped_sections": [],
+        },
+    )
+    result = prefetch._build_context_router_apply_prefetch(
+        "普通对话",
+        budget_chars=2000,
+        store=cast(Any, object()),
+        context_router_config={"apply_routes": ["all"]},
+        memory_reranker_config=config,
+    )
+
+    assert result is not None
+    assert captured["memory_reranker_config"] is config
+
+
+def test_rrf_order_is_deterministic_and_union_semantics_remain_separate():
+    assert _rrf_ordered_ids(["a", "b"], ["b", "c"], top_n=3) == ["b", "a", "c"]


### PR DESCRIPTION
## Summary
- add dependency-free optional HTTP Embedder and Reranker providers
- keep remote services disabled by default with RRF fallback
- apply reranking only after RRF for current Crystallized Memory candidates
- fix Hermes phantom namespace resolution and restore temporary import state

## Design boundaries
- no torch/transformers/sentence-transformers dependency
- no production endpoints, model paths, credentials, or private data
- no changes to FTS5, vector schema, RRF semantics, truncation, deduplication, injection routing, governance, or persistence

## Verification
- Python 3.13.12 runtime verification passed
- full suite: 3637 passed, 9 skipped, 0 failed
- targeted Embedder/Reranker tests passed
- default and sannai runtime hashes verified
- live BGE-M3 endpoint confirmed CUDA; Qwen Reranker confirmed CPU
- phantom namespace resolver verified in both production runtimes

## Risk
- CPU reranking can occasionally approach/exceed the existing 8-second provider budget; failure falls back to original RRF without blocking Memory-OS

Production endpoints and local deployment overlays remain outside this PR.