### PR TITLE
fix(memory-os): permit scope 门少算一个字段，恒 FAIL 从未真正校验（DH）

### DIFF
--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -4698,7 +4698,42 @@ public_checkout_probe --strict）+ `git diff --check` 全绿。
 
 ## 待办
 
-**主机级模型面空回复：`judge_empty_response` / `llm_empty_content`（DG 部署时定死，2026-09-10）。**
+**空回复根因：`-900k` 是 Hermes 私有别名，Memory-OS 把它原样发上了线（2026-09-10 实测定案）。**
+
+**先纠正本节的前一版结论**：曾写成"主机级模型面故障"。owner 反问"我的 Hermes agent 用
+`gpt-5.6-luna-900k` 明明可以"，逼出了真正的根因——**不是限额，也不是主机故障，是 Memory-OS
+绕过了 Hermes 的模型名归一化**。
+
+实测链条（每一步都有报错原文，不是推断）：
+1. 照搬部署版 `_call_openai_responses` 直接发一次调用，把被吞的异常打出来：
+   `openai.BadRequestError: 400 - {'detail': "The 'gpt-5.6-luna-900k' model is not supported
+   when using Codex with a ChatGPT account."}`，两 profile 一致。
+2. 怀疑是缺 Codex 身份头（`agent/codex_headers.py` 的 `originator`/`ChatGPT-Account-ID`）。
+   带上、不带、两者合并各试一次——**三种都是同一个 400**，排除 SDK 适配问题。
+3. 拉账号模型目录 `GET /backend-api/codex/models`：
+   `gpt-6-astra / gpt-reserve / gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna / gpt-5.5 /
+   codex-auto-review` —— **`gpt-5.6-luna-900k` 不在其中**。
+4. 那 Hermes 自己为何能用？`agent/model_metadata.py` 给出答案：
+   `CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"`，注释写明 *"Never sent on the wire"*；
+   `strip_codex_context_variant_suffix()` 在发请求前剥掉后缀，
+   `agent/transports/codex.py:730` 同样注明「`-900k` 是 Hermes 侧别名，后端只认基础 slug」。
+   **`-900k` 是大上下文选择器别名，不是模型 ID。** Hermes 自己的传输层剥；
+   Memory-OS 的 `_call_hermes_runtime_model` 取 `runtime["model"]` **原样上线**，于是 400。
+5. 对照实验：同一凭证发 `gpt-5.6-luna` 立即返回 `{"ok":true}`。
+
+**owner 裁定（2026-09-10）：不在 Memory-OS 里做这个适配。** 剥 `-900k` 是 Hermes 的私有约定，
+写进来就等于把记忆层绑死在单一 provider 上，而我们要的是不同 LLM 都能复用的调用面。
+因此**不新增 provider 特例代码**。方向留给另立项：Memory-OS 不该自己手写三套 wire 调用
+（`chat_completions` / `codex_responses` / `anthropic_messages`），应当走 Hermes 已归一化的
+调用面；在那之前这条对任何"模型名 ≠ wire 名"的 provider 都会复发。
+
+**与本批直接相关、且已被本次实测坐实的那半个缺陷**：`_call_hermes_runtime_model` 的
+`except Exception: return ""` 把一个**明确的 400**吞成"模型没话说"。真实报错在 15 天里
+从未出现在任何账本、日志或监控里——只有把异常打出来才看见。这正是 CLAUDE.md
+「Completion Is Not Output」点名的形状，`fact_judge` 早有正确写法（typed failure reason）。
+**这条是 provider 无关的，应当修**，与上面的"不做定制"不冲突。
+
+（原记录，保留备查：）**主机级模型面空回复：`judge_empty_response` / `llm_empty_content`（DG 部署时定死，2026-09-10）。**
 Hermes 运行时模型（provider `hermes_default` → `openai-codex`，model `gpt-5.6-luna-900k`，
 api_mode `codex_responses`）对 Memory-OS 的治理 lane **恒返回空内容**。两条独立证据同指一处：
 ① 部署探针 `low-clue-recall dry-run --llm-judge` 在**两个 profile** 都 warn，reason
@@ -4713,7 +4748,8 @@ api_mode `codex_responses`）对 Memory-OS 的治理 lane **恒返回空内容**
 再回头看 lane 侧是否需要把"连续 N 次全空"升级成 monitor 分级——目前该 lane 计数器齐全
 却**无人分级**，又是一例"指标算了没有读者"。
 
-**`session_mirror_auto_apply_permit_integrity_invalid`：permit scope 恒不匹配（DG 部署时归因，2026-09-10）。**
+**~~`session_mirror_auto_apply_permit_integrity_invalid`：permit scope 恒不匹配~~ —— DH 已修（2026-09-10）。**
+原始诊断保留备查：
 monitor FAIL，reason 恒为 `execution_gate_scope_mismatch`：`permit_count=1`、
 `completion_count=1`、`expires_at_status=valid_at_completion`、`unused_before_apply=True`、
 `consumed_after_apply=True` **全部正常**，唯独 `permit_scope_hash != expected_scope_hash`。
@@ -7672,3 +7708,47 @@ sannai 单次运行 `sessions_scanned=405 / sessions_eligible=252 / sessions_pro
 按 envelope 探它会得到 main/sannai 各 0，**这不是证据**——它是 cognitive loop 的步骤，
 不开自己的 permit（loop 只有四个显式 envelope），0 是设计如此。下次核它要读
 边账本产出，别读 envelope。
+
+## DH — permit scope 校验方与生产者字段集分叉：一个从未真正校验过的门（2026-09-10）
+
+- **触发**：DG 部署验证时把 `session_mirror_auto_apply_permit_integrity_invalid` 归因为
+  "先于部署的存量缺陷"并登记待办；owner 指示"代码缺陷可以直接修复"。
+- **根因（可复算，不是推断）**：permit 的 `scope_hash` 取自
+  `session_mirror._session_mirror_auto_apply_scope` —— 该函数是这个 scope 形状的**单一真源**，
+  发证侧（`session_mirror.py:312`）与仓库内 verifier（`:1234`）都调它，共 **6 个字段**。
+  而 `memory_os_3_200_monitor.py` 的 `expected_scope` 是**手工重建**的 **5 个字段**，
+  少了 `platform_denylist`。用监控自己的哈希函数复算：
+
+  | | 值 |
+  |---|---|
+  | 生产库 permit `scope_hash` | `83eec368e082d1bb…` |
+  | hash(生产者 6 字段) | `83eec368e082d1bb…` ← 逐字节复现 |
+  | hash(校验方 5 字段) | `05ed324af6dbf9bc…` ← 永不相等 |
+  | 补上 `platform_denylist` 后 | 相等 |
+
+  **决定性对照**：同一个 envelope `xgate_20260910T060944377594Z_b44b83fe8e`，
+  仓库内 resolver 记录的是 `scope_match: true / status: valid`（它用的是共享构造器），
+  监控却报 `execution_gate_scope_mismatch`。错的只有监控这一侧。
+  后果不是"报错"而是**这个门从来没有校验过任何东西**：它恒 FAIL，与是否真有 scope 漂移无关，
+  于是真漂移与假警报完全同貌。
+- **为什么测试没抓到**：两处既有 permit 测试的 scope 夹具是**手写的 5 字段字典**——
+  夹具与缺陷保持一致，所以永远不会失败。这正是
+  [[counterfactual-tests-must-use-real-producer]] 记的那条：**夹具必须由真生产者构造**。
+- **修复**：
+  - `session_mirror.py`：`_append_apply_record` 增 `platform_denylist` 入参并写进 apply 记录
+    （此前该字段只存在于 policy 与 permit，外部校验方无从取值）；
+    `_bounded_apply_record` 对缺字段的历史行投影为 `None` 而非 `[]`——**让"没有 denylist"
+    与"这条记录早于该字段"可区分**，后者不可校验，不能报成失配。
+  - `memory_os_3_200_monitor.py`：`expected_scope` 补第 6 个字段，取自 `latest_apply`；
+    字段缺失时返回新状态 `unverifiable` + 原因码
+    `legacy_apply_record_without_platform_denylist`，classify 侧走 **INFO 而非 FAIL**
+    （INFO 无需 `CLEAN_HOST_WARN_CLASSIFICATIONS` 登记，与 `continuity_freshness_findings`
+    同例）。**断言一个算不出来的失配，正是这个门空转数周的原因。**
+- **反事实**：抽掉监控里补的那一行 → 平价测试与既有的
+  `accepts_completed_permit_after_ttl` 双双失败（`assert 'invalid' == 'ok'`）；恢复即通过。
+- **防再犯**：新增 `test_session_mirror_permit_scope_key_parity`，夹具**由真构造器生成**。
+  将来给构造器加第 7 个字段而不同步监控，这条测试会直接挂——而不是像这次一样，
+  让门悄悄变成永假。
+- **一句话教训**：**一个恒 FAIL 的门和一个恒 PASS 的门一样没用**，
+  两者都不再携带信息。CLAUDE.md 已有「A gate whose vocabulary drifts from its producer's
+  checks nothing, silently」——这次是它的镜像：不是漏检，是永远误检。

--- a/plugins/memory/memory_os/session_mirror.py
+++ b/plugins/memory/memory_os/session_mirror.py
@@ -680,6 +680,7 @@ class SessionMirror:
                 skipped_by_limit_count=skipped_by_limit_count,
                 skipped_by_owner_rejection_count=skipped_by_owner_rejection_count,
                 platform_allowlist=platforms,
+                platform_denylist=sorted(denied),
                 max_sessions=limit,
                 selected_sessions=selected_safe_sessions,
                 selected_session_fingerprints=selected_fingerprints,
@@ -916,6 +917,7 @@ class SessionMirror:
         skipped_by_limit_count: int,
         skipped_by_owner_rejection_count: int,
         platform_allowlist: list[str],
+        platform_denylist: list[str],
         max_sessions: int,
         selected_sessions: list[dict[str, Any]],
         selected_session_fingerprints: list[str],
@@ -935,6 +937,11 @@ class SessionMirror:
             "apply_bounded": bool(max_sessions or platform_allowlist),
             "max_sessions": max_sessions,
             "platform_allowlist": platform_allowlist,
+            # Recorded so an external verifier can rebuild the SAME scope the
+            # permit was minted from. `_session_mirror_auto_apply_scope` is the
+            # single source of truth for that shape and it hashes six fields;
+            # a reader that can only source five can never reproduce the hash.
+            "platform_denylist": platform_denylist,
             "candidate_session_count": candidate_session_count,
             "selected_session_count": selected_session_count,
             "skipped_by_platform_count": skipped_by_platform_count,
@@ -1345,6 +1352,11 @@ def _bounded_apply_record(record: dict[str, Any]) -> dict[str, Any]:
         "apply_bounded": bool(record.get("apply_bounded")),
         "max_sessions": record.get("max_sessions"),
         "platform_allowlist": record.get("platform_allowlist") if isinstance(record.get("platform_allowlist"), list) else [],
+        # Absent on records written before the field existed. The projection
+        # keeps that absence visible (None, not []) so a verifier can tell
+        # "no denylist" from "this record predates the field" — the second
+        # cannot be scope-checked and must not be reported as a mismatch.
+        "platform_denylist": record.get("platform_denylist") if isinstance(record.get("platform_denylist"), list) else None,
         "candidate_session_count": record.get("candidate_session_count"),
         "selected_session_count": record.get("selected_session_count"),
         "skipped_by_platform_count": record.get("skipped_by_platform_count"),

--- a/scripts/memory_os_3_200_monitor.py
+++ b/scripts/memory_os_3_200_monitor.py
@@ -2664,6 +2664,17 @@ def classify_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
                             "execution_gate_envelope_id": permit_integrity.get("execution_gate_envelope_id") or "",
                         }
                     )
+                elif permit_integrity.get("status") == "unverifiable":
+                    # The apply record predates `platform_denylist`, so the
+                    # permit's scope hash cannot be rebuilt. Report the gap as
+                    # INFO — asserting a mismatch we cannot compute is how this
+                    # gate spent weeks FAILing on nothing.
+                    info.append(
+                        {
+                            "code": "session_mirror_auto_apply_permit_integrity_unverifiable",
+                            "value": permit_integrity,
+                        }
+                    )
                 else:
                     fail.append(
                         {
@@ -7882,6 +7893,29 @@ def session_mirror_auto_apply_permit_integrity(latest_apply, latest_governance):
         for item in (latest_apply.get("selected_session_fingerprints") if isinstance(latest_apply.get("selected_session_fingerprints"), list) else [])
       ],
     }
+    # The permit's scope is minted by `session_mirror._session_mirror_auto_apply_scope`,
+    # the single source of truth for this shape. This rebuild MUST carry the
+    # same key set: a hash over five of its six fields can never match, so the
+    # gate reports `execution_gate_scope_mismatch` on every run whether or not
+    # any real drift exists — which is how it FAILed continuously from at least
+    # 2026-09-07 while the in-repo resolver reported `scope_match: true` for the
+    # very same envelope. `test_session_mirror_permit_scope_key_parity` pins the
+    # two key sets together so a newly added scope field fails loudly instead of
+    # silently making this gate vacuous.
+    _denylist = latest_apply.get("platform_denylist")
+    if _denylist is None:
+        # Written before the producer recorded the field: the expected hash
+        # cannot be reconstructed. Say so rather than assert a mismatch.
+        return {
+          "status": "unverifiable",
+          "reason": "legacy_apply_record_without_platform_denylist",
+          "execution_gate_envelope_id": envelope_id,
+        }
+    expected_scope["platform_denylist"] = sorted(
+      [str(item).lower() for item in _denylist if str(item or "").strip()]
+      if isinstance(_denylist, list)
+      else []
+    )
     expected_scope_hash = _execution_gate_scope_hash(expected_scope)
     if len(permits) != 1:
         return {

--- a/tests/scripts/test_memory_os_3_200_monitor.py
+++ b/tests/scripts/test_memory_os_3_200_monitor.py
@@ -4153,6 +4153,7 @@ def test_session_mirror_permit_integrity_accepts_completed_permit_after_ttl(monk
     latest_apply = {
         "max_sessions": 1,
         "platform_allowlist": ["telegram"],
+        "platform_denylist": [],
         "selected_session_fingerprints": ["smfp_done"],
     }
     latest_governance = {
@@ -4161,13 +4162,18 @@ def test_session_mirror_permit_integrity_accepts_completed_permit_after_ttl(monk
         "execution_gate_envelope_id": "xgate_completed",
         "execution_gate_permit_resolution": {"unused_before_apply": True},
     }
-    scope = {
-        "approval_ref": "oa_graduated",
-        "stable_scope_id": "lane:telegram",
-        "max_sessions_per_run": 1,
-        "platform_allowlist": ["telegram"],
-        "selected_session_fingerprints": ["smfp_done"],
-    }
+    # Built by the REAL producer, not hand-written: a hand-made dict is how the
+    # five-vs-six field drift stayed invisible to this suite for weeks.
+    from plugins.memory.memory_os.session_mirror import _session_mirror_auto_apply_scope
+
+    scope = _session_mirror_auto_apply_scope(
+        approval_ref="oa_graduated",
+        stable_scope_id="lane:telegram",
+        max_sessions_per_run=1,
+        platform_allowlist=["telegram"],
+        platform_denylist=[],
+        selected_session_fingerprints=["smfp_done"],
+    )
     records = [
         {
             "stage": "permit",
@@ -4209,6 +4215,7 @@ def test_session_mirror_permit_integrity_rejects_multiple_completions(monkeypatc
     latest_apply = {
         "max_sessions": 1,
         "platform_allowlist": ["telegram"],
+        "platform_denylist": [],
         "selected_session_fingerprints": ["smfp_done"],
     }
     latest_governance = {
@@ -4217,13 +4224,18 @@ def test_session_mirror_permit_integrity_rejects_multiple_completions(monkeypatc
         "execution_gate_envelope_id": "xgate_completed_twice",
         "execution_gate_permit_resolution": {"unused_before_apply": True},
     }
-    scope = {
-        "approval_ref": "oa_graduated",
-        "stable_scope_id": "lane:telegram",
-        "max_sessions_per_run": 1,
-        "platform_allowlist": ["telegram"],
-        "selected_session_fingerprints": ["smfp_done"],
-    }
+    # Built by the REAL producer, not hand-written: a hand-made dict is how the
+    # five-vs-six field drift stayed invisible to this suite for weeks.
+    from plugins.memory.memory_os.session_mirror import _session_mirror_auto_apply_scope
+
+    scope = _session_mirror_auto_apply_scope(
+        approval_ref="oa_graduated",
+        stable_scope_id="lane:telegram",
+        max_sessions_per_run=1,
+        platform_allowlist=["telegram"],
+        platform_denylist=[],
+        selected_session_fingerprints=["smfp_done"],
+    )
     records = [
         {
             "stage": "permit",
@@ -9140,3 +9152,165 @@ def test_shell_alias_no_env_section_strips_hermes_home_explicitly():
 
     assert '_no_env = {k: v for k, v in os.environ.items() if k != "HERMES_HOME"}' in script
     assert "executor.submit(load_json_cmd, command, _no_env)" in script
+
+
+def _session_mirror_permit_snapshot(permit_integrity):
+    """A healthy snapshot whose only variable is the permit-integrity verdict."""
+    snapshot = _healthy_snapshot()
+    snapshot["session_mirror"] = {
+        "schema_version": "memory-os.session_mirror_monitor_summary.v0",
+        "status": "ok",
+        "session_count": 54,
+        "covered_session_count": 30,
+        "pending_session_count": 24,
+        "dry_run_status": "ok",
+        "dry_run_new_event_count": 24,
+        "dry_run_written_event_ids_count": 0,
+        "dry_run_findings_count": 0,
+        "correlation_status": "ok",
+        "pending_only_group_count": 0,
+        "pending_only_groups": [],
+        "raw_private_body_printed": False,
+        "latest_apply_status": "ok",
+        "latest_apply_bounded": True,
+        "latest_apply_written_event_ids_count": 1,
+        "latest_apply_duplicate_ignored_count": 0,
+        "latest_apply_raw_private_body_printed": False,
+        "latest_apply_approval_resolved": True,
+        "latest_apply_owner_channel_bound": True,
+        "latest_apply_owner_approved": True,
+        "latest_apply_approval_source": "owner_action_lane_graduation",
+        "latest_apply_auto_apply": True,
+        "latest_apply_lane_graduated": True,
+        "latest_apply_execution_gate_envelope_id": "xgate_legacy",
+        "session_mirror_auto_apply_execution_gate_bound": True,
+        "session_mirror_auto_apply_permit_integrity": permit_integrity,
+        "latest_apply_boundary_true_count": 0,
+    }
+    return snapshot
+
+
+def _permit_records(envelope_id, scope, scope_hash):
+    return [
+        {
+            "stage": "permit",
+            "execution_gate_envelope_id": envelope_id,
+            "lane_id": "session_mirror_auto_apply",
+            "risk_class": "bounded_append_only_data_ingress",
+            "boundary_true": False,
+            "boundary": {
+                "actual_send": False,
+                "actual_execute": False,
+                "actual_identity_write": False,
+                "actual_unapproved_crystallized_approval": False,
+            },
+            "scope": scope,
+            "scope_hash": scope_hash,
+            "created_at": "2000-01-01T00:00:00Z",
+            "expires_at": "2000-01-01T00:15:00Z",
+        },
+        {
+            "stage": "completion",
+            "execution_gate_envelope_id": envelope_id,
+            "lane_id": "session_mirror_auto_apply",
+            "created_at": "2000-01-01T00:00:05Z",
+            "execution_status": "ok",
+        },
+    ]
+
+
+def test_session_mirror_permit_scope_key_parity(monkeypatch):
+    """The monitor must rebuild the permit scope with the producer's field set.
+
+    ``session_mirror._session_mirror_auto_apply_scope`` is the single source of
+    truth for that shape and the permit's ``scope_hash`` is taken over it. When
+    the monitor rebuilt five of its six fields the hash could never match, so
+    the gate reported ``execution_gate_scope_mismatch`` on every run whether or
+    not any real drift existed -- measured on production from at least
+    2026-09-07, while the in-repo resolver reported ``scope_match: true`` for
+    the very same envelope.
+
+    The fixture is built through the real producer, so adding a field to the
+    builder without teaching the monitor fails here instead of silently making
+    the gate vacuous again.
+    """
+    from plugins.memory.memory_os.session_mirror import _session_mirror_auto_apply_scope
+
+    namespace: dict[str, object] = {}
+    _exec_remote_probe_prefix(namespace)
+    scope = _session_mirror_auto_apply_scope(
+        approval_ref="oa_parity",
+        stable_scope_id="lane:parity",
+        max_sessions_per_run=2,
+        platform_allowlist=["telegram", "cli"],
+        platform_denylist=["discord"],
+        selected_session_fingerprints=["smfp_parity"],
+    )
+    latest_apply = {
+        "max_sessions": 2,
+        "platform_allowlist": ["telegram", "cli"],
+        "platform_denylist": ["discord"],
+        "selected_session_fingerprints": ["smfp_parity"],
+    }
+    latest_governance = {
+        "approval_ref": "oa_parity",
+        "stable_scope_id": "lane:parity",
+        "execution_gate_envelope_id": "xgate_parity",
+        "execution_gate_permit_resolution": {"unused_before_apply": True},
+    }
+    records = _permit_records("xgate_parity", scope, namespace["_execution_gate_scope_hash"](scope))
+    monkeypatch.setitem(namespace, "_read_jsonl", lambda path: records)
+
+    integrity = namespace["session_mirror_auto_apply_permit_integrity"](latest_apply, latest_governance)
+
+    assert integrity["status"] == "ok", integrity
+    assert integrity["scope_match"] is True
+
+
+def test_session_mirror_permit_integrity_legacy_record_is_unverifiable(monkeypatch):
+    """An apply record predating ``platform_denylist`` cannot be scope-checked.
+
+    Asserting a mismatch that cannot be computed is what made this gate FAIL
+    for weeks on nothing, so the absence gets its own status.
+    """
+    namespace: dict[str, object] = {}
+    _exec_remote_probe_prefix(namespace)
+    latest_apply = {
+        "max_sessions": 1,
+        "platform_allowlist": ["telegram"],
+        # no platform_denylist key at all -- a pre-fix record
+        "selected_session_fingerprints": ["smfp_legacy"],
+    }
+    latest_governance = {
+        "approval_ref": "oa_legacy",
+        "stable_scope_id": "lane:legacy",
+        "execution_gate_envelope_id": "xgate_legacy",
+        "execution_gate_permit_resolution": {"unused_before_apply": True},
+    }
+    monkeypatch.setitem(namespace, "_read_jsonl", lambda path: [])
+
+    integrity = namespace["session_mirror_auto_apply_permit_integrity"](latest_apply, latest_governance)
+
+    assert integrity["status"] == "unverifiable"
+    assert integrity["reason"] == "legacy_apply_record_without_platform_denylist"
+
+
+def test_classify_snapshot_grades_unverifiable_permit_integrity_as_info():
+    snapshot = _session_mirror_permit_snapshot(
+        {
+            "status": "unverifiable",
+            "reason": "legacy_apply_record_without_platform_denylist",
+            "execution_gate_envelope_id": "xgate_legacy",
+        }
+    )
+
+    classification = classify_snapshot(snapshot)
+
+    assert not any(
+        item["code"] == "session_mirror_auto_apply_permit_integrity_invalid"
+        for item in classification["fail"]
+    )
+    assert any(
+        item["code"] == "session_mirror_auto_apply_permit_integrity_unverifiable"
+        for item in classification.get("info", [])
+    )


### PR DESCRIPTION
## 根因：校验方少算一个字段，导致这个门从未真正校验过任何东西

permit 的 `scope_hash` 取自 `session_mirror._session_mirror_auto_apply_scope`——**这个 scope 形状的单一真源**，发证侧与仓库内 verifier 都调它，共 **6 个字段**。监控是**手工重建**的 **5 个字段**，少了 `platform_denylist`。

用监控自己的哈希函数复算（不是推断）：

| | 值 |
|---|---|
| 生产库 permit `scope_hash` | `83eec368e082d1bb…` |
| hash(生产者 6 字段) | `83eec368e082d1bb…` ← 逐字节复现 |
| hash(校验方 5 字段) | `05ed324af6dbf9bc…` ← 永不相等 |
| 补上 `platform_denylist` | 相等 |

**决定性对照**：同一个 envelope `xgate_20260910T060944377594Z_b44b83fe8e`，仓库内 resolver（用共享构造器）记录 `scope_match: true / status: valid`，监控却报 `execution_gate_scope_mismatch`。

后果不是"噪音告警"，而是**这个门恒 FAIL、不携带任何信息**——真漂移与假警报完全同貌。生产上这个状态至少从 2026-09-07 持续至今。

## 为什么测试抓不到

两处既有 permit 测试的 scope 夹具是**手写的 5 字段字典**——夹具与缺陷保持一致，所以永远不会失败。

现在夹具改为由真构造器生成，并新增 `test_session_mirror_permit_scope_key_parity` 同样用构造器造 permit。**将来给构造器加第 7 个字段而不同步监控，这条会直接挂**，而不是像这次一样让门悄悄变成永假。

## 修复

**`session_mirror.py`** — `platform_denylist` 此前只存在于 policy 与 permit，外部校验方无从取值。`_append_apply_record` 现在把它记进 apply 记录，与 `platform_allowlist` 并列。`_bounded_apply_record` 对缺该字段的历史行投影为 `None` 而非 `[]`：**"没有 denylist"与"这条记录早于该字段"必须可区分**。

**`memory_os_3_200_monitor.py`** — `expected_scope` 补第 6 个字段，取自 `latest_apply`；字段缺失时返回新状态 `unverifiable` + 原因码 `legacy_apply_record_without_platform_denylist`，classify 走 **INFO 而非 FAIL**。断言一个算不出来的失配，正是这个门空转数周的原因。INFO 无需 `CLEAN_HOST_WARN_CLASSIFICATIONS` 登记，与 `continuity_freshness_findings` 同例。

## 验证

反事实：抽掉监控里补的那一行 → 新平价测试与既有的 `accepts_completed_permit_after_ttl` 双双失败（`assert 'invalid' == 'ok'`）；恢复即通过。

+3 测试，全量 **3708 passed / 13 skipped / 0 failed**，五门全绿。

## 顺带更正 checklist 里一条错误结论

此前把空回复记成"主机级模型面故障"。owner 反问"我的 Hermes agent 用 `gpt-5.6-luna-900k` 明明可以"，逼出真根因：

`-900k` 是 **Hermes 私有的大上下文选择器别名**，不是模型 ID。`agent/model_metadata.py` 注明 *"Never sent on the wire"*，`strip_codex_context_variant_suffix()` 在发请求前剥掉；Memory-OS 取 `runtime["model"]` **原样上线**，后端 400。

排除的两个中间假设：带/不带 Codex 身份头三种组合都是同一个 400（非 SDK 适配）；账号模型目录里根本没有该 ID，且那条 HTTP 429 只覆盖 09-07→09-09 而故障自 8/26 连续（非限额）。

**owner 裁定：不在 Memory-OS 做这个适配**——剥后缀是 Hermes 私有约定，写进来会把记忆层绑死单一 provider。本 PR **不含任何 provider 特例代码**，只更正记录。provider 无关的那半个缺陷（`except Exception: return ""` 把明确的 400 吞成空串，真实报错 15 天不可见）单独登记待办。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdZUig7neYTAoaDpRfqczg
