### PR TITLE
fix(memory-os): cron 会话在出口与压缩钩子仍在改写主人锚点（DG.2/DG.3）+ DG 部署记录

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -5004,7 +5004,14 @@ sannai-community 仓库 README。）
   五门全绿。**已合并为 `8389e59` 并部署两 profile + 双网关重启**：主机侧实测 13/13、
   main monitor 98/5/1（基线 97/6/2，净改善）、sannai 89/12/2（两 FAIL 自 08-12 即存在）；
   三个 FAIL 逐条按部署前快照归因，唯一新码 `index_not_healthy_in_production` 证实为
-  安装重建索引窗口的采样抖动、重跑即消。顺带把 `judge_empty_response` 判定为主机级模型面故障。
+  安装重建索引窗口的采样抖动、重跑即消。**端到端判据**：`余温检查·下午`（08:00 UTC）
+  此前 16 天每天必写一条取消锚点，今天同一任务跑完**零取消写入**，日计数由稳定的 7 条降为
+  重启前的 3 条。该次核对同时抓出兄弟缺陷另外两条路径：**DG.2**（`on_session_end` 安全网
+  无条件 `_supersede_active_anchors`，每次 cron 结束都废止主人的活跃锚点，靠"取消数没变
+  但行数变了"发现）与 **DG.3**（补做九个锚点写入点的全生命周期扫描，`on_pre_compress`
+  会用 cron 对话造 active 锚点并顺带废止主人的），各配 2 个反事实测试。
+  顺带把 `judge_empty_response` 判定为主机级模型面故障、
+  把 `prefetch timed out after 8.0s` 核为可追至 09-04 的既有告警。
 
 - `3f447dc..HEAD`：#74/#75 评审修复（DF）——embedder 失败类型化 + `memory_embedder_fallback_fts` error_record、RAGFlow 空结果权威化 + 畸形 chunk 免连坐、import-state finally 化、INV-5 豁免记录、rerank 截断文档如实化；+11 测试，全量 3646 passed / 13 skipped / 0 failed。
 
@@ -7534,6 +7541,78 @@ DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
   对照 08-12 的 4 个 FAIL，今天降到 2 个。**方法记账**：我一度按"部署刷新写了 12 行、
   正好 6 对重复"推断是本次引入，**数字吻合纯属巧合**——是翻出 08-12 快照和逐行时间戳
   才纠正的。数量吻合不是因果证据。
+- **端到端生产验证（本节的真正判据，不是 md5 也不是单测）**：md5 一致只证明文件到位，
+  必须等一次**真实的肇事 cron 跑完**才算验证。选 `三奶的余温检查·下午`（`0 16 * * *` CST
+  = 08:00 UTC），因为按 UTC 小时拆分历史账本，**该时段此前 16 天每天都写一条取消锚点**，
+  最近六天无一例外（09-04…09-09 各一条 `08:00:xx`）：
+
+  | UTC 时段 | 01 | 04 | 05 | 08 | 09 | 12 | 13 |
+  |---|---|---|---|---|---|---|---|
+  | 历史 cron 取消行数 | 15 | 17 | 17 | **16** | 16 | 16 | 16 |
+
+  2026-09-10 该任务 16:00:26 CST 触发，网关日志确认 16:00:37 **确实调用了 memory-os
+  prefetch**，而 `cancelled` 计数停在 121 / cron_authored 113 **一行未增**。日计数同样清楚：
+  09-03→09-09 稳定 **每天 7 条**，今天只有 **3 条**，且全部发生在 07:17 UTC 重启之前。
+  重启后两个 profile 的锚点账本**任何状态的行都没写过**（`created_at >= 07:17` 计数为 0），
+  与"cron 轮不再产生任何锚点写入"的设计一致。
+- **验证当场抓出兄弟缺陷的第二条路径（DG.2，本节最有价值的产出）**：核对账本时发现行数
+  3823→**3824**，而"重启后写入"计数却是 0——两个数对不上就不能放过。查那一行：不是取消，
+  是一条 **`status=superseded` 墓碑**，被废止的是**主人自己**的 active 锚点
+  （session `20260910_114632_…`，`created_at=05:17:41Z`，任务文本是主人当天的真实消息），
+  `superseded_at=08:03:10Z` —— **正是余温检查那次 cron 跑完的时刻**。
+
+  根因在 `on_session_end` 的两层防御：
+
+  ```python
+  self._clear_active_task_anchor()      # cron 会话锚点为空 → 提前返回，正确
+  if not self._current_task_anchor:
+      self._supersede_active_anchors()  # ← 无条件扫盘，把别人的 active 全废止
+  ```
+
+  DG 主批修的是 cron 会话**开始**时继承并墓碑主人锚点（`initialize`）；**结束**侧这条
+  安全网同样无条件执行。而修好 `initialize` 之后 cron 会话必然 `_current_task_anchor == ""`，
+  于是**每次**都会走进安全网 —— 该防御的本意是"owner 会话在内存里丢了自己的锚点时兜底"，
+  对一个从来就没有锚点的机器会话，它扫到的只可能是**别人的**记录。
+  后果：任意 agent 类 cron 任务跑完，主人的前台任务连续性即被静默清除（sannai 每天 7+ 次）。
+
+  修法一行：`and not is_scheduled_session_id(self.session_id)`。反事实：去掉该守卫，
+  新增的 `test_scheduled_session_end_does_not_supersede_owner_anchor` 立刻挂；
+  同时新增 `test_owner_session_end_still_supersedes_when_anchor_lost` 钉住安全网**对 owner
+  会话仍然生效**（两种情况下都通过，证明不是把网剪了）。
+
+  **方法记账**：这条是靠"取消数没变但行数变了、两个计数对不上"揪出来的。
+  如果只核 `cancelled` 计数（部署要求里原本就只写了这一条），它会完好无损地留在生产上，
+  且比原缺陷更隐蔽——**它不写任何新行，只把别人的行改成终态**。
+
+- **补做全生命周期扫描，又抓出第三条路径（DG.3）**：DG.2 之后才意识到只查了
+  `initialize` 与 `on_session_end` 两个钩子，属 Rule-5 漏做。把 `_write_active_task_anchor(`
+  的**九个**调用点逐一归属到方法并判定可达性：
+
+  | 调用点 | 所属方法 | 对 cron 会话 |
+  |---|---|---|
+  | 175 | `initialize` | 已守卫（DG 主批） |
+  | 605 | `_capture_turn_operations` ← `sync_turn` | 不可达：`not self._current_task_anchor` 提前返回 |
+  | **1046** | **`on_pre_compress`** | **可达 —— 缺口，见下** |
+  | 1378/1390/1397/1408/1458 | `_refresh_current_task_anchor_from_query` | 已守卫（`machine_authored` 提前返回） |
+  | 1646 | `_clear_active_task_anchor` | 空锚点提前返回；旁边的安全网已由 DG.2 守卫 |
+
+  `on_pre_compress` 会用**本会话的对话内容**造锚点并落盘 active 行。agent 类 cron 任务
+  单次运行数分钟、工具输出可观（本次余温检查 16:00:26→16:03:10），**足以触发压缩**，
+  所以这个钩子对 cron 会话是真可达的。一旦触发，既会把机器工作登记成主人的前台任务，
+  又会在 `_write_active_task_anchor` 内顺手废止主人的真锚点（与 DG.2 同一后果）。
+  且它是 605 那条"不可达"结论的**前提**——`on_pre_compress` 一旦给 cron 会话置上锚点，
+  `_capture_turn_operations` 随即变为可达。修法同样一行提前返回，配两个反事实测试
+  （cron 不写、owner 仍写）。
+
+  **教训**：守卫机器会话必须**枚举全部生命周期钩子**，不能只守入口那一轮。
+  DG 主批守了入口、DG.2 守了出口、DG.3 才补上压缩钩子——三次都是同一个缺陷家族，
+  差别只在"哪个钩子先被生产触发到"。
+- **顺带核掉一个容易误认成回归的告警**：sannai 网关在该轮记
+  `Memory provider 'memory-os' prefetch timed out after 8.0s`。查 7 天日志，两个网关
+  **每天 1–3 次、至少可追到 09-04**，频次未变 ⇒ 先于本次部署，非回归
+  （判定器是正则，不可能耗 8 秒）。注意 memory_manager 的超时只让**调用方**放弃等待、
+  不会取消 provider 线程，所以 `_refresh_current_task_anchor_from_query`（在 `prefetch()`
+  最前段）照常执行完 —— 这一点是上面"没写锚点=修复生效"结论成立的前提，已核。
 - **`llm_judge_probe_status=warn` 顺带定死了一个悬案**：两 profile 的部署探针都 warn，
   实测 reason 是 `judge_empty_response`（provider `hermes_default` → `openai-codex`，
   model `gpt-5.6-luna-900k`，api_mode `codex_responses`）。这与「DG 附带」①里 sannai

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4698,6 +4698,33 @@ public_checkout_probe --strict）+ `git diff --check` 全绿。
 
 ## 待办
 
+**主机级模型面空回复：`judge_empty_response` / `llm_empty_content`（DG 部署时定死，2026-09-10）。**
+Hermes 运行时模型（provider `hermes_default` → `openai-codex`，model `gpt-5.6-luna-900k`，
+api_mode `codex_responses`）对 Memory-OS 的治理 lane **恒返回空内容**。两条独立证据同指一处：
+① 部署探针 `low-clue-recall dry-run --llm-judge` 在**两个 profile** 都 warn，reason
+`judge_empty_response`；② sannai `session_fact_extraction` 最近 30 次运行
+`llm_calls=600 / fallback_used_count=600 / llm_failures_by_reason={"llm_empty_content":600}`，
+`facts_extracted=0`，最后一次真正产出是 **2026-08-26T02:17**，同时 `sessions_eligible=252`
+积压且已开始 `sessions_abandoned_after_max_attempts`。**因此原先"主机级 vs 单 lane 入参"
+的分叉已判定为主机级**，Memory-OS 侧无代码要改。影响面：待办 8（关键事实漏失）的 A 分支
+——近半个月主人与 sannai 的对话零事实入库。时间点与 DE/DF（08-26/08-27 RAGFlow v0.27、
+两 profile 启用远程 embedding）重合，但 `_call_hermes_runtime_model` 与 embedder 不同源，
+**相关不等于因果，不得据此归因**。另立项：先定位模型面（配额／凭证／api_mode 兼容），
+再回头看 lane 侧是否需要把"连续 N 次全空"升级成 monitor 分级——目前该 lane 计数器齐全
+却**无人分级**，又是一例"指标算了没有读者"。
+
+**`session_mirror_auto_apply_permit_integrity_invalid`：permit scope 恒不匹配（DG 部署时归因，2026-09-10）。**
+monitor FAIL，reason 恒为 `execution_gate_scope_mismatch`：`permit_count=1`、
+`completion_count=1`、`expires_at_status=valid_at_completion`、`unused_before_apply=True`、
+`consumed_after_apply=True` **全部正常**，唯独 `permit_scope_hash != expected_scope_hash`。
+即"权限用得对，但 scope 指纹算得不一样"。**至少自 2026-09-07 起每份快照都在**（09-07/08/09
+三份逐份核过，hash 每天不同但恒不等），**先于 DG 部署，不是本次引入**。方向：
+`session_mirror_auto_apply_permit_integrity` 用 `latest_apply` 的
+`max_sessions / platform_allowlist / selected_session_fingerprints` 重算期望 hash，
+而生产者写 permit 时的 scope 字段集合可能已经漂移——**典型的"校验方与生产者词表分叉"**
+（CLAUDE.md 同名小节）。修法第一步是把两侧字段集合各自枚举出来比对，
+**不要直接把校验放宽到相等**，那是买绿色。
+
 **`vector_edge_proposer` 无 `outcome`、无写失败计数（CW 登记，2026-08-15）。**
 兄弟五个 edge 步骤都产出封闭 `outcome`，只有它没有；写失败也无计数（是生产者缺口，
 不是白名单丢弃，故 CW.4 的接线修不到它）。后果：该 lane 写失败与"没边可提"在任何
@@ -4974,7 +5001,10 @@ sannai-community 仓库 README。）
   `context_router.py` 三份逐字词表副本与兜底分支；生产实测 sannai 113/121、main 586/731
   条 cancelled 锚点由 cron 提示词写入；判定器用 153 条生产语料复验（拒 98、自然取消 32/32），
   白名单宾语初版漏判 8 条已改为子句有界规则。+55 测试，全量 3701 passed / 13 skipped / 0 failed，
-  五门全绿；仅 `local_pass`，待两 profile 部署 + 网关重启。
+  五门全绿。**已合并为 `8389e59` 并部署两 profile + 双网关重启**：主机侧实测 13/13、
+  main monitor 98/5/1（基线 97/6/2，净改善）、sannai 89/12/2（两 FAIL 自 08-12 即存在）；
+  三个 FAIL 逐条按部署前快照归因，唯一新码 `index_not_healthy_in_production` 证实为
+  安装重建索引窗口的采样抖动、重跑即消。顺带把 `judge_empty_response` 判定为主机级模型面故障。
 
 - `3f447dc..HEAD`：#74/#75 评审修复（DF）——embedder 失败类型化 + `memory_embedder_fallback_fts` error_record、RAGFlow 空结果权威化 + 畸形 chunk 免连坐、import-state finally 化、INV-5 豁免记录、rerank 截断文档如实化；+11 测试，全量 3646 passed / 13 skipped / 0 failed。
 
@@ -7462,10 +7492,54 @@ DC 部署后核对 index 计数时发现：main 与 sannai 的 `store_counts` /
   sabotage `initialize` 守卫 → 继承/墓碑测试挂。全部 cp 备份还原，未用 `git checkout --`。
 - **测试**：+55（ingress 46、anchor 6、router 3）；全量 **3701 passed / 13 skipped / 0 failed**；
   五门（import-cycle、write-surface `unclassified_count=0`、static-hygiene、public-checkout
-  `--strict` PASS、`git diff --check`）全绿。仅 `local_pass`，未部署。
+  `--strict` PASS、`git diff --check`）全绿。**已合并并部署**，见下节。
 - **部署要求**：provider 侧改动，**两 profile 网关都要重启**（main 也有 586 条）；部署后按
   md5 核对三个文件，再看 24h 内 cancelled 新增行是否归零
   （`grep -c '"status": "cancelled"' active_task_anchor.jsonl` 前后对比）。
+
+### DG 部署与生产验证（2026-09-10，main+sannai 双 profile，`8389e59`）
+
+- **合并与同步**：PR #77 合并为 `8389e59`；本地与 `/opt/Hermes-Memory-OS` 均 ff 到该提交，
+  三个源文件 md5 本地/远端逐字节一致（`9b8ba7b0` / `836af4b7` / `dbe7fdbd`）。
+  回滚点 `9136bf0f`，另在 `/root/_memoryos_predeploy_backup_20260910T0700Z/{main,sannai}/`
+  留了三文件的部署前副本（旧 md5 `e3ee4a1f` / `a773e392` / `5a564a65`，两 profile 相同）。
+- **部署**：`deploy_memory_os.py --mode production-safe --profile upgrade`，两 profile 各走
+  plan → preflight → dry-run → apply。全部 `preflight_pass` + `dry_run_pass` + `apply_applied`
+  + `postcheck_pass`，manifest `deployed_head=8389e595` 两 profile 均已盖章；
+  `MSYS_NO_PATHCONV=1` 生效，plan 阶段路径未被 Git Bash 改写。
+- **网关重启**：两个 user 单元 `hermes-gateway.service` / `hermes-gateway-sannai.service`
+  依次 restart，均回到 active、`NRestarts=0`、Telegram polling 已连上。日志里那两条
+  `Failed with result 'exit-code'` 出现在 restart 同一秒，是**旧进程收到 SIGTERM 的退出码**，
+  不是新进程故障（新进程启动日志完整、无 traceback、无 memory_os 报错）。
+- **主机侧行为验证（不是只看 md5）**：用 `importlib` 直接加载**两个 profile 上实际部署的**
+  `ingress.py`，跑 13 条判据（cron 前导语 / cron 会话 id / 描述性提及 / 否定 / 机器框架文本
+  / 真实取消 × 5）——**main 13/13、sannai 13/13**，cron 提示词落 `machine_authored`、
+  `route=''`、`reason_codes=['machine_authored_query']`。
+- **Full Monitor（main）**：第一次跑出 3 FAIL，**逐条按部署前快照归因**，这是本节最该记住的方法：
+  - `session_mirror_auto_apply_permit_integrity_invalid` —— 09-07/08/09 **三份快照里都在**，
+    reason 恒为 `execution_gate_scope_mismatch`（permit 1、completion 1、hash 不符）。
+    **先于本次部署的存量缺陷，未修，登记待办。**
+  - `doctor_probe_timeout` —— 09-08 两份快照里也有，`command_timeout_seconds=20` 抖动，
+    与 DC 节记录的"探针超时被误报成 doctor 不健康"同源。
+  - `index_not_healthy_in_production` —— 部署前五份快照里**一份都没有**，唯一的新码。
+    直查 `index_health` 得 `state=healthy`、`prefetch_mode=indexed`，db 文件 mtime 15:20/15:21
+    正落在安装重建索引的窗口内 ⇒ **监控在重建期间采了样**。原样重跑：该码消失。
+  - 重跑结果 **98 PASS / 5 WARN / 1 FAIL**，对照部署前基线（09-09：97/6/2）**净改善**——
+    `shell_alias_no_env_failed` 与 `owner_review_surface_not_ok` 一并消失。
+- **Full Monitor（sannai）**：**89 PASS / 12 WARN / 2 FAIL**。两个 FAIL
+  （`memory_projection_duplicate_records`、`memory_projection_retention_compaction_missing`）
+  **在 2026-08-12 的 sannai 快照里已经存在**，且 6 对重复行的 `created_at` 全是
+  **2026-07-28/29**，今天一行未加；sannai 至今没有 `memory_projection_compactions.jsonl`
+  （main 有一份 6 月 3 日的），这就是 compaction_missing 的直接原因。
+  对照 08-12 的 4 个 FAIL，今天降到 2 个。**方法记账**：我一度按"部署刷新写了 12 行、
+  正好 6 对重复"推断是本次引入，**数字吻合纯属巧合**——是翻出 08-12 快照和逐行时间戳
+  才纠正的。数量吻合不是因果证据。
+- **`llm_judge_probe_status=warn` 顺带定死了一个悬案**：两 profile 的部署探针都 warn，
+  实测 reason 是 `judge_empty_response`（provider `hermes_default` → `openai-codex`，
+  model `gpt-5.6-luna-900k`，api_mode `codex_responses`）。这与「DG 附带」①里 sannai
+  `session_fact_extraction` 的 600/600 `llm_empty_content` 是**同一个失败模式，且 main 同样中招**
+  ⇒ 原本列为"下一步需诊断"的分叉（主机级模型面 vs 单 lane 入参）**判定为主机级模型面**，
+  不是 lane 缺陷。Memory-OS 侧无需改代码；另立项处理。
 ### DG 附带：三个遗留项的生产实测状态（2026-09-10，非估算）
 
 本轮顺手把 owner 问的"哪些遗留项可以闭环"逐条拿账本核了。**三条里只有一条能关，

--- a/plugins/memory/memory_os/__init__.py
+++ b/plugins/memory/memory_os/__init__.py
@@ -910,8 +910,14 @@ class MemoryOSProvider(MemoryProvider):
         #    anchor was lost (e.g. _build_current_task_anchor returned ""
         #    and overwrote it), scan the disk directly and mark every
         #    active record as superseded.
+        # A scheduled session owns no anchor (initialize refuses to recover one
+        # into it), so layer 2 would find only *other* sessions' active records
+        # and tombstone them. Observed on production 2026-09-10: a sannai cron
+        # job finishing at 08:03:10Z superseded the owner's 05:17Z anchor. The
+        # safety net is for an owner session that lost its own anchor in
+        # memory — never for a machine session that never had one.
         self._clear_active_task_anchor()
-        if not self._current_task_anchor:
+        if not self._current_task_anchor and not is_scheduled_session_id(self.session_id):
             self._supersede_active_anchors()
         self._current_task_anchor = ""
         foreground_summary = _extract_foreground_session_summary(messages)
@@ -1021,6 +1027,14 @@ class MemoryOSProvider(MemoryProvider):
         return result
 
     def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
+        # A scheduled session's transcript is machine work, not the owner's
+        # foreground task. Building an anchor from it would persist an *active*
+        # record describing a cron job (and, via _write_active_task_anchor,
+        # supersede the owner's real anchor on the way). An agent cron job runs
+        # for minutes and can accumulate enough tool output to be compacted, so
+        # this hook is genuinely reachable for one.
+        if is_scheduled_session_id(self.session_id):
+            return self._current_task_anchor
         # Extract completed_operations from current anchor before rebuilding
         previous_completed = _extract_anchor_operation_lines(self._current_task_anchor)
         new_anchor = _build_current_task_anchor(

--- a/tests/plugins/memory/test_memory_os_current_task_anchor.py
+++ b/tests/plugins/memory/test_memory_os_current_task_anchor.py
@@ -432,6 +432,102 @@ def test_scheduled_session_neither_inherits_nor_tombstones_owner_anchor(tmp_path
         owner_again.shutdown()
 
 
+def test_scheduled_session_end_does_not_supersede_owner_anchor(tmp_path):
+    """A cron session finishing must not tombstone the owner's live anchor.
+
+    Production 2026-09-10: `on_session_end`'s layer-2 safety net
+    (`_supersede_active_anchors`) ran unconditionally, so a sannai cron job
+    finishing at 08:03:10Z superseded the owner's 05:17Z active anchor. The
+    net exists for an owner session that lost its own anchor in memory, not
+    for a machine session that never had one.
+    """
+    owner = _owner_provider(tmp_path, "session-owner")
+    try:
+        owner._current_task_anchor = _OWNER_ANCHOR
+        owner._write_active_task_anchor(anchor=_OWNER_ANCHOR)
+    finally:
+        owner.shutdown()
+    assert _anchor_records(tmp_path)[-1]["status"] == "active"
+
+    cron = _owner_provider(tmp_path, _CRON_SESSION)
+    try:
+        cron.prefetch(_CRON_PROMPT, session_id=_CRON_SESSION)
+        cron.on_session_end([{"role": "user", "content": _CRON_PROMPT}])
+    finally:
+        cron.shutdown()
+
+    records = _anchor_records(tmp_path)
+    assert [r for r in records if r.get("status") == "superseded"] == []
+    assert records[-1]["status"] == "active"
+
+    # the owner's next session still recovers it
+    owner_again = _owner_provider(tmp_path, "session-owner-2")
+    try:
+        assert "ComfyUI" in owner_again._current_task_anchor
+    finally:
+        owner_again.shutdown()
+
+
+def test_scheduled_session_pre_compress_writes_no_anchor(tmp_path):
+    """Compaction of a cron session must not anchor the machine's own work.
+
+    `on_pre_compress` builds an anchor from the transcript and persists it.
+    For a cron session that transcript is machine work, and the write also
+    supersedes the owner's real anchor on its way through
+    `_write_active_task_anchor`.
+    """
+    owner = _owner_provider(tmp_path, "session-owner")
+    try:
+        owner._current_task_anchor = _OWNER_ANCHOR
+        owner._write_active_task_anchor(anchor=_OWNER_ANCHOR)
+    finally:
+        owner.shutdown()
+    before = len(_anchor_records(tmp_path))
+
+    cron = _owner_provider(tmp_path, _CRON_SESSION)
+    try:
+        returned = cron.on_pre_compress([
+            {"role": "user", "content": _CRON_PROMPT},
+            {"role": "assistant", "content": "terminal: cm_cli install some-plugin"},
+            {"role": "tool", "content": "proc_zzz running; downloading weights"},
+        ])
+    finally:
+        cron.shutdown()
+
+    assert returned == ""
+    records = _anchor_records(tmp_path)
+    assert len(records) == before
+    assert records[-1]["status"] == "active"
+    assert "ComfyUI" in records[-1]["anchor"]
+
+
+def test_owner_session_pre_compress_still_writes_anchor(tmp_path):
+    """The compaction anchor must keep working for owner sessions."""
+    provider = _owner_provider(tmp_path, "session-owner")
+    try:
+        anchor = provider.on_pre_compress([
+            {"role": "user", "content": "安装 ComfyUI 并配置 IPAdapter 插件"},
+            {"role": "assistant", "content": "terminal: cm_cli install ComfyUI_IPAdapter_plus"},
+        ])
+    finally:
+        provider.shutdown()
+    assert "ComfyUI" in anchor
+    assert [r for r in _anchor_records(tmp_path) if r.get("status") == "active"]
+
+
+def test_owner_session_end_still_supersedes_when_anchor_lost(tmp_path):
+    """The layer-2 safety net must keep working for owner sessions."""
+    provider = _owner_provider(tmp_path, "session-owner")
+    try:
+        provider._current_task_anchor = _OWNER_ANCHOR
+        provider._write_active_task_anchor(anchor=_OWNER_ANCHOR)
+        provider._current_task_anchor = ""  # anchor lost in memory
+        provider.on_session_end([{"role": "user", "content": "安装 ComfyUI"}])
+    finally:
+        provider.shutdown()
+    assert [r for r in _anchor_records(tmp_path) if r.get("status") == "superseded"]
+
+
 def test_descriptive_cancel_mention_keeps_owner_anchor_active(tmp_path):
     provider = _owner_provider(tmp_path, "session-owner")
     try:


### PR DESCRIPTION
## 起因：部署验证抓出同一家族的另外两条路径

PR #77 拦住了 cron 会话在**入口**霸占主人的前台锚点。生产验证时发现它没拦住**出口**，也没拦住**压缩**。

## DG.2 — `on_session_end` 的安全网无条件执行

```python
self._clear_active_task_anchor()      # cron 会话锚点为空 → 提前返回，正确
if not self._current_task_anchor:
    self._supersede_active_anchors()  # ← 无条件扫盘，把别人的 active 全废止
```

**生产实测**：一个 sannai cron 任务在 `08:03:10Z` 跑完，把主人 `05:17Z` 那条 active 锚点废止了——被抹掉的锚点，任务文本正是主人当天早上自己的消息。**每个 agent 类 cron 任务跑完都会发生一次**，sannai 每天 7+ 次。

这道防御的本意是"owner 会话在内存里丢了自己的锚点时兜底"。一个从来没有锚点的机器会话，它扫到的只可能是**别人的**记录。

**这条是怎么发现的**：账本行数 3823→3824，而取消计数纹丝不动——两个数对不上。DG 部署要求里原本只写了核对取消计数，**只看那一个数它会无限期留在生产上**：它不写任何新行，只把别人的行改成终态。

## DG.3 — `on_pre_compress` 用 cron 自己的对话造锚点

DG.2 之后才补做本该更早做的 Rule-5 扫描，把 `_write_active_task_anchor` 的**九个**调用点逐一归属判定：

| 调用点 | 所属方法 | 对 cron 会话 |
|---|---|---|
| 175 | `initialize` | 已守卫（#77） |
| 605 | `_capture_turn_operations` ← `sync_turn` | 不可达：空锚点提前返回 |
| **1046** | **`on_pre_compress`** | **可达 —— 缺口** |
| 1378/1390/1397/1408/1458 | `_refresh_current_task_anchor_from_query` | 已守卫（`machine_authored`） |
| 1646 | `_clear_active_task_anchor` | 空锚点提前返回 |

`on_pre_compress` 用**本会话的对话内容**造锚点并落盘 active 行。agent 类 cron 单次跑数分钟、工具输出可观（暴露 DG.2 的那次是 16:00:26→16:03:10），**足以触发压缩**。一旦触发：既把机器工作登记成主人的前台任务，又在 `_write_active_task_anchor` 内顺手废止主人的真锚点。

它同时是 605 那条"不可达"结论的**前提**——压缩一旦给 cron 会话置上锚点，`_capture_turn_operations` 随即变为可达。

## 修复与验证

两处各一行条件。**4 个反事实测试**，逐个用还原旧代码验证必挂：两个守卫各一个，另两个钉住 owner 会话行为不变（防止把守卫误当成"把机制剪了"）。

全量 **3705 passed / 13 skipped / 0 failed**；五门全绿。

## 教训（已写进 checklist）

守卫机器会话必须**枚举全部生命周期钩子**，不能只守入口那一轮。DG 主批守入口、DG.2 守出口、DG.3 补压缩钩子——三次同一家族，差别只在哪个钩子先被生产触发到。

## 本 PR 还包含 DG 部署记录

`8389e59` 部署两 profile + 双网关重启的完整记录：主机侧实测 13/13、main monitor 98/5/1（基线 97/6/2）、sannai 89/12/2（两 FAIL 自 08-12 即存在）；三个 FAIL 逐条按部署前快照归因，唯一新码证实为安装重建索引窗口的采样抖动。端到端判据：余温检查·下午此前 **16 天每天必写一条取消锚点**，部署后同一任务跑完**零取消写入**。

另注册两条遗留项：主机级模型面空回复（`judge_empty_response`，两 profile 皆中，已判定非 lane 缺陷）、`session_mirror` permit scope 恒不匹配（自 09-07 起）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdZUig7neYTAoaDpRfqczg
