### PR TITLE
fix(memory-os): 取消意图判定改为封闭规则集 + cron 会话双守卫（生产 93%/80% 的取消锚点是定时任务写的）

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4972,7 +4972,8 @@ sannai-community 仓库 README。）
   （整词 ASCII + CJK 否定/报告/疑问/宾语守卫，返回规则 id 落 audit）、新增 cron 会话与
   Hermes 机器提示词双守卫（`initialize` 不再让 cron 会话继承并墓碑主人锚点）、删除
   `context_router.py` 三份逐字词表副本与兜底分支；生产实测 sannai 113/121、main 586/731
-  条 cancelled 锚点由 cron 提示词写入。+42 测试，全量 3688 passed / 13 skipped / 0 failed，
+  条 cancelled 锚点由 cron 提示词写入；判定器用 153 条生产语料复验（拒 98、自然取消 32/32），
+  白名单宾语初版漏判 8 条已改为子句有界规则。+55 测试，全量 3701 passed / 13 skipped / 0 failed，
   五门全绿；仅 `local_pass`，待两 profile 部署 + 网关重启。
 
 - `3f447dc..HEAD`：#74/#75 评审修复（DF）——embedder 失败类型化 + `memory_embedder_fallback_fts` error_record、RAGFlow 空结果权威化 + 畸形 chunk 免连坐、import-state finally 化、INV-5 豁免记录、rerank 截断文档如实化；+11 测试，全量 3646 passed / 13 skipped / 0 failed。
@@ -7412,6 +7413,37 @@ DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
     cancelled 写入的 audit `active_task_anchor_recorded` 增 `ingress_rule`（唯一能回答
     "为什么取消"的耐久字段）。
   - `context_router.py`：删除三份私有词表、`_has_cancellation` 及三条兜底分支。
+- **合入前用生产语料复验，抓到本批最严重的一次自伤（CL 教训第二次兑现）**：初版规则只用
+  手写语料验证就准备推送。按 CL 节「验证样本自带幸存者偏差」把两个账本里**非 cron** 的 153 条
+  真实取消文本拉下来，跑真函数逐条看，结果分两半：
+
+  **好消息**——97 条被正确拒绝，且其中若干条证明旧代码不只是"噪音"而是**反向执行主人意图**：
+  `继续最小闭环，没全部完成不要停止下来！`、`已授权直接迁移……没完全迁移任务不能停止循环！`、
+  `sannai 迁移可以完全先停止后再操作迁移！按方案开干吧`——主人明说"**不要停止**""**不能停止**"
+  "开干吧"，旧代码逐条记成了取消。另有约 40 条 `[ASYNC DELEGATION BATCH COMPLETE]`、
+  9 条 `[Continuing toward your standing goal]`、12 条 `[The user sent a text document: …]`、
+  2 条 `Loading weights: 100%|…` 终端输出——**全是 Hermes 自己的框架文本**，与 cron 前导语同类，
+  说明"机器输入被当成主人话语"这个面比只看 cron 更宽。
+
+  **坏消息**——初版规则要求动词后跟一个白名单任务名词，于是 `取消掉这个渲染任务`、
+  `停止安装插件`、`停止渲染视频`、`放弃这个方案`、`取消下载模型`、`停下手上的活` **全部漏判**
+  （手工边界探针 22 条里漏 8 条）。**漏判比原缺陷更糟**：未命中的取消句会掉进
+  `_format_current_task_anchor`，把"取消这个渲染任务"本身变成一条新的 **active** 锚点。
+  白名单宾语正是本项目反复吃亏的那类反模式（CLAUDE.md「A gate whose vocabulary drifts from
+  its producer's checks nothing」的近亲：这里是**词表试图穷举世界**）。
+
+  **改法**：宾语不再枚举，改用**子句形状有界 + 拒绝式尾部**——动词须领起一个短子句
+  （动词后 ≤12 字、整子句 ≤30 字），尾部不得是描述框架（`的` 紧跟动词 / `时$` / `后多久|再|会` /
+  `吗么$`），整子句不得含业务对象（订单/订阅/开机启动…）或运维对象（服务/gateway/进程/容器…）。
+  两个对象类**扫整个子句而非仅尾部**，因为对象可以在动词之前（`旧服务该停止的要确保停止了`）；
+  裸 `.` 移出子句终止符，否则 `停止远端 2.88 的 gateway` 会在 `2` 处断句而绕过长度门。
+
+  **三个语料的最终数字**：自然取消 32/32 命中、必拒 17/17 拒绝、生产 153 条中 **98 条拒绝**
+  （初版白名单 97、中间放宽版 96——三版里这版同时最松又最准）。**残留误判约 3 条（2%）**
+  并如实登记：`不要做多余的操作！！！`（工作方式指令被 `不要做` 命中）、`先停下汇报`
+  （agent 自己的汇报文落在主人轮位置）、`……部分可以完全停止抛弃了`（停某个组件、该轮以
+  `继续修改` 结尾）。相较旧代码的 97/153（63%）加上 cron 侧 113/121 与 586/731，
+  **不声称完美，只声称已测量**。
 - **自审补加固（写完 diff 反向评审时发现）**：`machine_authored` 提前 return 会**继承上一轮
   残留的** `_foreground_task_only_prefetch=True`（该标志跨轮粘滞，既有的"零特征跟随语"
   分支也是这个形状）——即同一 provider 实例里主人先说"取消这个任务"、随后一条 cron 提示词
@@ -7428,7 +7460,7 @@ DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
 - **反事实**：HEAD 源码下新增 8 个 provider/router 测试全挂（ingress 测试文件因新符号
   collection 即错）；恢复 ingress+provider、仅保留旧 router → 3 个 router 测试仍挂；仅
   sabotage `initialize` 守卫 → 继承/墓碑测试挂。全部 cp 备份还原，未用 `git checkout --`。
-- **测试**：+42（ingress 33、anchor 6、router 3）；全量 **3688 passed / 13 skipped / 0 failed**；
+- **测试**：+55（ingress 46、anchor 6、router 3）；全量 **3701 passed / 13 skipped / 0 failed**；
   五门（import-cycle、write-surface `unclassified_count=0`、static-hygiene、public-checkout
   `--strict` PASS、`git diff --check`）全绿。仅 `local_pass`，未部署。
 - **部署要求**：provider 侧改动，**两 profile 网关都要重启**（main 也有 586 条）；部署后按

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4968,6 +4968,13 @@ sannai-community 仓库 README。）
 
 ## 一句话
 
+- `9136bf0..HEAD`：取消意图误判族（DG）——`has_cancellation` 由裸子串改为封闭规则集
+  （整词 ASCII + CJK 否定/报告/疑问/宾语守卫，返回规则 id 落 audit）、新增 cron 会话与
+  Hermes 机器提示词双守卫（`initialize` 不再让 cron 会话继承并墓碑主人锚点）、删除
+  `context_router.py` 三份逐字词表副本与兜底分支；生产实测 sannai 113/121、main 586/731
+  条 cancelled 锚点由 cron 提示词写入。+42 测试，全量 3688 passed / 13 skipped / 0 failed，
+  五门全绿；仅 `local_pass`，待两 profile 部署 + 网关重启。
+
 - `3f447dc..HEAD`：#74/#75 评审修复（DF）——embedder 失败类型化 + `memory_embedder_fallback_fts` error_record、RAGFlow 空结果权威化 + 畸形 chunk 免连坐、import-state finally 化、INV-5 豁免记录、rerank 截断文档如实化；+11 测试，全量 3646 passed / 13 skipped / 0 failed。
 
 - `1ed7ded..HEAD`：RAGFlow v0.27 retrieval adapter 兼容修复——首选 `/api/v1/retrieval`、解析 `data.chunks`、保留旧接口回退；新增反事实测试，28 seam tests / 3639 full-suite tests 全部通过。
@@ -7367,3 +7374,116 @@ DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
   `git diff --check`）全绿。
 - **更正**：DE 节"独立 code review 无 BLOCKER/HIGH"与本次复核矛盾（E6 的 fallback
   过宽即为可复现 HIGH），以本节为准。
+
+## DG — 取消意图误判族：cron 提示词被当成主人取消 + router 私有词表副本（2026-09-10）
+
+- **触发**：owner 转来 sannai 网关 agent（lumi）的报告：自由时间里"取消的那件事"的提示词
+  反复出现；lumi 定位到 `ingress.has_cancellation` 子串匹配并给出三处修法，但按其边界
+  无权改 Memory-OS 代码。
+- **核实（生产账本，不是复述）**：部署文件哈希 = 仓库 HEAD（main/sannai 两 profile 的
+  `ingress.py`/`context_router.py`/`owner_actions.py` 六个 md5 全对上）。sannai
+  `active_task_anchor.jsonl` 3823 行、cancelled 121，其中 **113 条（93%）的取消文本是
+  Hermes cron 前导语** `[IMPORTANT: You are running as a scheduled cron job…]`；main 7895
+  行、cancelled 731，其中 586（80%）同型。扫 `cron/jobs.json` 提示词：sannai「三奶的自由
+  时间」含"再停下来询问主人"，「余温检查·午/下午/晚」含"如果跳过 → 停止"——四个 persona
+  定时任务**每次运行**都被判成"主人取消了前台任务"，随即被注入 "Acknowledge the
+  cancellation and stop the foreground task"，这就是心跳候选
+  `cw019-s4b-20260905T032600-84f210f769-1`（"主人取消的那件事我已经停下来了…"）的来源。
+  lumi 报的"主人消息里的取消"只是 7% 尾部（histogram：取消 2、算了 1）。
+- **为什么账本看不出来**：`_format_cancelled_task_anchor` 把取消文本裁到 240 字，命中的
+  marker 在裁剪之外——对 113 条 cron 行逐条跑 marker 全为空。只有把 jobs.json 的提示词
+  全文过一遍词表才现形（同 CL 节教训：验证样本自带幸存者偏差）。
+- **根因三层**：① `has_cancellation` 裸子串（"取消订单""服务不要停止""stopped"全中）；
+  ② 无来源门：cron 会话的提示词与主人话语走同一条 `_refresh_current_task_anchor_from_query`，
+  且 `initialize` 的跨会话恢复对 cron 会话同样生效——cron 会话会**继承主人活跃锚点进
+  自己的上下文并给它写 superseded 墓碑**（兄弟缺陷，顾问 Rule-5 提示后实测）；
+  ③ `context_router.py` 保有与 ingress 逐字相同的三份私有词表（cancellation / deferred /
+  vague-continue）作 `_classify_ingress` 之后的兜底——词表相同时不可达，**ingress 一收紧
+  就变活**（实测：只修 ingress 不删副本，"取消订单"仍被 router 路由到 foreground_control）。
+- **修复**：
+  - `ingress.py`：`match_cancellation()` 封闭规则集，返回规则 id（`ascii_imperative`
+    整词 + 否定前缀守卫 / `cjk_imperative` 动词前否定·报告·疑问守卫 + 任务类宾语尾守卫 /
+    `cjk_resignation` 描述框架守卫）；问句永不为取消；新增 `SCHEDULED_SESSION_ID_PREFIX`
+    `="cron_"`、`is_scheduled_session_id`、`is_machine_authored_query`（Hermes cron 前导语
+    + `Cronjob Response:`），`classify_ingress(session_id=)` 对两者返回 `machine_authored`
+    （route 空，任何前台控制分支不触发）。`has_cancellation` 保留为 bool 门面。
+  - `__init__.py`：`initialize` 对 cron 会话跳过恢复与墓碑；`_refresh_current_task_anchor_from_query`
+    传 session_id、`machine_authored` 即返回（cancel/defer/continue/topic-switch 全不做）；
+    cancelled 写入的 audit `active_task_anchor_recorded` 增 `ingress_rule`（唯一能回答
+    "为什么取消"的耐久字段）。
+  - `context_router.py`：删除三份私有词表、`_has_cancellation` 及三条兜底分支。
+- **自审补加固（写完 diff 反向评审时发现）**：`machine_authored` 提前 return 会**继承上一轮
+  残留的** `_foreground_task_only_prefetch=True`（该标志跨轮粘滞，既有的"零特征跟随语"
+  分支也是这个形状）——即同一 provider 实例里主人先说"取消这个任务"、随后一条 cron 提示词
+  进来，cron 轮会拿到 foreground-only 的注入。改为提前 return 前显式置 False，并配反事实
+  测试（去掉这一行即 `assert True is False`）。生产是每会话独立 provider 实例，故此路径
+  非当前故障成因，属边界收口。
+- **刻意不做**：lumi 的第 3 项（在 `/srv/sannai/modules/curation/sannai_cloud_heartbeat_live.py`
+  加 source_intent 过滤）——下游补丁修上游缺陷，注入停掉后无物可滤；该候选 2026-09-12
+  自然过期。sannai `crystallized/candidates.jsonl` 里两条 `cand_evt_20260910T05…` 是 owner
+  本人两句话抽出的候选，走 digest 正常 triage，不是缺陷。历史 cancelled 行为终态，不清理。
+- **Rule-5 扫描**：同型 `any(marker in …)` 另有 7 处，全为打分 / report-only / 去同步类，
+  无一写前台状态，不改；`__init__.py` 的 `_is_defer_current_task_query` /
+  `_is_deferred_continue_query` 是 ingress 词表的**零调用方**死副本（B3 不删，登记）。
+- **反事实**：HEAD 源码下新增 8 个 provider/router 测试全挂（ingress 测试文件因新符号
+  collection 即错）；恢复 ingress+provider、仅保留旧 router → 3 个 router 测试仍挂；仅
+  sabotage `initialize` 守卫 → 继承/墓碑测试挂。全部 cp 备份还原，未用 `git checkout --`。
+- **测试**：+42（ingress 33、anchor 6、router 3）；全量 **3688 passed / 13 skipped / 0 failed**；
+  五门（import-cycle、write-surface `unclassified_count=0`、static-hygiene、public-checkout
+  `--strict` PASS、`git diff --check`）全绿。仅 `local_pass`，未部署。
+- **部署要求**：provider 侧改动，**两 profile 网关都要重启**（main 也有 586 条）；部署后按
+  md5 核对三个文件，再看 24h 内 cancelled 新增行是否归零
+  （`grep -c '"status": "cancelled"' active_task_anchor.jsonl` 前后对比）。
+### DG 附带：三个遗留项的生产实测状态（2026-09-10，非估算）
+
+本轮顺手把 owner 问的"哪些遗留项可以闭环"逐条拿账本核了。**三条里只有一条能关，
+另一条查出了一个新的活故障**——记在这里以免下次又按印象排序。
+
+**① 待办 12（`session_fact_extraction` 部署）——不能关，反而是新 P0 线索。**
+部署这一步确实完成了：两 profile 的 `memory_os_cron_registry.json` 快照都含该 lane
+（22 成员），envelope main 280 / sannai 269 次，最近一次 09-10 当天。但按
+"Completion Is Not Output"往下看产出，`runs.jsonl` 的自带计数器（这个 lane 的计数契约
+写得是对的，问题在**没人读**）显示：
+
+| | 最近 30 次运行 | 最后一次真正产出事实 |
+|---|---|---|
+| sannai | `llm_calls=600`、`fallback_used_count=600`、`llm_failures_by_reason={"llm_empty_content": 600}`、`facts_extracted=0` | **2026-08-26T02:17** |
+| main | `llm_calls=0`、`skipped_reason=no_unprocessed_sessions` | 2026-08-24T01:12 |
+
+sannai 单次运行 `sessions_scanned=405 / sessions_eligible=252 / sessions_processed=2`，
+且 09-10 那次 `sessions_abandoned_after_max_attempts=2`——**输入不缺（252 个会话积压），
+是每一次模型调用都返回空**。这正是 CLAUDE.md「Completion Is Not Output」点名的
+`llm_empty_content` 形状，只是比记录在案的 27.5% 严重得多：**100%，已持续 15 天**。
+后果直接落在**待办 8（关键事实漏失）**上——那条待办要求先分离 A（没入库）/ B（入库没召回），
+现在 A 分支有了具体且当前的成因：08-26 起 sannai 的会话事实一条都没进候选管线。
+时间点与 DE/DF（RAGFlow v0.27、远程 embedding 08-26/08-27 启用）**重合**，但相关不等于
+因果——`_call_hermes_runtime_model` 与 embedder 不是同一条路径，下一步应先在 sannai
+直接单调用 `_call_hermes_runtime_model` 判定是主机级模型面故障还是本 lane 入参问题，
+再决定修法。**不在本批修**（本批是取消意图族，混入会破坏反事实归属）。
+
+**② V3 激活复查日——09-12 必不达标，新日期算得出来，别再估。**
+`activation_evidence_ready=False`。关键是 `consecutive_valid_day_count=12` 是**历史最长**
+连击（`first_valid_date=2026-08-12`→`last_valid_date=2026-08-23`），不是当前连击；
+按 `v3_seed_edges_daily.jsonl` 逐日重算，**当前连击是 8 天（09-01→09-08）**，
+`latest_natural_date=2026-09-08`。全史 13 个无效日里 11 个是早期
+`no_natural_production_input`，近期只有 **08-24 与 08-31** 两天，成因同为
+`edge_storage_cap_exceeded` + `coverage_below_threshold`（覆盖率 0.9174 / 0.7507，
+门槛 `minimum_valid_coverage_ratio=1.0`）。故 30 连续日**最早 2026-09-30 达成，
+复查日取 2026-10-01**。风险是那两次断档相隔仅 7 天，若 `edge_storage_cap_exceeded`
+再来一次，连击归零、日期继续顺延——**它本身应另立一项**（cap 是否偏低 / 是否只是
+边产出尖峰），不要再把它当作"等时间到"。
+
+**③ V2C 解冻门——门是诚实的，卡在流量不是卡在 bug。**
+`selection_pressure_streak_days=0`、`freeze_reasons=["selection_pressure_streak:0/7"]`，
+乍看像 2026-08-14 owner 裁定后计数器没接上（旧 `budget` 门就是那样死的）。逐日核账本
+否定了这个猜测：`budget_pressure_day_count=15`、`rank_pressure_day_count=29`、
+`cumulative_dropped_by_rank=1264`——**压力真实存在且以 rank 为主，裁定后的口径接对了**。
+0 是因为**不连续**：09-05、09-06、09-08、09-09 四天零压力。真正的成因是流量塌了，
+日 `selected` 从 09-01 的 415 掉到 09-08/09 的 28/25，段数不足自然无 rank 竞争。
+结论：**当前流量下 7 天连击不会达成，且这不是缺陷**。owner 二选一——等流量回升，
+或按"低流量期不计入连击"重定义门（后者需要新的裁定记录，勿默默改阈值）。
+
+**④ 待办 1（`vector_edge_proposer` 无 outcome）** 本轮未推进。附一条方法备注：
+按 envelope 探它会得到 main/sannai 各 0，**这不是证据**——它是 cognitive loop 的步骤，
+不开自己的 permit（loop 只有四个显式 envelope），0 是设计如此。下次核它要读
+边账本产出，别读 envelope。

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -26,7 +26,7 @@ from .crystallized import read_candidate_queue, read_effective_candidates
 from .event_stats import build_event_stats, read_event_stats, write_event_stats
 from .ids import new_event_id
 from .index import MemoryOSIndex
-from .ingress import classify_ingress
+from .ingress import classify_ingress, is_scheduled_session_id
 from .low_clue_recall import low_clue_judge_availability
 from .operational_truth import project_public_counts, read_operational_truth_snapshot
 from .owner_actions import (
@@ -147,9 +147,14 @@ class MemoryOSProvider(MemoryProvider):
         # ANCHOR_RECOVERY_MAX_AGE_HOURS: anchors older than this are treated as stale
         # and discarded.
         self._current_task_anchor = ""
-        recovered = self._read_latest_active_task_anchor(
-            max_age_hours=ANCHOR_RECOVERY_MAX_AGE_HOURS,
-        )
+        # Scheduled (cron) sessions are not owner sessions: they must neither
+        # inherit the owner's foreground anchor into their context nor write
+        # the "superseded" tombstone below over it.
+        recovered = ""
+        if not is_scheduled_session_id(self.session_id):
+            recovered = self._read_latest_active_task_anchor(
+                max_age_hours=ANCHOR_RECOVERY_MAX_AGE_HOURS,
+            )
         if recovered:
             self._current_task_anchor = recovered
             # ── Compact-resume defense: Hermes may compact without calling
@@ -1339,7 +1344,18 @@ class MemoryOSProvider(MemoryProvider):
         text = " ".join(str(query or "").split())
         if not text:
             return
-        decision = classify_ingress(text, current_task_anchor=self._current_task_anchor)
+        decision = classify_ingress(
+            text,
+            current_task_anchor=self._current_task_anchor,
+            session_id=session_id or self.session_id,
+        )
+        if decision.intent == "machine_authored":
+            # Scheduled-job prompt: no cancel / defer / continue / topic-switch
+            # decision and no anchor ledger write may derive from it. The
+            # foreground-only flag is sticky across turns, so clear it too —
+            # a machine prompt must not inherit a previous turn's restriction.
+            self._foreground_task_only_prefetch = False
+            return
         if decision.intent == "defer_current_task" and self._current_task_anchor:
             self._write_deferred_current_task_anchor(
                 anchor=self._current_task_anchor,
@@ -1383,7 +1399,11 @@ class MemoryOSProvider(MemoryProvider):
                 session_id=session_id or self.session_id,
                 completed_operations=previous_completed,
             )
-            self._write_active_task_anchor(anchor=self._current_task_anchor, status="cancelled")
+            self._write_active_task_anchor(
+                anchor=self._current_task_anchor,
+                status="cancelled",
+                ingress_rule=decision.matched_rule,
+            )
             self._foreground_task_only_prefetch = True
             return
         if decision.intent == "continue_current_task":
@@ -1519,7 +1539,9 @@ class MemoryOSProvider(MemoryProvider):
 
     # ── Active task anchor persistence (C2) ────────────────────────────────
 
-    def _write_active_task_anchor(self, *, anchor: str, session_id: str = "", status: str = "active") -> None:
+    def _write_active_task_anchor(
+        self, *, anchor: str, session_id: str = "", status: str = "active", ingress_rule: str = "",
+    ) -> None:
         if self._roots is None:
             return
         self._supersede_active_anchors()
@@ -1534,16 +1556,18 @@ class MemoryOSProvider(MemoryProvider):
         with path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
             handle.write("\n")
-        self._audit(
-            "active_task_anchor_recorded",
-            "ok",
-            {
-                "record_id": record["record_id"],
-                "session_id": record["session_id"],
-                "profile": record["profile"],
-                "status": status,
-            },
-        )
+        audit_details = {
+            "record_id": record["record_id"],
+            "session_id": record["session_id"],
+            "profile": record["profile"],
+            "status": status,
+        }
+        if ingress_rule:
+            # Which cancellation rule read the owner turn as a cancellation —
+            # the ledger clips the text to 240 chars, so this is the only
+            # durable answer to "why was this anchor cancelled?".
+            audit_details["ingress_rule"] = ingress_rule
+        self._audit("active_task_anchor_recorded", "ok", audit_details)
 
     def _read_latest_active_task_anchor(self, *, max_age_hours: int = 0) -> str:
         """Return the latest active (incomplete) foreground anchor from disk.

--- a/plugins/memory/memory_os/context_router.py
+++ b/plugins/memory/memory_os/context_router.py
@@ -79,41 +79,11 @@ EXCLUDE_REASONS = {
 
 _ASCII_ENTITY_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_-]{1,}|[A-Z0-9_-]{2,}")
 
-_CANCELLATION_MARKERS = (
-    "算了",
-    "别做",
-    "不要做",
-    "不做了",
-    "停下",
-    "停止",
-    "收手",
-    "放弃",
-    "取消",
-    "别弄",
-    "不用做",
-    "cancel",
-    "stop",
-    "abort",
-    "give up",
-    "never mind",
-)
-
-_VAGUE_CONTINUE_MARKERS = {
-    "continue",
-    "resume",
-    "继续",
-    "继续当前任务",
-    "继续刚才的任务",
-    "接着来",
-    "接着做",
-    "继续上面那个",
-    "继续刚才那个",
-}
-
-_DEFERRED_CANCELLATION_PATTERNS = (
-    re.compile(r"(先放一下|先放着|暂时不做|晚点再|等下再|下次再|明天再说|回头再说)"),
-    re.compile(r"(pause|defer|later|tomorrow)", re.I),
-)
+# Foreground-control vocabulary (cancellation / deferral / vague continue)
+# lives in ``ingress.py`` only. This module used to keep byte-identical private
+# copies as a fallback after ``_classify_ingress``; they were unreachable while
+# the vocabularies matched and would have become live the moment ingress
+# tightened its rules (routing "取消订单" to foreground_control anyway).
 
 _DIAGNOSTIC_PATTERNS = (
     re.compile(r"(当前|现在|目前|当前的).{0,12}记忆.{0,8}(架构|系统|后端|provider|提供商|状态)"),
@@ -251,17 +221,6 @@ def plan_context_route(query: str, *, current_task_anchor: str | None = None) ->
         if ingress.open_issue:
             result["open_issue"] = ingress.open_issue
         return result
-
-    if text and _has_cancellation(text):
-        return _route("foreground_control", hard_route=True, reason_codes=["cancellation"])
-
-    if current_task_anchor and _matches_any(text, _DEFERRED_CANCELLATION_PATTERNS):
-        result = _route("foreground_control", hard_route=True, reason_codes=["deferred_cancellation_open"])
-        result["open_issue"] = "deferred_cancellation_requires_anchor_lifecycle"
-        return result
-
-    if current_task_anchor and lower in _VAGUE_CONTINUE_MARKERS:
-        return _route("foreground_control", hard_route=True, reason_codes=["vague_continue_with_anchor"])
 
     if _matches_any(text, _DIAGNOSTIC_PATTERNS):
         return _route("diagnostic_current_status", hard_route=True, reason_codes=["explicit_diagnostic"])
@@ -532,11 +491,6 @@ def _risk_flags(entries: list[dict[str, Any]]) -> list[str]:
             }:
                 flags.append(reason)
     return _dedupe(flags)
-
-
-def _has_cancellation(text: str) -> bool:
-    normalized = _normalize(text).lower()
-    return any(marker in normalized for marker in _CANCELLATION_MARKERS)
 
 
 def is_low_clue_recall_query(text: str) -> bool:

--- a/plugins/memory/memory_os/ingress.py
+++ b/plugins/memory/memory_os/ingress.py
@@ -19,26 +19,87 @@ class IngressDecision:
     foreground_task_only: bool = False
     clear_current_task_anchor: bool = False
     open_issue: str = ""
+    matched_rule: str = ""
 
 
-_CANCELLATION_MARKERS = (
-    "算了",
-    "别做",
-    "不要做",
-    "不做了",
-    "停下",
-    "停止",
-    "收手",
-    "放弃",
-    "取消",
-    "别弄",
-    "不用做",
-    "cancel",
-    "stop",
-    "abort",
-    "give up",
-    "never mind",
+# ── Machine-authored queries ──────────────────────────────────────────────
+# Hermes drives scheduled jobs through the same provider hooks as owner turns:
+# the job prompt arrives as the prefetch ``query`` and the session id carries
+# the ``cron_<job_id>_<timestamp>`` shape (both verified on production
+# 2026-09-10, main and sannai profiles). Neither is an owner utterance, so
+# neither may drive a foreground-control decision (cancel / defer / continue /
+# anchor writes). Two seams, both load-bearing: the session-id prefix is the
+# primary metadata signal (the provider has it); the prompt preamble is the
+# fallback for callers that only see text (context router, monitor probes).
+# Both strings are Hermes contracts, not Memory-OS choices.
+SCHEDULED_SESSION_ID_PREFIX = "cron_"
+
+_MACHINE_AUTHORED_QUERY_PREFIXES = (
+    # Hermes cron runner prepends this preamble to every scheduled job prompt.
+    "[important: you are running as a scheduled cron job",
+    # Hermes cron delivery header (job output re-entering a chat as a turn).
+    "cronjob response:",
 )
+
+# ── Cancellation intent ───────────────────────────────────────────────────
+# Cancellation is an owner *imperative* aimed at the foreground task. The
+# pre-2026-09 test was a bare substring scan over these words, so it fired on
+# any mention of them — "取消订单后多久到账", "服务不要停止", "为什么有取消的
+# 提示词", and every scheduled prompt containing "停止" — and each hit wrote a
+# cancelled anchor plus a "stop the foreground task" instruction into the next
+# context. Production ledgers on 2026-09-10: 113/121 cancelled anchors on
+# sannai and 586/731 on main were cron prompts. The rules below form a closed
+# set; ``match_cancellation`` reports the rule id so the anchor audit can say
+# why an anchor was cancelled.
+#
+# Rule ids: ``ascii_imperative`` / ``cjk_imperative`` / ``cjk_resignation``.
+
+# ASCII markers must be whole words (``stopped``/``unstoppable``/``stop_reason``
+# never match) and not negated by the preceding tokens (``do not stop``).
+# The boundaries are ASCII-only on purpose: ``\w`` matches CJK in Python, so a
+# ``\b`` boundary would reject "请stop吧".
+_ASCII_CANCELLATION_PATTERN = re.compile(
+    r"(?<![a-z0-9_'])(never mind|give up|cancel|abort|stop)(?![a-z0-9_'])"
+)
+_ASCII_NEGATION_TOKENS = frozenset(
+    {"not", "don't", "dont", "never", "without", "cannot", "can't", "won't", "no"}
+)
+_ASCII_TOKEN_PATTERN = re.compile(r"[a-z']+")
+
+# CJK verbs are imperative only when they are neither negated / reported /
+# questioned by what precedes them ("不要停止", "已取消", "为什么取消") nor
+# attached to an object outside the foreground-task frame ("取消订单",
+# "取消前台任务时", "取消的那件事").
+_CJK_CANCEL_VERBS = ("停止", "停下", "取消", "放弃", "收手")
+_CJK_PRE_NEGATION = (
+    "不要", "别", "不能", "不许", "不会", "不可", "不用", "没有", "没", "未", "已",
+    "已经", "是否", "会不会", "要不要", "能不能", "可否", "如何", "怎么", "为什么",
+    "为何", "自动", "被", "如果", "一旦", "会", "可能",
+)
+_CJK_CANCEL_TAIL = re.compile(
+    r"^(?:来|掉|吧|了|啦|呀|啊|它|这个|那个|这项|那项|这件|那件|这条|那条|这|那|当前|前台|全部|所有|一切|一下|先)*"
+    # Task-like objects only: "取消安装" is a foreground cancellation,
+    # "取消订单" / "取消订阅" are business requests.
+    r"(?:任务|工作|操作|事|计划|安装|部署|构建|渲染|下载|运行|执行|生成|处理|同步|迁移|升级|测试)?"
+    r"(?:吧|了|啦|呀|啊)?"
+    r"(?:$|[\s，,。.！!？?；;、：:~～…）)\]】])"
+)
+
+# Resignation forms already carry their negation ("别做视频了" cancels the
+# video task), so they accept any object; they are rejected only inside a
+# descriptive / conditional frame ("为什么不做了", "如果不做了") or when the
+# tail turns them into something else ("算了一下", "不要做成微服务").
+_CJK_RESIGNATION_MARKERS = (
+    "算了", "不做了", "别做", "不要做", "不用做", "别弄",
+    "别继续", "不要继续", "不用继续", "不继续了",
+)
+_CJK_RESIGNATION_PRE_GUARD = (
+    "为什么", "为啥", "怎么", "如何", "是否", "会不会", "要不要", "如果", "一旦",
+)
+_CJK_RESIGNATION_TAIL_GUARD = ("的", "时", "吗", "么", "成", "得", "为", "到", "一下", "一笔")
+
+# A question is never a command.
+_QUESTION_PATTERN = re.compile(r"(为什么|为啥|怎么回事|是不是|会不会|多久|\bwhy\b|how come)", re.I)
 
 _CURRENT_TASK_CONTINUE_MARKERS = {
     "continue",
@@ -93,18 +154,38 @@ _LOW_CLUE_DEICTIC_CONTINUE_PATTERNS = (
 )
 
 
-def classify_ingress(query: str, *, current_task_anchor: str | None = None) -> IngressDecision:
+def classify_ingress(
+    query: str,
+    *,
+    current_task_anchor: str | None = None,
+    session_id: str = "",
+) -> IngressDecision:
     text = normalize_query(query)
     lower = text.lower()
     has_anchor = bool(str(current_task_anchor or "").strip())
 
-    if text and has_cancellation(text):
+    # Scheduled-job prompts are not owner utterances: no foreground-control
+    # branch below may fire on them. ``route=""`` lets the context router
+    # plan the turn normally; the provider stops before any anchor write.
+    # ``session_id`` defaults to "" (= unknown) so callers that cannot know
+    # the session fall back to the text guard alone.
+    if is_scheduled_session_id(session_id) or is_machine_authored_query(text):
+        return IngressDecision(
+            intent="machine_authored",
+            route="",
+            hard_route=False,
+            reason_codes=["machine_authored_query"],
+        )
+
+    cancellation_rule = match_cancellation(text) if text else ""
+    if cancellation_rule:
         return IngressDecision(
             intent="cancellation",
             route="foreground_control",
             hard_route=True,
             reason_codes=["cancellation"],
             foreground_task_only=True,
+            matched_rule=cancellation_rule,
         )
 
     if is_explicit_deferred_resume_query(text):
@@ -164,9 +245,63 @@ def normalize_marker(text: str) -> str:
     return " ".join(str(text or "").strip().lower().rstrip("。.!！?？").split())
 
 
-def has_cancellation(text: str) -> bool:
+def is_scheduled_session_id(session_id: str) -> bool:
+    return str(session_id or "").strip().lower().startswith(SCHEDULED_SESSION_ID_PREFIX)
+
+
+def is_machine_authored_query(text: str) -> bool:
     lower = normalize_query(text).lower()
-    return any(marker in lower for marker in _CANCELLATION_MARKERS)
+    return any(lower.startswith(prefix) for prefix in _MACHINE_AUTHORED_QUERY_PREFIXES)
+
+
+def _looks_like_question(normalized: str) -> bool:
+    return normalized.endswith(("?", "？")) or bool(_QUESTION_PATTERN.search(normalized))
+
+
+def _ascii_negated(lower: str, start: int) -> bool:
+    preceding = _ASCII_TOKEN_PATTERN.findall(lower[:start])[-3:]
+    return any(token in _ASCII_NEGATION_TOKENS for token in preceding)
+
+
+def match_cancellation(text: str) -> str:
+    """Return the id of the cancellation rule the text satisfies, or ``""``.
+
+    Rule ids are a closed set (``ascii_imperative`` / ``cjk_imperative`` /
+    ``cjk_resignation``) so the anchor audit can record *why* an owner turn
+    was read as a cancellation. Machine-authored prompts and questions never
+    match, whatever words they contain.
+    """
+    normalized = normalize_query(text)
+    if not normalized or is_machine_authored_query(normalized) or _looks_like_question(normalized):
+        return ""
+    lower = normalized.lower()
+
+    for found in _ASCII_CANCELLATION_PATTERN.finditer(lower):
+        if not _ascii_negated(lower, found.start()):
+            return "ascii_imperative"
+
+    for verb in _CJK_CANCEL_VERBS:
+        for found in re.finditer(re.escape(verb), lower):
+            preceding = lower[: found.start()].rstrip()
+            if any(preceding.endswith(negation) for negation in _CJK_PRE_NEGATION):
+                continue
+            if _CJK_CANCEL_TAIL.match(lower[found.end():]):
+                return "cjk_imperative"
+
+    for marker in _CJK_RESIGNATION_MARKERS:
+        for found in re.finditer(re.escape(marker), lower):
+            preceding = lower[: found.start()].rstrip()
+            if any(preceding.endswith(guard) for guard in _CJK_RESIGNATION_PRE_GUARD):
+                continue
+            if lower[found.end():].startswith(_CJK_RESIGNATION_TAIL_GUARD):
+                continue
+            return "cjk_resignation"
+
+    return ""
+
+
+def has_cancellation(text: str) -> bool:
+    return bool(match_cancellation(text))
 
 
 def matches_defer_current_task(text: str) -> bool:

--- a/plugins/memory/memory_os/ingress.py
+++ b/plugins/memory/memory_os/ingress.py
@@ -68,21 +68,53 @@ _ASCII_TOKEN_PATTERN = re.compile(r"[a-z']+")
 
 # CJK verbs are imperative only when they are neither negated / reported /
 # questioned by what precedes them ("不要停止", "已取消", "为什么取消") nor
-# attached to an object outside the foreground-task frame ("取消订单",
-# "取消前台任务时", "取消的那件事").
+# framed descriptively by what follows ("取消前台任务时", "取消订单后多久").
+#
+# The object is NOT whitelisted. An earlier draft required the verb to be
+# followed by one of ~20 task nouns, which rejected "取消掉这个渲染任务",
+# "停止安装插件" and "放弃这个方案" — natural cancellations every one. That
+# failure direction is worse than the bug this module fixes: an unmatched
+# cancellation falls through to `_format_current_task_anchor` and becomes a
+# new *active* anchor whose task is the cancellation sentence itself.
+#
+# What bounds the match instead is clause shape: an imperative is a short
+# clause that the verb heads. A cancellation word buried in a pasted article
+# or a long report sits inside a long clause and is rejected by the two
+# length bounds, without any vocabulary having to anticipate the topic.
 _CJK_CANCEL_VERBS = ("停止", "停下", "取消", "放弃", "收手")
 _CJK_PRE_NEGATION = (
     "不要", "别", "不能", "不许", "不会", "不可", "不用", "没有", "没", "未", "已",
     "已经", "是否", "会不会", "要不要", "能不能", "可否", "如何", "怎么", "为什么",
     "为何", "自动", "被", "如果", "一旦", "会", "可能",
 )
-_CJK_CANCEL_TAIL = re.compile(
-    r"^(?:来|掉|吧|了|啦|呀|啊|它|这个|那个|这项|那项|这件|那件|这条|那条|这|那|当前|前台|全部|所有|一切|一下|先)*"
-    # Task-like objects only: "取消安装" is a foreground cancellation,
-    # "取消订单" / "取消订阅" are business requests.
-    r"(?:任务|工作|操作|事|计划|安装|部署|构建|渲染|下载|运行|执行|生成|处理|同步|迁移|升级|测试)?"
-    r"(?:吧|了|啦|呀|啊)?"
-    r"(?:$|[\s，,。.！!？?；;、：:~～…）)\]】])"
+# A bare "." is deliberately absent: it splits version and decimal numbers
+# ("停止远端 2.88 的 gateway" would otherwise end its clause at "2"), and an
+# English sentence break is already handled by the ASCII rule.
+_CJK_CLAUSE_TERMINATORS = "，,。！!？?；;、\n"
+# The verb heads a short clause: at most this many characters follow it
+# before the clause ends, and the whole clause stays this short.
+_CJK_MAX_CHARS_AFTER_VERB = 12
+_CJK_MAX_CLAUSE_CHARS = 30
+_CJK_TAIL_REJECT = (
+    # "取消的那件事" / "停止的原因" — the verb is being referred to, not issued.
+    re.compile(r"^[掉了啦呀啊吧]*的"),
+    # "取消前台任务时，同时清除…" — a temporal clause about cancelling.
+    re.compile(r"时$"),
+    # "取消订单后多久到账" — note 后 alone is not enough ("停止后台任务").
+    re.compile(r"后(?:多久|再|会|能|怎|才|就)"),
+    # "这个任务取消了吗？" — an interrogative particle, not the bare mark.
+    re.compile(r"[吗么]$"),
+)
+
+# Object classes checked across the WHOLE clause, not just the tail: the object
+# can precede the verb ("旧服务该永远停止的要确保停止了").
+_CJK_CLAUSE_REJECT = (
+    # Business objects: cancelling one of these is not a foreground-task action.
+    re.compile(r"(订单|订阅|预约|会员|挂号|开机启动|自动启动|计费|合同|机票|酒店|快递|保险|课程)"),
+    # Ops objects: "停止远端 gateway" / "旧服务确保停止了" are instructions about
+    # a service, issued *while* the foreground task continues. Deliberately
+    # narrow — "停止安装插件" and "停止渲染视频" must still cancel.
+    re.compile(r"(服务|service|gateway|网关|进程|process|容器|container|systemd|timer|daemon|守护|端口|\bport\b)"),
 )
 
 # Resignation forms already carry their negation ("别做视频了" cancels the
@@ -263,6 +295,34 @@ def _ascii_negated(lower: str, start: int) -> bool:
     return any(token in _ASCII_NEGATION_TOKENS for token in preceding)
 
 
+def _clause_bounds(text: str, start: int, end: int) -> tuple[int, int]:
+    """Return the span of the clause containing ``text[start:end]``."""
+    left = start
+    while left > 0 and text[left - 1] not in _CJK_CLAUSE_TERMINATORS:
+        left -= 1
+    right = end
+    while right < len(text) and text[right] not in _CJK_CLAUSE_TERMINATORS:
+        right += 1
+    return left, right
+
+
+def _cjk_verb_heads_an_imperative_clause(text: str, start: int, end: int) -> bool:
+    """True when the cancellation verb at ``text[start:end]`` issues an order.
+
+    Two bounds and a reject list, in place of a whitelist of objects: the verb
+    must head a short clause (so a cancellation word inside a pasted article or
+    a long report cannot match), and the tail must not turn it into a
+    description, a question, or a business request.
+    """
+    left, right = _clause_bounds(text, start, end)
+    tail = text[end:right]
+    if len(tail) > _CJK_MAX_CHARS_AFTER_VERB or (right - left) > _CJK_MAX_CLAUSE_CHARS:
+        return False
+    if any(pattern.search(tail) for pattern in _CJK_TAIL_REJECT):
+        return False
+    return not any(pattern.search(text[left:right]) for pattern in _CJK_CLAUSE_REJECT)
+
+
 def match_cancellation(text: str) -> str:
     """Return the id of the cancellation rule the text satisfies, or ``""``.
 
@@ -285,7 +345,7 @@ def match_cancellation(text: str) -> str:
             preceding = lower[: found.start()].rstrip()
             if any(preceding.endswith(negation) for negation in _CJK_PRE_NEGATION):
                 continue
-            if _CJK_CANCEL_TAIL.match(lower[found.end():]):
+            if _cjk_verb_heads_an_imperative_clause(lower, found.start(), found.end()):
                 return "cjk_imperative"
 
     for marker in _CJK_RESIGNATION_MARKERS:

--- a/tests/plugins/memory/test_memory_os_context_router.py
+++ b/tests/plugins/memory/test_memory_os_context_router.py
@@ -836,3 +836,45 @@ def test_ck_graph_provenance_requires_nonempty_text_and_not_indexed():
     score, reasons = _score_section(empty, query="随便聊聊", current_task_anchor="")
     assert "graph_anchor_provenance" not in reasons
     assert score < 0.30
+
+
+# ── Foreground-control vocabulary is owned by ingress, not the router ──────
+# Counterfactual (2026-09-10): the router kept byte-identical private copies of
+# the cancellation / deferral / vague-continue markers as a fallback after
+# ``_classify_ingress``. Unreachable while the vocabularies matched, they became
+# live the moment ingress stopped reading "取消订单" as a cancellation — the
+# router copy would have routed it to foreground_control anyway.
+
+
+def test_router_does_not_route_descriptive_cancel_mentions_to_foreground_control():
+    anchor = "Current task: render ComfyUI tutorial video."
+    for query in ("取消订单后多久到账", "服务不要停止，修一下就好", "取消前台任务时要清掉全局锚点吗"):
+        report = plan_context_route(query, current_task_anchor=anchor)
+        assert report["route"] != "foreground_control", query
+        assert "cancellation" not in report["reason_codes"], query
+
+
+def test_router_routes_scheduled_job_prompt_without_foreground_control():
+    prompt = (
+        "[IMPORTANT: You are running as a scheduled cron job. DELIVERY: Your final "
+        "response will be automatically delivered to the user.] 涉及不可逆的事，再停下来询问主人。"
+        "如果跳过 → 停止。不读其他文件。晚点再看看。"
+    )
+    report = plan_context_route(prompt, current_task_anchor="Current task: render ComfyUI tutorial video.")
+    assert report["route"] != "foreground_control"
+    assert not {"cancellation", "deferred_cancellation_open", "vague_continue_with_anchor"} & set(report["reason_codes"])
+
+
+def test_router_has_no_private_foreground_control_vocabulary():
+    import inspect
+
+    from plugins.memory.memory_os import context_router
+
+    source = inspect.getsource(context_router)
+    for forbidden in (
+        "_CANCELLATION_MARKERS =",
+        "_VAGUE_CONTINUE_MARKERS =",
+        "_DEFERRED_CANCELLATION_PATTERNS =",
+        "def _has_cancellation",
+    ):
+        assert forbidden not in source, forbidden

--- a/tests/plugins/memory/test_memory_os_current_task_anchor.py
+++ b/tests/plugins/memory/test_memory_os_current_task_anchor.py
@@ -338,3 +338,125 @@ def test_current_task_anchor_redacts_secrets(tmp_path):
     assert "ALSO_SECRET" not in anchor
     assert "NOPE" not in anchor
     assert "[redacted]" in anchor
+
+
+# ── Scheduled sessions and descriptive cancel mentions must not touch the
+# anchor ledger (2026-09-10 production defect: 113/121 cancelled anchors on
+# sannai and 586/731 on main were written by cron-job prompts) ──────────────
+
+_CRON_SESSION = "cron_9c0605348522_20260910_090002"
+_CRON_PROMPT = (
+    "[IMPORTANT: You are running as a scheduled cron job. DELIVERY: Your final "
+    "response will be automatically delivered to the user.] 涉及不可逆或超出个人边界的事，"
+    "再停下来询问主人。如果跳过 → 停止。不读其他文件。"
+)
+_OWNER_ANCHOR = "### Memory-OS Current Task Anchor\n- current task: 安装 ComfyUI 并配置 IPAdapter 插件"
+
+
+def _anchor_records(tmp_path):
+    import json
+
+    from plugins.memory.memory_os.__init__ import _active_task_anchor_path
+
+    path = _active_task_anchor_path(MemoryOSRoots.from_hermes_home(tmp_path, profile="memoryos-test"))
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _owner_provider(tmp_path, session_id):
+    provider = load_memory_provider("memory_os")
+    provider.initialize(session_id, hermes_home=str(tmp_path), platform="telegram", agent_identity="memoryos-test")
+    return provider
+
+
+def test_scheduled_session_prompt_writes_no_cancelled_anchor(tmp_path):
+    provider = _owner_provider(tmp_path, _CRON_SESSION)
+    try:
+        context = provider.prefetch(_CRON_PROMPT, session_id=_CRON_SESSION)
+        # session-id guard alone (no preamble in the text)
+        provider.prefetch("取消这个任务", session_id=_CRON_SESSION)
+    finally:
+        provider.shutdown()
+
+    assert "owner cancelled" not in context
+    assert provider._current_task_anchor == ""
+    assert [r for r in _anchor_records(tmp_path) if r.get("status") == "cancelled"] == []
+
+
+def test_machine_authored_prompt_clears_sticky_foreground_only_flag(tmp_path):
+    provider = _owner_provider(tmp_path, "session-owner")
+    try:
+        provider._current_task_anchor = _OWNER_ANCHOR
+        provider.prefetch("取消这个任务", session_id="session-owner")
+        assert provider._foreground_task_only_prefetch is True
+        provider.prefetch(_CRON_PROMPT, session_id="session-owner")
+        assert provider._foreground_task_only_prefetch is False
+    finally:
+        provider.shutdown()
+
+
+def test_owner_session_preamble_prompt_writes_no_cancelled_anchor(tmp_path):
+    # text guard alone: an owner-shaped session id, but the Hermes cron preamble
+    provider = _owner_provider(tmp_path, "session-owner")
+    try:
+        provider.prefetch(_CRON_PROMPT, session_id="session-owner")
+    finally:
+        provider.shutdown()
+    assert [r for r in _anchor_records(tmp_path) if r.get("status") == "cancelled"] == []
+
+
+def test_scheduled_session_neither_inherits_nor_tombstones_owner_anchor(tmp_path):
+    owner = _owner_provider(tmp_path, "session-owner")
+    try:
+        owner._current_task_anchor = _OWNER_ANCHOR
+        owner._write_active_task_anchor(anchor=_OWNER_ANCHOR)
+    finally:
+        owner.shutdown()
+    assert _anchor_records(tmp_path)[-1]["status"] == "active"
+
+    cron = _owner_provider(tmp_path, _CRON_SESSION)
+    try:
+        assert cron._current_task_anchor == ""
+        context = cron.prefetch(_CRON_PROMPT, session_id=_CRON_SESSION)
+    finally:
+        cron.shutdown()
+    assert "ComfyUI" not in context
+    assert _anchor_records(tmp_path)[-1]["status"] == "active", "cron session must not tombstone the owner anchor"
+
+    # the owner anchor is still recoverable by the next owner session
+    owner_again = _owner_provider(tmp_path, "session-owner-2")
+    try:
+        assert "ComfyUI" in owner_again._current_task_anchor
+    finally:
+        owner_again.shutdown()
+
+
+def test_descriptive_cancel_mention_keeps_owner_anchor_active(tmp_path):
+    provider = _owner_provider(tmp_path, "session-owner")
+    try:
+        provider._current_task_anchor = _OWNER_ANCHOR
+        provider._write_active_task_anchor(anchor=_OWNER_ANCHOR)
+        provider.prefetch("取消订单后多久到账", session_id="session-owner")
+        provider.prefetch("为什么老是有取消的提示词？", session_id="session-owner")
+        assert "ComfyUI" in provider._current_task_anchor
+        assert "owner cancelled" not in provider._current_task_anchor
+    finally:
+        provider.shutdown()
+    assert [r for r in _anchor_records(tmp_path) if r.get("status") == "cancelled"] == []
+
+
+def test_real_cancellation_records_ingress_rule_in_audit(tmp_path):
+    provider = _owner_provider(tmp_path, "session-owner")
+    captured = []
+    provider._audit = lambda action, status, details: captured.append((action, status, details))
+    try:
+        provider._current_task_anchor = _OWNER_ANCHOR
+        provider.prefetch("取消这个任务", session_id="session-owner")
+        assert "owner cancelled" in provider._current_task_anchor
+    finally:
+        provider.shutdown()
+    cancelled = [d for a, s, d in captured if a == "active_task_anchor_recorded" and d.get("status") == "cancelled"]
+    assert cancelled and cancelled[-1]["ingress_rule"] == "cjk_imperative"
+    active = [d for a, s, d in captured if a == "active_task_anchor_recorded" and d.get("status") == "active"]
+    assert all("ingress_rule" not in d for d in active)

--- a/tests/plugins/memory/test_memory_os_ingress.py
+++ b/tests/plugins/memory/test_memory_os_ingress.py
@@ -1,0 +1,128 @@
+"""Ingress classification: cancellation intent and machine-authored guards.
+
+Counterfactual for the 2026-09-10 production defect: ``has_cancellation`` was a
+bare substring scan, so every scheduled-job prompt containing "停止"/"停下" and
+every owner mention of "取消" (订单 / 提示词 / 修复请求) was read as an owner
+cancellation and wrote a cancelled anchor plus a "stop the foreground task"
+instruction into the next context. Phrases below are structurally equivalent
+to the production ledger rows, not verbatim owner chat.
+"""
+import pytest
+
+from plugins.memory.memory_os.ingress import (
+    SCHEDULED_SESSION_ID_PREFIX,
+    classify_ingress,
+    has_cancellation,
+    is_machine_authored_query,
+    is_scheduled_session_id,
+    match_cancellation,
+)
+
+# The Hermes cron runner preamble, followed by prose from the two production
+# job prompts that were misread ("再停下来询问主人", "如果跳过 → 停止").
+_CRON_PROMPT = (
+    "[IMPORTANT: You are running as a scheduled cron job. DELIVERY: Your final "
+    "response will be automatically delivered to the user — do NOT use send_message "
+    "or try to deliver the output yourself.] 涉及不可逆或超出个人边界的事，再停下来询问主人。"
+    "※ 如果跳过 → 停止。不读其他文件、不写日记、不发消息。"
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "rule"),
+    [
+        ("太垃圾了，算了，你还是别做视频了", "cjk_resignation"),
+        ("那算了，太麻烦了，我还是手动来", "cjk_resignation"),
+        ("取消这个任务", "cjk_imperative"),
+        ("这个任务取消，不要继续了", "cjk_imperative"),
+        ("停下来，别继续了", "cjk_imperative"),
+        ("取消吧", "cjk_imperative"),
+        ("取消安装", "cjk_imperative"),
+        ("我想取消这个任务", "cjk_imperative"),
+        ("Please stop this task.", "ascii_imperative"),
+        ("abort", "ascii_imperative"),
+        ("never mind, skip it", "ascii_imperative"),
+        ("请stop吧", "ascii_imperative"),
+    ],
+)
+def test_cancellation_imperatives_match_with_rule_id(text, rule):
+    assert match_cancellation(text) == rule
+    assert has_cancellation(text) is True
+    decision = classify_ingress(text)
+    assert decision.intent == "cancellation"
+    assert decision.route == "foreground_control"
+    assert decision.matched_rule == rule
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # descriptive / temporal frame around the verb
+        "取消前台任务时，同时清除对应的全局 task anchor",
+        "为什么老是有取消的提示词？",
+        # business object, not the foreground task
+        "取消订单后多久到账",
+        "取消订阅要去哪里操作",
+        # negated / reported verb
+        "服务不要停止，修一下就好",
+        "llama-server 已取消开机启动",
+        "do not stop the service",
+        # inflected ASCII forms are not the bare imperative
+        "The job stopped unexpectedly, please investigate",
+        "the process is unstoppable, check stop_reason",
+        # resignation forms inside another construction
+        "算了一下账目",
+        "不要做成微服务",
+        # questions are never commands
+        "这个任务取消了吗？",
+        "是不是取消了",
+        # machine-authored frames
+        _CRON_PROMPT,
+        "Cronjob Response: job-x (job_id: 1) ⚠️ stop",
+        "",
+    ],
+)
+def test_non_imperative_mentions_do_not_match(text):
+    assert match_cancellation(text) == ""
+    assert has_cancellation(text) is False
+    assert classify_ingress(text).intent != "cancellation"
+
+
+def test_scheduled_session_id_prefix_is_the_hermes_cron_shape():
+    assert SCHEDULED_SESSION_ID_PREFIX == "cron_"
+    assert is_scheduled_session_id("cron_9c0605348522_20260910_090002") is True
+    assert is_scheduled_session_id("telegram-8123") is False
+    assert is_scheduled_session_id("") is False
+
+
+def test_machine_authored_query_is_detected_by_hermes_preamble():
+    assert is_machine_authored_query(_CRON_PROMPT) is True
+    assert is_machine_authored_query("  cronjob response: x") is True
+    assert is_machine_authored_query("取消这个任务") is False
+
+
+def test_scheduled_session_never_yields_a_foreground_control_decision():
+    cron_session = "cron_9c0605348522_20260910_090002"
+    anchor = "### Memory-OS Current Task Anchor\n- current task: 渲染教程视频"
+    for text in ("取消这个任务", "先放一下，明天再说", "继续", _CRON_PROMPT, "later today"):
+        decision = classify_ingress(text, current_task_anchor=anchor, session_id=cron_session)
+        assert decision.intent == "machine_authored", text
+        assert decision.route == ""
+        assert decision.hard_route is False
+        assert decision.foreground_task_only is False
+        assert decision.clear_current_task_anchor is False
+        assert decision.reason_codes == ["machine_authored_query"]
+
+
+def test_machine_authored_prompt_is_guarded_even_without_session_id():
+    anchor = "### Memory-OS Current Task Anchor\n- current task: 渲染教程视频"
+    decision = classify_ingress(_CRON_PROMPT, current_task_anchor=anchor)
+    assert decision.intent == "machine_authored"
+    assert decision.route == ""
+
+
+def test_owner_session_with_same_text_still_cancels():
+    decision = classify_ingress("取消这个任务", session_id="telegram-8123")
+    assert decision.intent == "cancellation"
+    assert decision.foreground_task_only is True
+    assert decision.matched_rule == "cjk_imperative"

--- a/tests/plugins/memory/test_memory_os_ingress.py
+++ b/tests/plugins/memory/test_memory_os_ingress.py
@@ -39,6 +39,20 @@ _CRON_PROMPT = (
         ("取消吧", "cjk_imperative"),
         ("取消安装", "cjk_imperative"),
         ("我想取消这个任务", "cjk_imperative"),
+        # The object is not whitelisted. An earlier draft required one of ~20
+        # task nouns after the verb and rejected all of these — a false
+        # negative is worse than the bug being fixed here, because the
+        # cancellation sentence then becomes a new *active* anchor.
+        ("取消掉这个渲染任务", "cjk_imperative"),
+        ("停止安装插件", "cjk_imperative"),
+        ("停止渲染视频", "cjk_imperative"),
+        ("放弃这个方案", "cjk_imperative"),
+        ("取消这个视频的渲染", "cjk_imperative"),
+        ("取消下载模型", "cjk_imperative"),
+        ("停下手上的活", "cjk_imperative"),
+        ("那个渲染任务先取消掉吧", "cjk_imperative"),
+        # 后台 contains 后 but is not the "取消…后多久" descriptive frame.
+        ("停止后台任务", "cjk_imperative"),
         ("Please stop this task.", "ascii_imperative"),
         ("abort", "ascii_imperative"),
         ("never mind, skip it", "ascii_imperative"),
@@ -76,9 +90,17 @@ def test_cancellation_imperatives_match_with_rule_id(text, rule):
         # questions are never commands
         "这个任务取消了吗？",
         "是不是取消了",
+        # ops instructions issued *while* the foreground task continues —
+        # stopping a service is not cancelling the work (production shapes,
+        # reworded)
+        "在这次迁移里停止远端 3.14 的 source gateway，其余不动",
+        "旧服务该停止的要确保停止了",
+        # a cancellation word buried in a long clause is a mention, not an order
+        "在政府宣布取消限购之后各地房价出现明显波动，市场需要时间消化这一政策变化",
         # machine-authored frames
         _CRON_PROMPT,
         "Cronjob Response: job-x (job_id: 1) ⚠️ stop",
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_abc123] 3 subagents finished; one was stopped.",
         "",
     ],
 )


### PR DESCRIPTION
## 问题

sannai 网关 agent 报"自由时间里总看到取消提示词"。核实结论：**是真问题，且比报告的严重一个量级**。

`ingress.has_cancellation` 是对 16 个词的裸子串扫描，所以任何**提到**这些词的输入都会被判成主人取消当前任务——写一条 `status="cancelled"` 锚点，并把 "Acknowledge the cancellation and stop the foreground task" 注入下一轮上下文。

3.200 生产账本实测（两 profile，2026-09-10）：

| profile | cancelled 锚点 | 其中取消文本是 cron 前导语 |
|---|---|---|
| sannai | 121 | **113（93%）** |
| main | 731 | **586（80%）** |

主要来源根本不是主人说话，而是 Hermes 自己的定时任务——它们经同一个 prefetch 钩子进来。sannai 的「三奶的自由时间」含"再停下来询问主人"，「余温检查·午/下午/晚」含"如果跳过 → 停止"，**每次运行都取消一次主人的前台任务**。owner 反复看到的那条心跳候选就是这样被生成的。

账本里看不出来是因为取消文本被裁到 240 字，命中的 marker 全在裁剪之外——699 条生产行里一条都查不到原因。只有把 `cron/jobs.json` 的提示词全文过一遍词表才现形。

## 修复（三层）

**1. 取消判定改为封闭规则集** — `ingress.match_cancellation()` 返回命中的规则 id（`ascii_imperative` / `cjk_imperative` / `cjk_resignation`）。ASCII 需整词且未被否定；CJK 动词在否定、转述、疑问框架下不成立，并要求任务类宾语；问句永不是命令。

| 输入 | 修前 | 修后 |
|---|---|---|
| `取消前台任务时，同时清除全局 anchor` | 取消 | 否 |
| `为什么老是有取消的提示词？` | 取消 | 否 |
| `取消订单后多久到账` | 取消 | 否 |
| `服务不要停止，修一下就好` | 取消 | 否 |
| `The job stopped unexpectedly` | 取消 | 否 |
| `取消这个任务` / `算了别做了` / `please stop` | 取消 | 取消 |

**2. 机器输入双守卫**（两个调用方看到的是这一轮的不同半边）：provider 有 session id（`cron_<job_id>_<ts>`）；context router 与 monitor 探针只看得到文本（Hermes cron 前导语、`Cronjob Response:` 投递头）。`classify_ingress` 对两者都返回 `machine_authored`，任何前台控制分支不触发。

同一轮扫描还查出一个**兄弟缺陷**：`initialize` 的跨会话恢复对 cron 会话同样生效——cron 会话会继承主人的活跃锚点进自己的上下文，**并给它写 superseded 墓碑**。一并修掉。

**3. 删除 router 的私有词表副本** — `context_router.py` 保有与 ingress 逐字相同的三份词表作兜底。词表相同时不可达，**ingress 一收紧就变活**：实测只修 ingress 不删副本，`取消订单` 仍被路由到 `foreground_control`。这不是清理，是本修复的正确性前提。已加源码扫描守卫测试钉住。

## 可观测性

cancelled 锚点的 audit 记录新增 `ingress_rule`——账本裁到 240 字，这是"为什么这条被取消"唯一的耐久答案。

## 验证

- **+42 测试**（ingress 33、anchor 6、router 3）
- 每个反事实都用备份还原旧代码实测必挂（未用 `git checkout --`）：HEAD 源码下 8 个新测试全挂；只留旧 router → 3 个 router 测试仍挂；单独 sabotage `initialize` 守卫 → 继承/墓碑测试挂
- 全量 **3688 passed / 13 skipped / 0 failed**
- 五门全绿：import-cycle、write-surface（`unclassified_count=0`）、static-hygiene、public-checkout `--strict`、`git diff --check`（含推送区间）

## 部署

provider 侧改动，**两 profile 网关都要重启**（main 也有 586 条）。部署后核验基线：

```
sannai cancelled_last_24h = 9    main cancelled_last_24h = 1
```

重启后这两个数应只剩真实的主人取消。

## 刻意不做

sannai agent 建议的第三项（在 `/srv/sannai/modules/curation/sannai_cloud_heartbeat_live.py` 加 source_intent 过滤）——用下游补丁修上游缺陷；注入停掉后无物可滤，那条候选 2026-09-12 自然过期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdZUig7neYTAoaDpRfqczg
