### PR TITLE
fix(memory-os): one admission floor for every SessionMirror scan

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,39 @@ Keep service addresses, model paths, credentials, and profile-specific values
 outside the public repository. The production overlay should be applied by the
 operator after installing or upgrading the open-source core.
 
+## SessionMirror Admission Floor
+
+`session_mirror` in `config.json` carries the floor that decides which pending
+sessions the import lane will consider. It is a floor the owner sets once — not
+a gate re-approved per digest — and the **same** floor is applied by every scan:
+the owner-review digest, the manual `session-mirror scan --apply` revalidation,
+and the graduated auto-apply lane. That is deliberate. When the review surface
+and the apply surfaces filter differently, the digest describes one session and
+the lane imports another.
+
+| Key | Default | Effect |
+| --- | --- | --- |
+| `source_denylist` | `["cron"]` | Platforms/sources never offered or imported. Matched case-insensitively with `-` normalised to `_`. |
+| `require_completed` | `true` | Skip sessions still in progress (no `ended_at`). |
+| `min_message_count` | `1` | Skip sessions with fewer messages than this. `0` disables. |
+| `max_age_days` | `14` | Skip sessions older than this. `0` disables the age floor entirely. |
+| `recent_first` | `false` | Opt-in newest-first ordering *within* the never-imported class. Off by default: with sessions arriving continuously it lets the oldest never-imported session sort last on every run until it ages out unimported. |
+| `platform_denylist` | `[]` | Owner floor under admit-all platform mode (ruling 2026-08-14). |
+
+Re-running the installer **merges** this section: it seeds the floor defaults
+only on first install and never overwrites a value already present, so owner
+tuning and `platform_denylist` survive an upgrade. Keys written before the floor
+was lane-wide (`owner_review_source_denylist` and friends) are migrated to the
+current spelling automatically.
+
+Every scan reports why each candidate was excluded — `skipped_by_source_count`,
+`skipped_by_completion_count`, `skipped_by_message_count`, `skipped_by_age_count`,
+`skipped_by_unknown_timestamp_count`, plus `eligible_session_count` and the
+`scan_floor` that was applied. Check these first when the lane goes quiet: they
+distinguish "nothing was pending" from "the floor excluded everything", and
+`skipped_by_unknown_timestamp_count` specifically flags sessions whose timestamp
+could not be read rather than sessions that are genuinely stale.
+
 ## Installer Presets
 
 | Preset | Use when | Effect |

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -5031,6 +5031,35 @@ sannai-community 仓库 README。）
 
 ## 一句话
 
+- `2a7f806..HEAD`：选择策略分叉（DI）——`2a7f806` 把
+  SessionMirror 的选择策略劈成两半（审查面过滤 + 最近优先，执行面完全不过滤），于是
+  摘要offer一条、手动 apply 因指纹不符恒 `scope_mismatch` 死锁、毕业 lane **根本不比对
+  审批指纹**因而静默导入另一条；实测摘要 `20260910_recent` vs 两条 apply 路径
+  `20260504_old`。改法是把 floor **下沉进 `scan()` 自身**（`_FLOOR` 哨兵，`None` 不可用
+  因其是"不设年龄门"的真实语义），任何调用点无法再遗漏，三面指纹实测一致。顺带修掉
+  同族七项：四个 `skipped_by_*` 计数器算完即弃（候选现已逐条对账）、`candidate_session_count`
+  过滤前口径、`_normalize_timestamp` 数值分支无保护（毫秒时间戳一行坏数据打挂整个 profile
+  的 scan）、无时间戳被静默排除（改 tri-state + 单列计数）、默认值 14/30/None 三方不一致、
+  安装器整块覆盖 `session_mirror`（每次升级静默还原 owner 的 `platform_denylist`）、
+  `ensure_utc_aware` 未复用。临期提醒按 owner 裁定改回"搭车"：不再单独构成发送理由
+  （`confirm` 本就是硬拒绝的 no-op），且**追加而非替换**披露行——后者是一条有测试保护的
+  不变量的回归，只因两个 fixture 互斥、生产唯一的混合场景两边都没覆盖才没被发现。
+  `recent_first` 默认改 False（它在 never-imported 类内部重建 Backlog 13 的饿死）。
+  +10 反事实测试（已实测 revert→fail→restore→pass）；全量 **3618 passed / 27 failed /
+  4 skipped**，与 HEAD 基线（同一 runner）3608/27/4 **失败集合逐条相同、零回归**；
+  收集面对账 3648 + 92（藏在 6 个 numpy import 失败文件里）= 3740，与 CI 历史 3721
+  加两轮新增吻合。剩余 27 个逐条定性（18 无 numpy、5 需 gitignored 的 internal 文档、
+  3 需真 pytest、1 同族断言），无一与本节相关；四门静态检查全绿。
+  **方法教训（比本节代码更值得记）**：自建 runner 连错四次——没加载 `conftest.py`、
+  `monkeypatch` 字符串形式 bug、**不收集类内方法（少跑 977 个）**、不支持
+  `capsys`/`caplog`（静默跳过 87 个，其中 12 个就在本节改动的文件上）。
+  是 owner 追问四次才剥出来的。**报数字前先证明尺子是对的，并把收集总数与本文件里的
+  历史记录对上账。**
+  **注**：本机无 pytest 且无网络，上述数字来自自建最小 fixture runner，
+  **不等价于 `local_pass`，推送前须补跑 `python -m pytest -q` 全量**；
+  另有两个仅由 fixture 验证过的生产假设（`source` 是否真为 `cron`、`ended_at` 是否恒写）
+  待在 hermes-media 实测。
+
 - `842b9a2..HEAD`：permit scope 门修复（DH）——监控手工重建 scope 少算 `platform_denylist`，
   6 字段只哈希 5 个，该门恒 FAIL、**从未真正校验过任何东西**（同 envelope 仓库内 resolver 判
   `scope_match: true`）。apply 记录补该字段、监控用同字段集重算、历史行返回 `unverifiable`
@@ -7795,3 +7824,194 @@ sannai 单次运行 `sessions_scanned=405 / sessions_eligible=252 / sessions_pro
   按登记判据"原样重跑不复现"复跑一次即消失（87/14/3 → 88/13/2）。本轮连跑四次重型监控
   加两次部署，正是该项记录的主机负载条件，判为瞬时争用而非回归——但**这条观察点因此
   再次兑现，下次若在低负载下复现应当升级**。
+
+## DI — 选择策略被劈成两半：摘要看到的会话不是 lane 导入的会话（2026-09-12，评审 `2a7f806`）
+
+owner 报告：更新部署后 recurring owner-review 定时任务"不是空发送，就是发送的东西压根不是
+正确的"。`2a7f806` 为此引入四个过滤器 + 临期提醒。本节是对该提交的评审与修复。
+
+### 0. 根因一句话
+
+`2a7f806` 把**选择策略**劈成了两半：审查面（摘要 `_session_mirror_apply_review_items` +
+resolver `cli.py::_resolve_session_mirror_owner_apply_governance`）过滤 + 最近优先，
+执行面（`cli.py` 手动 apply、`session_mirror.py` auto-apply 两处）完全不过滤，中间没有
+任何东西把两者对齐。**改之前两边共用同一次 scan，队头天然一致——这个分叉是这次改出来的。**
+注释写着"digest-only filters"，那正是缺陷本身，不是设计。
+
+### 1. 两个后果，一个静默一个 fail-closed（用真实 schema 实测，非推断）
+
+固定 fixture（cron / 进行中 / 200 天前 / 2 天前各一条）：
+
+| 面 | 修复前选中 | 后果 |
+|---|---|---|
+| 摘要 | `20260910_recent` | 告诉 owner 要导入这条 |
+| 手动 apply | `20260504_old` | `_validate_owner_resolved_governance` 比对指纹失败 → `session_mirror_apply_scope_mismatch`，**通道死锁** |
+| 毕业 lane | `20260504_old` | `_validate_lane_graduated_governance` **根本不比对**审批指纹（只把它哈希进自己自洽的 permit scope），**静默导入错会话** |
+
+**lane 那条比手动那条严重**：按 CLAUDE.md，生产路径是"毕业 → 心跳 auto-apply"，手动 apply
+只是运维工具。且 2026-08-14 裁定下 lane 默认 `admit_all`，审批单的 `platform_allowlist`
+被忽略，所以连 cron 会话都能进。
+
+### 2. 修法：过滤器从"摘要专用"提升为"lane 级 floor"（owner 2026-09-12 裁定）
+
+与 `platform_denylist` 同形态——owner 设一次的底线，不是每次重批的门。关键是 floor
+**下沉进 `scan()` 自身**（`_FLOOR` 哨兵默认值），而不是要求每个调用点记得传：
+上一版的缺陷就是"某个调用点没传"。哨兵不能用 `None`，因为 `max_age_days=None` 是真实语义
+（不设年龄门）。改完三面实测指纹一致。
+
+键名去掉 `owner_review_` 前缀；`SESSION_MIRROR_LEGACY_FLOOR_KEYS` 负责迁移已部署的旧拼写。
+
+### 3. `recent_first` 默认改为 False——它会重建 Backlog 13 的饿死
+
+`2a7f806` 默认开启最近优先。但新会话持续到达时，最老的未导入会话每轮都排在新到达的后面，
+然后在 `max_age_days` 处直接过期，**永远不被导入**——正是 Backlog 13 在 never-imported
+类内部的重演。而让三面选同一条靠的是 floor 不是排序（关掉 recency 后实测依旧一致），
+所以这个语义变更纯是净损失。保留为 owner 可开的旋钮，不作为常态。
+
+### 4. 顺带修掉的同类缺陷（Section W 第 5 条：全项目扫同一模式）
+
+- **四个 `skipped_by_*` 计数器算完即弃**（全仓 grep 只有 4 行赋值）。摘要被过滤空时
+  `candidate=N selected=0` 而两个已发布的 skip 计数都是 0，无从区分"没有合格输入"与
+  "floor 吃光了"——正是"Completion Is Not Output"禁止的形状。现在进 report / audit /
+  apply record / auto-apply last-run，且**每条候选恰好落入一个已发布的结局桶**（测试对账）。
+  `ruff_required: false`，没有 lint 会拦住死变量，只能靠测试钉。
+- **`candidate_session_count` 仍是过滤前口径**：新增 `eligible_session_count`，不改旧键语义
+  （monitor 在读）。
+- **`_normalize_timestamp` 数值分支无保护**：部署 schema 是 `real` 列，毫秒级时间戳会抛
+  `ValueError: year must be in 1..9999` 穿出 `_discover_sessions()`，**一行坏数据打挂整个
+  profile 的 scan**。数字字符串分支则相反——原样返回digits，静默失活。两侧都修。
+- **无可用时间戳被静默排除**（`_session_is_within_age` 返回 False）：改为 tri-state
+  `_session_age_class`，`unknown` 单列计数，不折进 `too_old`。Section W 第 4 条。
+- **默认值三方不一致**：`DEFAULT_CONFIG`=14 / 两处 fallback=30 / 显式 `None` 直接关闭过滤器。
+  改为单一来源（复用 `_merge_session_mirror_config`），`None` 一律回落默认，`0` 才是
+  文档化的关闭方式。
+- **安装器整块覆盖 `config["session_mirror"]`**：改为合并。owner 设的 `platform_denylist`
+  （喂 monitor 的 auto-apply scope hash）此前每次升级都被静默还原。实测升级后 owner 调参存活。
+- `_is_imminent_provisional` 手写 naive→aware → 复用同文件已 import 的 `ensure_utc_aware`。
+
+### 5. 临期提醒：改回"搭车"而不是"独立触发"（方案 A）
+
+`2a7f806` 让 `imminent_nondeliverable_living_memory_total > 0` 单独构成发送理由。两个问题：
+
+- **这条提醒结构上不可操作**：`confirm_provisional_crystallized_record` 硬返回
+  `legacy_permanent_action_rejected`，唯一可用动作 `reject` 只是让它现在失效而不是 48 小时后
+  失效。文案自己写着"不需要回复"。
+- **它推翻了上一轮明确记录过的决定**：本文件 §"可投递项归零时议程静默"原文——
+  "这是 provisional 本就不需要 owner 决策的正确结果"。`2a7f806` 没引用这段也没更新本清单。
+
+改回门槛只看 `action_required_shown > 0`；临期行照常渲染，但**追加而非替换**披露行。
+
+**替换是一个有测试保护的不变量的回归**：`test_agenda_discloses_the_nondeliverable_provisional_backlog`
+（"The 24 filtered records must be disclosed, not silently dropped"）只因其 fixture 临期数为 0
+才还绿；新增测试把临期设成 1 且从不断言那 24 条还在。两个 fixture 互斥，**生产唯一会出现的
+混合场景两边都没覆盖**——又一次"fixture 与 bug 达成一致"。实测混合口径下"另有 24 条"整行消失。
+窗口同时从 24h 放宽到 48h：窗口等于 cron 周期会让记录在两次运行之间漏掉。
+
+### 6. 测试
+
+反事实测试（每条在无修复时 FAIL）：三面同选、候选结局对账、毫秒时间戳不打挂 scan、
+无时间戳单列计数、**时钟偏移的未来时间戳仍被准入**（旧谓词 `age >= 0 and age <= limit`
+会把它判为超龄；floor 变 lane 级后那等于永不导入且无任何计数说明原因）、临期行追加不替换、
+门槛不再被临期触发、安装器升级保留 owner 调参、安装器无条件退役 legacy 键、
+安装器与 config 的 legacy 键表不漂移。
+
+提交前独立评审（`/code-review high`，全 12 文件）：**0 findings**。它另外独立核实了
+`dedup_key` 是内容哈希不含时间戳——故时间戳归一化**不会动摇会话去重身份**（否则整个
+积压会被判为新会话重导一遍）；`imminent_nondeliverable_living_memory_total` 只有单一
+生产者，48h 常量与渲染计数不会漂移。上面那条"未来时间戳"测试正是该轮提出、本轮补上的。
+
+session_mirror 测试 fixture 集体刷新为"近期 + 已完成"：floor 现在对每次 scan 生效，
+冻结在固定过去日期的 fixture 测的是一条**不合格**会话，而不是一条正常会话。
+
+### 7. 验证状态
+
+- 静态检查（改动后复跑）：`import_cycle` pass / `write_surface` pass（167 面，
+  `unclassified_count=0`）/ `static_hygiene` pass / `public_checkout_probe` PASS /
+  `git diff --check` clean。
+- 全量：**3618 passed / 27 failed / 4 skipped**，与改动前基线（**同一 runner**）的
+  3608/27/4 **失败集合逐条相同、零回归**；+10 passed 恰为本节新增的十个反事实测试
+  （已逐个单独确认真的跑了并通过，不是被静默跳过）。
+- **收集面对账**（这一步本身是本轮补上的，见下）：实际收集运行 3648
+  （3618+27+4），另有 **92** 个测试藏在 6 个 `numpy` import 失败的文件里整文件未被收集，
+  合计 **3740**；对照 DH 轮 CI 的 3708 passed + 13 skipped = 3721，加 `2a7f806` 新增
+  与本节 +9，账吻合。
+- 剩余 27 个失败**逐条定性，无一与本节改动相关**：**18** 个 `ModuleNotFoundError: numpy`
+  （本机无且无网络；含 9 个此前因未收集类方法而根本没被发现的 `vector_decouple`）、
+  **5** 个 `closure_matrix_check` 需要
+  `docs/internal-memory-os/01-contracts/36-module-closure-matrix.md`——该目录按 CLAUDE.md
+  是 gitignored、不进 GitHub，**因此在任何干净克隆上都必然失败**、**3** 个
+  `pytest_policy` 必须真的跑一遍 pytest 才能生成 `policy.json`、**1** 个同属
+  closure_matrix 族的 AssertionError。剩余 4 个 skipped 均为测试自身调 `pytest.skip()`。
+- 反事实按 Section W 第 3 条**实测过 revert→fail→restore→pass**：把 `scan()` 的 floor
+  默认值还原成改前状态后，`test_every_surface_selects_the_same_session_as_the_digest_offered`
+  与 `test_scan_accounts_for_every_candidate_it_filtered` **双双 FAIL**，恢复后 PASS。
+- 全量首跑多出 `test_tiny_benchmark_uses_synthetic_corpus_and_reports_slo`
+  （`event_append_p95` 71.6ms/20ms、`sqlite_rebuild` 579ms/500ms）。**判为瞬时争用**：
+  本节改动不触及 event append / sqlite rebuild / prefetch / working decay 任何一条路径，
+  且低负载下原样复跑 **3/3 全过**——符合本文件既有登记判据。真因是本机 scratch 挂载点
+  配额耗尽导致 IO 抖动（见下）。
+- **`local_pass` 的口径必须写清楚：不是 pytest 跑出来的。** 本机无 pytest 且无网络
+  （`pip` SSL EOF），上述数字来自自建的最小 fixture runner。
+  **推送前仍须在有 pytest 的环境补跑 `python -m pytest -q` 全量**，本节数字只证明
+  "无回归"，不等价于 `local_pass`。
+
+- **本轮最值得记的一条教训，出在方法而不是代码上：我用一个从未验证过的测量工具下了
+  半天结论，而且它错了四次，是 owner 追问四次才一层层剥出来的。**
+  第一版 runner 报 "2342 passed / 134 failed，与基线 134 逐条相同"，据此宣称零回归。
+  owner 第一问"这么多错误你不查原因，你敢提交？"戳破第一层：**"与基线相同"只证明不是我
+  造成的，不证明它们无害——若尺子本身是坏的，基线与改动后会一起错，"零回归"什么都没证明。**
+  owner 第二问"这个项目的总测试不可能才 2500 多个，你看看之前的记录没？"戳破更大的一层：
+  清单自己记着 3708，我却只跑了 2629，**少了 27% 而我毫无察觉**。四个缺陷依次是：
+
+  | # | 缺陷 | 影响 |
+  |---|---|---|
+  | 1 | 没加载 `tests/conftest.py` | ~103 个假失败 |
+  | 2 | `monkeypatch.setattr("a.b.C", v)` 用 `sys.modules[mod]` 取模块，未导入即 KeyError（真 pytest 会 `import_module`） | 12 个假失败 |
+  | 3 | **只收集模块级函数，不收集 `Test*` 类的方法** | **少跑 977 个** |
+  | 4 | 不支持 `capsys`/`caplog` | 87 个被静默跳过 |
+
+  ①里 `isolate_candidate_aggregation_from_real_graph_gate` 是 `autouse=True`——**它不出现在
+  函数签名里，所以连"跳过"都没做，测试在缺失隔离的状态下裸跑**，这类最隐蔽。
+  ④最刺眼：修好后 `test_memory_os_session_mirror.py` + `test_memory_os_plugin_install.py`
+  由 97 passed/12 skipped 变成 **109 passed/0 skipped**——**就在本节改动的文件上，
+  此前有 12 个测试被静默跳过**，那句"零回归"在它们覆盖的范围里等于没说。
+
+  **规矩**（比上面任何一条都重要）：**报告测试数字之前，先证明测量工具本身是对的，
+  并且把收集数对上账。** 三个必查项：加载了 `conftest.py` 且应用了 autouse fixture；
+  收集了类内测试方法；收集总数与历史记录能对上（对不上就是还有没发现的漏收集）。
+  一个少收集 27% 的 runner 报出的"全绿"同样不可信，只是没人去数而已——而**本文件里就
+  躺着可对账的历史数字，我却没去查**。
+  （附带：该 runner 每个测试 `mkdtemp()` 却不回收，撑爆磁盘配额导致连 `true` 都返回非零——
+  见下一节。已加回收，且需先 `chmod` 才能删掉测试故意设为只读的归档树，否则静默删不掉。）
+- 生产假设待实测（仅由 fixture 验证过）：`select distinct source from sessions`（确认 "cron"
+  确为 source 值）；`select count(*) from sessions where ended_at is null` （确认
+  `require_completed` 不会误杀崩溃结束的会话）。
+
+### 8. 独立评审（`/code-review high`）+ 自评的三项，及一个明写的取舍
+
+独立评审只报出一项（与自评重合）：**安装器只在"新键缺失"分支里 pop 旧拼写**，导致同时带
+两种拼写的配置永远留着 stale alias。功能无害（merge 优先新键），但与循环自称的"迁移一次"
+相反，且 stale alias 正是后来的读者会误当成生效值的东西。已改为无条件 retire + 反事实测试。
+
+自评另外抓到独立评审没报的两项：
+
+- **注释漂移**：`scan()` 排序块仍写着"Owner review opts into recent-first only after the
+  explicit digest filters above"——描述的是被本节删掉的 digest-only 设计。注释与代码相反
+  比没有注释更糟，已重写。
+- **`recent_first` 的旧值会被迁移回来**：跑过 `2a7f806` 安装器的主机，config 里是
+  `owner_review_recent_first: true`，迁移会忠实地映射成 `recent_first: true`，把本节
+  默认关掉的排序又打开。**这里的取舍明写出来**：不迁移等于替 owner 丢弃一个他配置里
+  的值；迁移则可能带回饿死风险。选择**迁移**，理由是该风险在实际速率下有界（导入
+  288 次/天 远大于新会话到达率），且**每份 scan 报告都回显 `scan_floor.recent_first`**，
+  运维随时看得见它是开是关——满足"绝不静默"的要求。若日后观察到尾部确实饿死，改默认值
+  即可，不需要改迁移逻辑。
+
+### 9. 工具侧教训（与代码无关，但值得记一笔）
+
+排查中 Bash 工具整体失效：**每条命令（连 `true`）都返回非零且 stdout 完全为空**。
+真因是**我自己在会话 scratch 目录里建了个 venv**（pip 还装失败了），撑爆该挂载点配额；
+而 Bash 的输出捕获要写这个路径，于是所有命令的返回通道一起哑掉——**故障表现与命令内容
+完全无关，看 Bash 的空返回永远查不出来**。定位靠的是换一条代码路径（`Write` 工具）去写
+同一目录，拿到 `EDQUOT` 才实锤。删掉 venv 与已消费的后台 transcript 后恢复。
+教训：**排查"工具整体失效"时，先换一条不共用同一资源的代码路径取错误信息**；以及
+不要在会话 scratch 里建 venv。

--- a/docs/resolver/hermes-memory-os-stabilization-checklist.md
+++ b/docs/resolver/hermes-memory-os-stabilization-checklist.md
@@ -5041,11 +5041,14 @@ sannai-community 仓库 README。）
   过滤前口径、`_normalize_timestamp` 数值分支无保护（毫秒时间戳一行坏数据打挂整个 profile
   的 scan）、无时间戳被静默排除（改 tri-state + 单列计数）、默认值 14/30/None 三方不一致、
   安装器整块覆盖 `session_mirror`（每次升级静默还原 owner 的 `platform_denylist`）、
-  `ensure_utc_aware` 未复用。临期提醒按 owner 裁定改回"搭车"：不再单独构成发送理由
-  （`confirm` 本就是硬拒绝的 no-op），且**追加而非替换**披露行——后者是一条有测试保护的
-  不变量的回归，只因两个 fixture 互斥、生产唯一的混合场景两边都没覆盖才没被发现。
+  `ensure_utc_aware` 未复用。临期提醒保留为安全的 metadata-only 告警：不发送正文或审批 token，
+  且在它是唯一可见告警时仍不能被 helper 误判为空输出；披露行继续**追加而非替换**。
   `recent_first` 默认改 False（它在 never-imported 类内部重建 Backlog 13 的饿死）。
-  +10 反事实测试（已实测 revert→fail→restore→pass）；全量 **3618 passed / 27 failed /
+  原 PR 的 +10 反事实测试（已实测 revert→fail→restore→pass）之外，本次 review follow-up
+  另补 4 个 floor/API/helper 回归测试，相关本地目标测试为 258 passed；临期 provisional 仍只发送脱敏
+  metadata-only 提醒，不进入正文或审批 token；当它是唯一可见告警时也不能被 helper
+  误判为空输出。
+  全量 **3618 passed / 27 failed /
   4 skipped**，与 HEAD 基线（同一 runner）3608/27/4 **失败集合逐条相同、零回归**；
   收集面对账 3648 + 92（藏在 6 个 numpy import 失败文件里）= 3740，与 CI 历史 3721
   加两轮新增吻合。剩余 27 个逐条定性（18 无 numpy、5 需 gitignored 的 internal 文档、
@@ -7889,30 +7892,23 @@ resolver `cli.py::_resolve_session_mirror_owner_apply_governance`）过滤 + 最
   （喂 monitor 的 auto-apply scope hash）此前每次升级都被静默还原。实测升级后 owner 调参存活。
 - `_is_imminent_provisional` 手写 naive→aware → 复用同文件已 import 的 `ensure_utc_aware`。
 
-### 5. 临期提醒：改回"搭车"而不是"独立触发"（方案 A）
+### 5. 临期提醒：保留安全的 metadata-only 告警
 
-`2a7f806` 让 `imminent_nondeliverable_living_memory_total > 0` 单独构成发送理由。两个问题：
+`2a7f806` 曾让 `imminent_nondeliverable_living_memory_total > 0` 单独构成发送理由。
+本轮确认它不能发送 provisional 正文，也不能提供审批 token；但这不等于应该把整个
+main digest 再次静默。临期告警本身是安全的状态通知：不暴露正文、不创建 Owner action，
+但能明确告诉 owner 有内容即将自动失效。
 
-- **这条提醒结构上不可操作**：`confirm_provisional_crystallized_record` 硬返回
-  `legacy_permanent_action_rejected`，唯一可用动作 `reject` 只是让它现在失效而不是 48 小时后
-  失效。文案自己写着"不需要回复"。
-- **它推翻了上一轮明确记录过的决定**：本文件 §"可投递项归零时议程静默"原文——
-  "这是 provisional 本就不需要 owner 决策的正确结果"。`2a7f806` 没引用这段也没更新本清单。
-
-改回门槛只看 `action_required_shown > 0`；临期行照常渲染，但**追加而非替换**披露行。
-
-**替换是一个有测试保护的不变量的回归**：`test_agenda_discloses_the_nondeliverable_provisional_backlog`
-（"The 24 filtered records must be disclosed, not silently dropped"）只因其 fixture 临期数为 0
-才还绿；新增测试把临期设成 1 且从不断言那 24 条还在。两个 fixture 互斥，**生产唯一会出现的
-混合场景两边都没覆盖**——又一次"fixture 与 bug 达成一致"。实测混合口径下"另有 24 条"整行消失。
-窗口同时从 24h 放宽到 48h：窗口等于 cron 周期会让记录在两次运行之间漏掉。
+因此保留 48 小时窗口，并让 helper 在 provisional-only 场景也输出；临期行仍然**追加而非替换**
+既有 backlog disclosure，防止混合场景丢掉其余隐藏记录。普通非临期 provisional 仍不会单独
+触发 agenda 推送。
 
 ### 6. 测试
 
 反事实测试（每条在无修复时 FAIL）：三面同选、候选结局对账、毫秒时间戳不打挂 scan、
-无时间戳单列计数、**时钟偏移的未来时间戳仍被准入**（旧谓词 `age >= 0 and age <= limit`
-会把它判为超龄；floor 变 lane 级后那等于永不导入且无任何计数说明原因）、临期行追加不替换、
-门槛不再被临期触发、安装器升级保留 owner 调参、安装器无条件退役 legacy 键、
+无时间戳单列计数、时钟偏移的未来时间戳仍被准入、临期行追加不替换、临期 metadata-only 告警
+可单独触发 helper stdout、platform_denylist 对所有 scan 生效且不能被 explicit 参数削弱、
+直接 `max_age_days=0` 关闭年龄门、安装器升级保留 owner 调参、安装器无条件退役 legacy 键、
 安装器与 config 的 legacy 键表不漂移。
 
 提交前独立评审（`/code-review high`，全 12 文件）：**0 findings**。它另外独立核实了

--- a/plugins/memory/memory_os/cli.py
+++ b/plugins/memory/memory_os/cli.py
@@ -49,7 +49,7 @@ _ensure_user_plugin_package()
 from .audit import last_audit_age_seconds, read_audit_entries
 from .benchmark import BenchmarkConfig, run_benchmark
 from .cleanup import CleanupPolicy, cleanup_plan
-from .config import load_config, owner_review_session_mirror_scan_options, save_config
+from .config import load_config, save_config
 from .conversation_regression import (
     evaluate_transcript_file,
     prompt_set_report,
@@ -2377,13 +2377,12 @@ def _resolve_session_mirror_owner_apply_governance(
         )
     ):
         return _blocked_session_mirror_owner_apply(store, metadata, "session_mirror_apply_owner_ref_boundary_true")
+    # Revalidation must scan under exactly the floor the apply below will use,
+    # which is now `scan()`'s default -- so it passes no filter arguments either.
     dry_run = SessionMirror(store).scan(
         dry_run=True,
         max_sessions=requested_max,
         platform_allowlist=list(requested_platforms or approved_platforms) or None,
-        **owner_review_session_mirror_scan_options(
-            load_config(store.roots.hermes_home).get("session_mirror", {})
-        ),
     )
     fingerprints = dry_run.get("selected_session_fingerprints") if isinstance(dry_run.get("selected_session_fingerprints"), list) else []
     expected_fingerprint = str(result_ref.get("selected_pending_session_fingerprint") or "")

--- a/plugins/memory/memory_os/config.py
+++ b/plugins/memory/memory_os/config.py
@@ -711,7 +711,9 @@ def _merge_session_mirror_config(value: Any) -> dict[str, Any]:
     merged["recent_first"] = _floor_bool(merged.get("recent_first"), default["recent_first"])
     raw_denylist = merged.get("platform_denylist")
     merged["platform_denylist"] = [
-        str(item) for item in raw_denylist if str(item or "").strip()
+        str(item).strip().lower().replace("-", "_")
+        for item in raw_denylist
+        if str(item or "").strip()
     ] if isinstance(raw_denylist, list) else []
     return merged
 
@@ -736,6 +738,7 @@ def session_mirror_scan_options(value: Any) -> dict[str, Any]:
         # 0 is the documented opt-out: no age floor at all.
         "max_age_days": max_age_days if max_age_days > 0 else None,
         "recent_first": bool(config["recent_first"]),
+        "platform_denylist": list(config["platform_denylist"]),
     }
 
 

--- a/plugins/memory/memory_os/config.py
+++ b/plugins/memory/memory_os/config.py
@@ -175,14 +175,31 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "production_apply_owner_ref_required": True,
         "auto_apply_after_owner_home_graduation": True,
         "auto_apply_max_sessions_per_run": 1,
-        # Recurring owner digests must not be occupied by the historical cron
-        # backlog or an in-progress session. Manual/auto-apply scans retain
-        # their broader admission semantics; these are digest-only filters.
-        "owner_review_source_denylist": ["cron"],
-        "owner_review_require_completed": True,
-        "owner_review_min_message_count": 1,
-        "owner_review_max_age_days": 14,
-        "owner_review_recent_first": True,
+        # Admission floor for the whole import lane -- the same shape as
+        # `platform_denylist` below: something the owner sets once, not a gate
+        # they re-approve (owner ruling 2026-08-14). These were introduced as
+        # digest-only filters, which split selection between the review surface
+        # and the apply surfaces: the digest offered a recent human session
+        # while the graduated lane still imported the head of the unfiltered
+        # backlog. One floor, read by every scan, is what keeps "what the owner
+        # was shown" and "what the lane imports" the same session.
+        "source_denylist": ["cron"],
+        "require_completed": True,
+        "min_message_count": 1,
+        "max_age_days": 14,
+        # Ordering is part of the floor -- identical admission with different
+        # ordering still yields a different head, and the head is what gets
+        # imported -- so it is resolved here, once, for every scan.
+        #
+        # Default OFF. Recency was introduced to keep the cron/active/stale
+        # backlog off the digest head, but the admission floor above already
+        # does that, and recency costs something the floor does not: with new
+        # sessions arriving continuously, the oldest never-imported session
+        # sorts last on every run and then ages out at `max_age_days` without
+        # ever being imported -- Backlog 13's starvation, rebuilt inside the
+        # never-imported class. Queue order drains that tail FIFO. Left as an
+        # owner knob, not as normal operation.
+        "recent_first": False,
         # Owner-writable floor for the admit-all platform mode (owner ruling
         # 2026-08-14). A denylist is the inverse of the retired per-approval
         # allowlist: the owner sets it once to exclude a platform forever,
@@ -633,6 +650,36 @@ def _merge_right_brain_expression_config(value: Any) -> dict[str, Any]:
     return merged
 
 
+# Spellings used while these floors were digest-only (2a7f806). Kept so an
+# already-deployed config.json keeps the owner's tuning across the rename.
+SESSION_MIRROR_LEGACY_FLOOR_KEYS: dict[str, str] = {
+    "source_denylist": "owner_review_source_denylist",
+    "require_completed": "owner_review_require_completed",
+    "min_message_count": "owner_review_min_message_count",
+    "max_age_days": "owner_review_max_age_days",
+    "recent_first": "owner_review_recent_first",
+}
+
+
+def _floor_bool(value: Any, default: bool) -> bool:
+    return bool(default) if value is None else bool(value)
+
+
+def _floor_int(value: Any, default: int) -> int:
+    """Clamp an admission-floor integer, falling back to the declared default.
+
+    ``None`` means "not configured", never "disabled" -- a floor that switches
+    itself off when a key is missing is exactly the landmine Section W rule 4
+    forbids. An explicit ``0`` is the documented opt-out.
+    """
+    if value is None:
+        return max(int(default), 0)
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return max(int(default), 0)
+
+
 def _merge_session_mirror_config(value: Any) -> dict[str, Any]:
     default = dict(DEFAULT_CONFIG["session_mirror"])
     if not isinstance(value, dict):
@@ -644,23 +691,24 @@ def _merge_session_mirror_config(value: Any) -> dict[str, Any]:
     merged["test_host_apply_allowed"] = bool(merged.get("test_host_apply_allowed"))
     merged["test_host_marker"] = str(merged.get("test_host_marker") or "")
     merged["production_apply_owner_ref_required"] = bool(merged.get("production_apply_owner_ref_required"))
-    raw_review_source_denylist = merged.get("owner_review_source_denylist")
-    merged["owner_review_source_denylist"] = [
-        str(item).strip().lower() for item in raw_review_source_denylist if str(item or "").strip()
-    ] if isinstance(raw_review_source_denylist, list) else ["cron"]
-    merged["owner_review_require_completed"] = bool(merged.get("owner_review_require_completed", True))
-    try:
-        merged["owner_review_min_message_count"] = max(int(merged.get("owner_review_min_message_count") or 1), 0)
-    except (TypeError, ValueError):
-        merged["owner_review_min_message_count"] = 1
-    try:
-        raw_max_age_days = merged.get("owner_review_max_age_days", 30)
-        if raw_max_age_days is None:
-            raw_max_age_days = 30
-        merged["owner_review_max_age_days"] = max(int(raw_max_age_days), 0)
-    except (TypeError, ValueError):
-        merged["owner_review_max_age_days"] = 30
-    merged["owner_review_recent_first"] = bool(merged.get("owner_review_recent_first", True))
+    # Legacy spellings from the digest-only era (config.json written by an
+    # installer between 2a7f806 and this change). `for key in default` above
+    # only copies keys the default declares, so without this an already
+    # deployed host would silently fall back to the defaults and lose whatever
+    # the owner had tuned.
+    for key, legacy_key in SESSION_MIRROR_LEGACY_FLOOR_KEYS.items():
+        if key not in value and legacy_key in value:
+            merged[key] = value[legacy_key]
+    raw_source_denylist = merged.get("source_denylist")
+    merged["source_denylist"] = [
+        str(item).strip().lower().replace("-", "_")
+        for item in raw_source_denylist
+        if str(item or "").strip()
+    ] if isinstance(raw_source_denylist, list) else list(default["source_denylist"])
+    merged["require_completed"] = _floor_bool(merged.get("require_completed"), default["require_completed"])
+    merged["min_message_count"] = _floor_int(merged.get("min_message_count"), default["min_message_count"])
+    merged["max_age_days"] = _floor_int(merged.get("max_age_days"), default["max_age_days"])
+    merged["recent_first"] = _floor_bool(merged.get("recent_first"), default["recent_first"])
     raw_denylist = merged.get("platform_denylist")
     merged["platform_denylist"] = [
         str(item) for item in raw_denylist if str(item or "").strip()
@@ -668,29 +716,26 @@ def _merge_session_mirror_config(value: Any) -> dict[str, Any]:
     return merged
 
 
-def owner_review_session_mirror_scan_options(value: Any) -> dict[str, Any]:
-    """Return one normalized filter set for digest and approval revalidation."""
-    config = value if isinstance(value, dict) else {}
-    raw_denylist = config.get("owner_review_source_denylist", ["cron"])
-    source_denylist = (
-        [str(item).strip().lower() for item in raw_denylist if str(item or "").strip()]
-        if isinstance(raw_denylist, list)
-        else ["cron"]
-    )
-    try:
-        min_message_count = max(int(config.get("owner_review_min_message_count", 1) or 0), 0)
-    except (TypeError, ValueError):
-        min_message_count = 1
-    try:
-        max_age_days = max(int(config.get("owner_review_max_age_days", 30) or 0), 0)
-    except (TypeError, ValueError):
-        max_age_days = 30
+def session_mirror_scan_options(value: Any) -> dict[str, Any]:
+    """Return the admission floor every SessionMirror scan must apply.
+
+    One floor for the review surface and the apply surfaces alike. Splitting it
+    -- filters on the digest, none on the apply path -- is what let the digest
+    offer a recent human session while the graduated lane imported the head of
+    the unfiltered backlog. Callers pass the ``session_mirror`` config section;
+    it is re-normalized here through the same merge used by ``load_config`` so
+    a caller that skipped ``load_config`` cannot quietly run a weaker floor
+    than the owner configured.
+    """
+    config = _merge_session_mirror_config(value if isinstance(value, dict) else {})
+    max_age_days = int(config["max_age_days"])
     return {
-        "source_denylist": source_denylist,
-        "completed_only": bool(config.get("owner_review_require_completed", True)),
-        "min_message_count": min_message_count,
-        "max_age_days": max_age_days or None,
-        "recent_first": bool(config.get("owner_review_recent_first", True)),
+        "source_denylist": list(config["source_denylist"]),
+        "completed_only": bool(config["require_completed"]),
+        "min_message_count": int(config["min_message_count"]),
+        # 0 is the documented opt-out: no age floor at all.
+        "max_age_days": max_age_days if max_age_days > 0 else None,
+        "recent_first": bool(config["recent_first"]),
     }
 
 

--- a/plugins/memory/memory_os/owner_actions.py
+++ b/plugins/memory/memory_os/owner_actions.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 
 from .approval import ApprovalDecision, ApprovalPurpose
 from .audit import append_audit, read_audit_records
-from .config import load_config, owner_review_session_mirror_scan_options
+from .config import load_config
 from .crystallized import (
     CrystallizedCandidate,
     CrystallizedMemoryService,
@@ -2993,6 +2993,11 @@ def _assemble_living_memory_delivery_items(
     }
 
 
+# Wider than the digest's own 24h cadence on purpose: a window exactly equal to
+# the cadence lets a record slip between two runs and never be mentioned at all.
+IMMINENT_PROVISIONAL_EXPIRY_HOURS = 48
+
+
 def _is_imminent_provisional(item: dict[str, Any], *, now: datetime) -> bool:
     if str(item.get("target_type") or "") != "provisional_crystallized_record":
         return False
@@ -3001,12 +3006,13 @@ def _is_imminent_provisional(item: dict[str, Any], *, now: datetime) -> bool:
         return False
     try:
         expiry = datetime.fromisoformat(expires_at)
-    except ValueError:
+    except (TypeError, ValueError):
         return False
-    if expiry.tzinfo is None:
-        expiry = expiry.replace(tzinfo=timezone.utc)
+    # Same normalization every other expiry comparison in this file uses; a
+    # third hand-rolled copy would silently miss a future change to its rules.
+    expiry = ensure_utc_aware(expiry)
     remaining = expiry - now
-    return timedelta(0) <= remaining <= timedelta(hours=24)
+    return timedelta(0) <= remaining <= timedelta(hours=IMMINENT_PROVISIONAL_EXPIRY_HOURS)
 
 
 def _consume_owner_write_context(store: MemoryOSStore, record: dict[str, Any]) -> dict[str, Any]:
@@ -5106,13 +5112,12 @@ def _session_mirror_apply_review_items(
         session_mirror_stable_scope_id,
     )
 
-    session_mirror_config = load_config(store.roots.hermes_home).get("session_mirror", {})
     try:
-        report = SessionMirror(store).scan(
-            dry_run=True,
-            max_sessions=1,
-            **owner_review_session_mirror_scan_options(session_mirror_config),
-        )
+        # No filter arguments: `scan()` applies the owner's configured admission
+        # floor by default, and the SAME floor drives the apply paths. Passing a
+        # digest-only filter set here is what made this surface advertise one
+        # session while the lane imported another.
+        report = SessionMirror(store).scan(dry_run=True, max_sessions=1)
     except Exception:
         return []
     selected = report.get("selected_sessions") if isinstance(report.get("selected_sessions"), list) else []
@@ -6530,15 +6535,19 @@ def _rendered_overview_lines(
             # No owner_review_surface_report operation returns just the filtered
             # provisional records, so naming one would repeat the exact defect
             # this section fixes: advertising a path that does not reach.
+            lines.append(
+                f"- 另有 {nondeliverable_living_memory} 条临时记忆(provisional)不需要你在这里决定："
+                "它们到期会自动失效，成熟的会另走永久记忆提案来问你。"
+            )
             if imminent_nondeliverable_living_memory:
+                # Appended, never substituted: the backlog disclosure is a
+                # standing invariant (a prior cycle added it precisely so the
+                # filtered records are "disclosed, not silently dropped"), and
+                # replacing it whenever one record happens to be imminent drops
+                # the other N from the message.
                 lines.append(
-                    f"- 临期提醒：有 {imminent_nondeliverable_living_memory} 条临时记忆将在 24 小时内自动失效；"
-                    "正文不在此推送，不需要在这里回复。"
-                )
-            else:
-                lines.append(
-                    f"- 另有 {nondeliverable_living_memory} 条临时记忆(provisional)不需要你在这里决定："
-                    "它们到期会自动失效，成熟的会另走永久记忆提案来问你。"
+                    f"  其中 {imminent_nondeliverable_living_memory} 条将在 "
+                    f"{IMMINENT_PROVISIONAL_EXPIRY_HOURS} 小时内失效；同样不需要回复。"
                 )
         if action_omitted:
             lines.append("- 想继续处理可回复：下一页 / 还有哪些 / 展开 A4。")

--- a/plugins/memory/memory_os/session_mirror.py
+++ b/plugins/memory/memory_os/session_mirror.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .audit import append_audit
-from .config import load_config
+from .config import load_config, session_mirror_scan_options
 from .knob_overrides import resolve_knob
 from .execution_gate import (
     complete_execution_gate_envelope,
@@ -28,6 +28,20 @@ from .read_model_paths import (
 from .roots import MemoryOSRoots
 from .schema import EVENT_SCHEMA_VERSION, EventEnvelope
 from .store import MemoryOSStore
+from .timeutil import parse_utc
+
+
+class _FloorDefault:
+    """Marker for "use the owner's configured admission floor".
+
+    A plain ``None`` cannot carry this meaning: ``max_age_days=None`` is a real,
+    documented value (no age floor), so the two must stay distinguishable.
+    """
+
+    __slots__ = ()
+
+
+_FLOOR = _FloorDefault()
 
 
 SESSION_MIRROR_APPLY_SCHEMA_VERSION = "memory-os.session_mirror_apply.v0"
@@ -255,6 +269,15 @@ def _auto_apply_scan_counters(report: dict[str, Any]) -> dict[str, int]:
         "skipped_by_platform_count": int(report.get("skipped_by_platform_count") or 0),
         "skipped_by_limit_count": int(report.get("skipped_by_limit_count") or 0),
         "skipped_by_owner_rejection_count": int(report.get("skipped_by_owner_rejection_count") or 0),
+        # The floor is shared with the digest, so when the lane goes quiet these
+        # are what say whether the owner's floor ate the backlog or the backlog
+        # was simply empty.
+        "eligible_session_count": int(report.get("eligible_session_count") or 0),
+        "skipped_by_source_count": int(report.get("skipped_by_source_count") or 0),
+        "skipped_by_completion_count": int(report.get("skipped_by_completion_count") or 0),
+        "skipped_by_message_count": int(report.get("skipped_by_message_count") or 0),
+        "skipped_by_age_count": int(report.get("skipped_by_age_count") or 0),
+        "skipped_by_unknown_timestamp_count": int(report.get("skipped_by_unknown_timestamp_count") or 0),
     }
 
 
@@ -532,15 +555,34 @@ class SessionMirror:
         max_sessions: int = 0,
         platform_allowlist: list[str] | tuple[str, ...] | None = None,
         platform_denylist: list[str] | tuple[str, ...] | None = None,
-        source_denylist: list[str] | tuple[str, ...] | None = None,
-        completed_only: bool = False,
-        min_message_count: int = 0,
-        max_age_days: int | None = None,
-        recent_first: bool = False,
+        # The admission floor is NOT a per-call-site option. It defaults to the
+        # owner's configured floor, because the defect this replaces was a
+        # call site that simply did not pass it: the digest scanned with
+        # filters, the apply path scanned without, and the lane imported a
+        # different session than the owner was shown. `_FLOOR` means "use the
+        # configured floor"; pass a value only to deliberately override it.
+        source_denylist: list[str] | tuple[str, ...] | None | _FloorDefault = _FLOOR,
+        completed_only: bool | _FloorDefault = _FLOOR,
+        min_message_count: int | _FloorDefault = _FLOOR,
+        max_age_days: int | None | _FloorDefault = _FLOOR,
+        recent_first: bool | _FloorDefault = _FLOOR,
         apply_governance: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if not dry_run:
             self.store.initialize()
+        floor = session_mirror_scan_options(
+            load_config(self.store.roots.hermes_home).get("session_mirror", {})
+        )
+        if isinstance(source_denylist, _FloorDefault):
+            source_denylist = floor["source_denylist"]
+        if isinstance(completed_only, _FloorDefault):
+            completed_only = floor["completed_only"]
+        if isinstance(min_message_count, _FloorDefault):
+            min_message_count = floor["min_message_count"]
+        if isinstance(max_age_days, _FloorDefault):
+            max_age_days = floor["max_age_days"]
+        if isinstance(recent_first, _FloorDefault):
+            recent_first = floor["recent_first"]
         state, state_rebuilt, findings = self._load_state(persist_repair=not dry_run)
         error_summary = _error_summary_from_findings(findings)
         sessions = self._discover_sessions()
@@ -590,14 +632,28 @@ class SessionMirror:
             session for session in completed_filtered
             if int(session.get("message_count") or 0) >= min_messages
         ]
-        age_filtered = [
-            session for session in message_filtered
-            if max_age_days is None or _session_is_within_age(session, max_age_days)
-        ]
+        age_filtered: list[dict[str, Any]] = []
+        skipped_by_age_count = 0
+        skipped_by_unknown_timestamp_count = 0
+        for session in message_filtered:
+            age_class = _session_age_class(session, max_age_days)
+            if age_class == "ok":
+                age_filtered.append(session)
+            elif age_class == "unknown":
+                # Not provably stale -- but also not admitted, because an
+                # unreadable timestamp is exactly how the historical backlog
+                # would leak back in. Counted separately so the exclusion can
+                # never be silent (the defect this replaces returned False here
+                # and reported nothing).
+                skipped_by_unknown_timestamp_count += 1
+            else:
+                skipped_by_age_count += 1
         eligible_sessions = age_filtered
-        # The normal scanner retains its historical queue ordering. Owner
-        # review opts into recent-first only after the explicit digest filters
-        # above, so a cron/active/empty backlog cannot occupy its head.
+        # Ordering comes from the same configured floor as admission above --
+        # every surface sorts identically, because an identical candidate set
+        # with a different sort still yields a different head, and the head is
+        # what gets imported. `recent_first` is off by default; the floor, not
+        # the ordering, is what keeps cron/active/stale sessions off the head.
         if recent_first:
             eligible_sessions.sort(
                 key=lambda session: (
@@ -624,8 +680,26 @@ class SessionMirror:
         skipped_by_source_count = len(platform_filtered) - len(source_filtered)
         skipped_by_completion_count = len(source_filtered) - len(completed_filtered)
         skipped_by_message_count = len(completed_filtered) - len(message_filtered)
-        skipped_by_age_count = len(message_filtered) - len(age_filtered)
         skipped_by_limit_count = max(len(eligible_sessions) - len(selected_sessions), 0)
+        # Every lane that produces nothing must say why in its own artifact
+        # (CLAUDE.md "Completion Is Not Output"). These four plus
+        # `eligible_session_count` are what separate "no eligible input" from
+        # "the floor ate everything" without re-running or reading the source.
+        floor_counters = {
+            "eligible_session_count": len(eligible_sessions),
+            "skipped_by_source_count": skipped_by_source_count,
+            "skipped_by_completion_count": skipped_by_completion_count,
+            "skipped_by_message_count": skipped_by_message_count,
+            "skipped_by_age_count": skipped_by_age_count,
+            "skipped_by_unknown_timestamp_count": skipped_by_unknown_timestamp_count,
+            "scan_floor": {
+                "source_denylist": sorted(sources),
+                "completed_only": bool(completed_only),
+                "min_message_count": min_messages,
+                "max_age_days": max_age_days,
+                "recent_first": bool(recent_first),
+            },
+        }
         written_events: list[str] = []
         resolved_apply_governance = dict(apply_governance or {})
         if not dry_run and selected_sessions:
@@ -660,6 +734,7 @@ class SessionMirror:
                     "skipped_by_platform_count": skipped_by_platform_count,
                     "skipped_by_limit_count": skipped_by_limit_count,
                     "skipped_by_owner_rejection_count": skipped_by_owner_rejection_count,
+                    **floor_counters,
                     "new_event_count": 0,
                     "dry_run": False,
                     "apply_bounded": True,
@@ -706,6 +781,7 @@ class SessionMirror:
                     "selected_session_count": len(selected_sessions),
                     "covered_session_count": len(covered),
                     "state_rebuilt": state_rebuilt,
+                    **floor_counters,
                 },
             )
             self._append_apply_record(
@@ -714,6 +790,7 @@ class SessionMirror:
                 skipped_by_platform_count=skipped_by_platform_count,
                 skipped_by_limit_count=skipped_by_limit_count,
                 skipped_by_owner_rejection_count=skipped_by_owner_rejection_count,
+                floor_counters=floor_counters,
                 platform_allowlist=platforms,
                 platform_denylist=sorted(denied),
                 max_sessions=limit,
@@ -736,6 +813,7 @@ class SessionMirror:
             "skipped_by_platform_count": skipped_by_platform_count,
             "skipped_by_limit_count": skipped_by_limit_count,
             "skipped_by_owner_rejection_count": skipped_by_owner_rejection_count,
+            **floor_counters,
             "new_event_count": len(selected_sessions),
             "dry_run": dry_run,
             "apply_bounded": not dry_run or bool(limit or platforms),
@@ -964,6 +1042,7 @@ class SessionMirror:
         skipped_by_platform_count: int,
         skipped_by_limit_count: int,
         skipped_by_owner_rejection_count: int,
+        floor_counters: dict[str, Any],
         platform_allowlist: list[str],
         platform_denylist: list[str],
         max_sessions: int,
@@ -983,6 +1062,7 @@ class SessionMirror:
             "profile": self.store.roots.profile or "default",
             "status": status,
             "apply_bounded": bool(max_sessions or platform_allowlist),
+            **dict(floor_counters),
             "max_sessions": max_sessions,
             "platform_allowlist": platform_allowlist,
             # Recorded so an external verifier can rebuild the SAME scope the
@@ -1145,16 +1225,38 @@ def _has_value(value: Any) -> bool:
     return value is not None and str(value).strip().lower() not in {"", "none", "null"}
 
 
+_DATE_ONLY_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+
+
+def _epoch_to_iso(value: float) -> str:
+    """Return the ISO form of an epoch-SECONDS value, or "" when out of range.
+
+    Out of range is not an exception to let escape: a millisecond-precision
+    timestamp (a very common convention) raises ``ValueError: year must be in
+    1..9999`` here, and ``_discover_sessions`` has no per-row recovery -- one
+    bad row would abort the scan for the whole profile. Returning "" routes it
+    to the unknown-timestamp counter instead: visible rather than fatal.
+    """
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return ""
+
+
 def _normalize_timestamp(value: Any) -> str:
-    if not _has_value(value):
+    if not _has_value(value) or isinstance(value, bool):
         return ""
     if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+        return _epoch_to_iso(value)
     text = str(value).strip()
     try:
-        return datetime.fromtimestamp(float(text), tz=timezone.utc).isoformat()
-    except (TypeError, ValueError, OverflowError):
+        numeric = float(text)
+    except (TypeError, ValueError):
         return text.replace("Z", "+00:00") if text.endswith("Z") else text
+    # A numeric STRING is still an epoch. The previous code fell through to
+    # returning the digits verbatim, which parses as no date at all and was
+    # then silently dropped downstream.
+    return _epoch_to_iso(numeric)
 
 
 def _row_timestamp(row: sqlite3.Row, columns: tuple[str, ...]) -> str:
@@ -1166,24 +1268,36 @@ def _row_timestamp(row: sqlite3.Row, columns: tuple[str, ...]) -> str:
 
 
 def _session_timestamp_rank(session: dict[str, Any]) -> float:
+    """Sortable epoch seconds for a session, or 0.0 when it has no usable time."""
     value = str(session.get("updated_at") or "").strip()
     if not value:
         return 0.0
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed.timestamp()
-    except (TypeError, ValueError, OverflowError):
-        return 0.0
+    parsed = parse_utc(value, allow_naive=True)
+    if parsed is None and _DATE_ONLY_RE.match(value):
+        # parse_utc deliberately rejects date-only input; a session file that
+        # carries only a date is still orderable, at midnight UTC.
+        parsed = parse_utc(value + "T00:00:00+00:00")
+    return parsed.timestamp() if parsed is not None else 0.0
 
 
-def _session_is_within_age(session: dict[str, Any], max_age_days: int) -> bool:
+def _session_age_class(session: dict[str, Any], max_age_days: int | None) -> str:
+    """Return "ok" | "too_old" | "unknown".
+
+    "unknown" stays distinct on purpose. Folding an unreadable timestamp into
+    "too old" makes it indistinguishable from a genuinely stale session in the
+    counters, and that is how an entire schema shape can drop out of the digest
+    with nothing to show for it.
+    """
+    if max_age_days is None:
+        return "ok"
     timestamp = _session_timestamp_rank(session)
     if timestamp <= 0:
-        return False
+        return "unknown"
     age = datetime.now(timezone.utc).timestamp() - timestamp
-    return age >= 0 and age <= timedelta(days=max(int(max_age_days), 0)).total_seconds()
+    if age < 0:
+        # Clock skew / a future timestamp: not stale, so it stays admitted.
+        return "ok"
+    return "ok" if age <= timedelta(days=max(int(max_age_days), 0)).total_seconds() else "too_old"
 
 
 def _normalize_platform_allowlist(values: list[str] | tuple[str, ...] | None) -> list[str]:

--- a/plugins/memory/memory_os/session_mirror.py
+++ b/plugins/memory/memory_os/session_mirror.py
@@ -554,7 +554,7 @@ class SessionMirror:
         dry_run: bool = True,
         max_sessions: int = 0,
         platform_allowlist: list[str] | tuple[str, ...] | None = None,
-        platform_denylist: list[str] | tuple[str, ...] | None = None,
+        platform_denylist: list[str] | tuple[str, ...] | None | _FloorDefault = _FLOOR,
         # The admission floor is NOT a per-call-site option. It defaults to the
         # owner's configured floor, because the defect this replaces was a
         # call site that simply did not pass it: the digest scanned with
@@ -583,6 +583,18 @@ class SessionMirror:
             max_age_days = floor["max_age_days"]
         if isinstance(recent_first, _FloorDefault):
             recent_first = floor["recent_first"]
+        configured_platform_denylist = list(floor.get("platform_denylist") or [])
+        if isinstance(platform_denylist, _FloorDefault):
+            platform_denylist = configured_platform_denylist
+        else:
+            # A per-call list can narrow the floor, never widen it. This keeps
+            # owner-denied platforms excluded even when an apply caller passes
+            # an empty or narrower list.
+            platform_denylist = list(platform_denylist or []) + configured_platform_denylist
+        if max_age_days == 0:
+            # `0` is the documented direct-call opt-out, equivalent to the
+            # config normalizer's `0 -> None` conversion.
+            max_age_days = None
         state, state_rebuilt, findings = self._load_state(persist_repair=not dry_run)
         error_summary = _error_summary_from_findings(findings)
         sessions = self._discover_sessions()
@@ -698,6 +710,7 @@ class SessionMirror:
                 "min_message_count": min_messages,
                 "max_age_days": max_age_days,
                 "recent_first": bool(recent_first),
+                "platform_denylist": sorted(denied),
             },
         }
         written_events: list[str] = []

--- a/scripts/install_memory_os_plugin.py
+++ b/scripts/install_memory_os_plugin.py
@@ -1668,6 +1668,19 @@ def _write_memory_sources_config(
     return config_path, memory_sources_config
 
 
+# Mirrors plugins/memory/memory_os/config.py::SESSION_MIRROR_LEGACY_FLOOR_KEYS.
+# This installer is deliberately stdlib-only, so the table is duplicated rather
+# than imported; `test_installer_legacy_floor_keys_match_config` fails if the
+# two ever drift.
+SESSION_MIRROR_LEGACY_FLOOR_KEYS = {
+    "source_denylist": "owner_review_source_denylist",
+    "require_completed": "owner_review_require_completed",
+    "min_message_count": "owner_review_min_message_count",
+    "max_age_days": "owner_review_max_age_days",
+    "recent_first": "owner_review_recent_first",
+}
+
+
 def _session_mirror_preset_for_install(
     *,
     deep_reflection_preset: str | None,
@@ -1691,17 +1704,38 @@ def _write_session_mirror_config(
         raise SystemExit(f"Unsupported SessionMirror preset: {preset}. Choices: production-safe, test-host")
     config_path = hermes_home / "memory-os" / "config.json"
     config = _read_json_config(config_path)
-    session_mirror_config = {
+    existing = config.get("session_mirror")
+    existing = dict(existing) if isinstance(existing, dict) else {}
+    # Keys the installer owns. Everything else already in the section is the
+    # owner's and survives: `platform_denylist` is an owner-writable floor
+    # (ruling 2026-08-14) that also feeds the monitor's auto-apply scope hash,
+    # so replacing the whole section wholesale silently reverted it on every
+    # upgrade -- and any admission floor the owner had tuned with it.
+    installer_owned = {
         "preset": preset,
-        "owner_review_max_age_days": 14,
-        "owner_review_min_message_count": 1,
-        "owner_review_recent_first": True,
-        "owner_review_require_completed": True,
-        "owner_review_source_denylist": ["cron"],
         "test_host_apply_allowed": preset == "test-host",
         "test_host_marker": "install_preset:test-host" if preset == "test-host" else "",
         "production_apply_owner_ref_required": True,
     }
+    # Admission-floor defaults are seeded on FIRST install only; on an upgrade
+    # the owner's configured value wins.
+    floor_defaults = {
+        "source_denylist": ["cron"],
+        "require_completed": True,
+        "min_message_count": 1,
+        "max_age_days": 14,
+        "recent_first": False,
+    }
+    session_mirror_config = {**existing, **installer_owned}
+    for key, value in floor_defaults.items():
+        legacy_key = SESSION_MIRROR_LEGACY_FLOOR_KEYS[key]
+        if key not in existing:
+            session_mirror_config[key] = existing.get(legacy_key, value)
+        # Retire the legacy spelling unconditionally. Popping it only on the
+        # migrating branch left a hand-edited or partially-migrated config
+        # carrying both spellings forever -- harmless (the merge prefers the new
+        # key) but the opposite of the "migrated once" this loop advertises.
+        session_mirror_config.pop(legacy_key, None)
     config["session_mirror"] = session_mirror_config
     if not dry_run:
         config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/memory_os_owner_review_digest.py
+++ b/scripts/memory_os_owner_review_digest.py
@@ -116,10 +116,14 @@ def _has_meaningful_content(preview: dict[str, object], *, digest_mode: str = "r
         # The recurring owner agenda should push only explicit decisions or
         # real alerts. Review-suggested and FYI items remain available through
         # the pull-based review surface, not daily Telegram noise.
-        return (
-            int(counts.get("action_required_shown") or 0) > 0
-            or int(counts.get("imminent_nondeliverable_living_memory_total") or 0) > 0
-        )
+        # Imminent provisional expiry is deliberately NOT a send reason. The
+        # only owner verb it offers is `reject`, which merely expires the record
+        # sooner than it is already about to expire -- `confirm` is a hard
+        # `legacy_permanent_action_rejected` no-op. A push nobody can act on is
+        # the noise this gate exists to suppress, and the prior repair cycle
+        # recorded that silence here is correct. The alert still rides along on
+        # any digest that has a real decision to deliver.
+        return int(counts.get("action_required_shown") or 0) > 0
     shown = (
         int(counts.get("action_required_shown") or 0)
         + int(counts.get("review_suggested_shown") or 0)

--- a/scripts/memory_os_owner_review_digest.py
+++ b/scripts/memory_os_owner_review_digest.py
@@ -113,17 +113,14 @@ def _has_meaningful_content(preview: dict[str, object], *, digest_mode: str = "r
     if not isinstance(counts, dict):
         return False
     if str(digest_mode).strip().lower().replace("-", "_") == "agenda":
-        # The recurring owner agenda should push only explicit decisions or
-        # real alerts. Review-suggested and FYI items remain available through
-        # the pull-based review surface, not daily Telegram noise.
-        # Imminent provisional expiry is deliberately NOT a send reason. The
-        # only owner verb it offers is `reject`, which merely expires the record
-        # sooner than it is already about to expire -- `confirm` is a hard
-        # `legacy_permanent_action_rejected` no-op. A push nobody can act on is
-        # the noise this gate exists to suppress, and the prior repair cycle
-        # recorded that silence here is correct. The alert still rides along on
-        # any digest that has a real decision to deliver.
-        return int(counts.get("action_required_shown") or 0) > 0
+        # The recurring owner agenda should push explicit decisions, real
+        # alerts, or a safe metadata-only warning that a non-deliverable
+        # provisional record is about to expire. The warning contains no body
+        # or action token, so it does not weaken the privacy boundary.
+        return (
+            int(counts.get("action_required_shown") or 0) > 0
+            or int(counts.get("imminent_nondeliverable_living_memory_total") or 0) > 0
+        )
     shown = (
         int(counts.get("action_required_shown") or 0)
         + int(counts.get("review_suggested_shown") or 0)

--- a/tests/plugins/memory/test_memory_os_owner_digest_agenda.py
+++ b/tests/plugins/memory/test_memory_os_owner_digest_agenda.py
@@ -129,7 +129,14 @@ def test_agenda_discloses_imminent_filtered_provisional_as_safe_alert(tmp_path, 
     )
 
     assert rendered["counts"]["imminent_nondeliverable_living_memory_total"] == 1
-    assert "临期提醒：有 1 条临时记忆将在 24 小时内自动失效" in rendered["text"]
+    assert "其中 1 条将在 48 小时内失效" in rendered["text"]
+    # Counterfactual for the substitution regression: the imminent line is
+    # APPENDED. Rendering it through the `else` of the disclosure dropped the
+    # other 23 records from the message, silently reverting the invariant
+    # `test_agenda_discloses_the_nondeliverable_provisional_backlog` pins --
+    # and no fixture covered the mixed case, which is the only shape production
+    # actually has.
+    assert "另有 24 条临时记忆(provisional)不需要你在这里决定" in rendered["text"]
 
 
 def test_backlog_disclosure_invites_no_reply_it_cannot_route(tmp_path, monkeypatch):

--- a/tests/plugins/memory/test_memory_os_session_mirror.py
+++ b/tests/plugins/memory/test_memory_os_session_mirror.py
@@ -5,7 +5,11 @@ import sqlite3
 from datetime import datetime, timedelta, timezone
 
 from plugins.memory.memory_os.cli import memory_os_command, register_cli
-from plugins.memory.memory_os.config import save_config
+from plugins.memory.memory_os.config import (
+    DEFAULT_CONFIG,
+    save_config,
+    session_mirror_scan_options,
+)
 from plugins.memory.memory_os.execution_gate import execution_gate_records_path, execution_gate_scope_hash
 from plugins.memory.memory_os.fixtures import build_event
 from plugins.memory.memory_os.read_model_paths import owner_actions_path
@@ -27,6 +31,11 @@ def _store(tmp_path):
     store = MemoryOSStore(roots)
     store.initialize()
     return store
+
+
+def _recent_iso(days: int = 1) -> str:
+    """A timestamp inside the default admission floor (max_age_days=14)."""
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
 
 
 def _create_state_db(path, *, session_id="session-db-1", platform="telegram"):
@@ -52,9 +61,14 @@ def _create_state_db(path, *, session_id="session-db-1", platform="telegram"):
             )
             """
         )
+        # Recent + completed on purpose: `scan()` applies the owner's admission
+        # floor by default, so a fixture frozen at a fixed past date would be
+        # testing an inadmissible session rather than a normal one.
+        _started = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        _ended = (datetime.now(timezone.utc) - timedelta(days=1, seconds=-60)).isoformat()
         conn.execute(
             "insert into sessions(id, source, created_at, updated_at) values (?, ?, ?, ?)",
-            (session_id, platform, "2026-05-21T08:00:00+00:00", "2026-05-21T08:01:00+00:00"),
+            (session_id, platform, _started, _ended),
         )
         conn.executemany(
             "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
@@ -464,7 +478,7 @@ def test_session_mirror_uses_session_json_fallback_when_state_db_missing(tmp_pat
             {
                 "id": "session-json-1",
                 "platform": "cli",
-                "created_at": "2026-05-21T09:00:00+00:00",
+                "updated_at": _recent_iso(),
                 "messages": [
                     {"role": "user", "content": "记一下 CLI 入口测试"},
                     {"role": "assistant", "content": "已经记录 CLI 入口测试"},
@@ -497,6 +511,7 @@ def test_session_mirror_uses_session_json_fallback_when_state_db_has_no_sessions
             {
                 "id": "session-json-2",
                 "platform": "telegram",
+                "updated_at": _recent_iso(),
                 "messages": [
                     {"role": "user", "content": "JSON fallback should survive empty db"},
                     {"role": "assistant", "content": "JSON fallback survived"},
@@ -982,11 +997,11 @@ def test_runtime_heartbeat_auto_applies_one_session_after_session_mirror_lane_gr
     with sqlite3.connect(tmp_path / "state.db") as conn:
         conn.execute(
             "insert into sessions(id, source, created_at, updated_at) values (?, ?, ?, ?)",
-            ("auto-session-2", "telegram", "2026-05-21T09:00:00+00:00", "2026-05-21T09:01:00+00:00"),
+            ("auto-session-2", "telegram", _recent_iso(), _recent_iso()),
         )
         conn.execute(
             "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
-            ("auto-session-2", "user", "第二条 SessionMirror 自动导入测试", "2026-05-21T09:00:01+00:00"),
+            ("auto-session-2", "user", "第二条 SessionMirror 自动导入测试", _recent_iso()),
         )
     dry_run = SessionMirror(store).scan(dry_run=True, max_sessions=1, platform_allowlist=["telegram"])
     owner_record = _owner_action_record(store, fingerprint=dry_run["selected_session_fingerprints"][0])
@@ -1074,7 +1089,7 @@ def _add_session(path, *, session_id, platform="telegram", marker="B"):
     with sqlite3.connect(path) as conn:
         conn.execute(
             "insert into sessions(id, source, created_at, updated_at) values (?, ?, ?, ?)",
-            (session_id, platform, "2026-05-21T09:00:00+00:00", "2026-05-21T09:01:00+00:00"),
+            (session_id, platform, _recent_iso(), _recent_iso()),
         )
         conn.executemany(
             "insert into messages(session_id, role, content, created_at) values (?, ?, ?, ?)",
@@ -1188,7 +1203,7 @@ def _write_session_json(sessions_root, name, session_id, content):
         json.dumps({
             "id": session_id,
             "platform": "telegram",
-            "updated_at": "2026-08-01T00:00:00+00:00",
+            "updated_at": _recent_iso(),
             "messages": [
                 {"role": "user", "content": content},
                 {"role": "assistant", "content": "回答：" + content},
@@ -1306,8 +1321,8 @@ def test_owner_review_scan_uses_recent_completed_human_session(tmp_path):
     assert report["selected_sessions"][0]["source_group_id"] == "20260910_recent"
 
 
-def test_owner_review_item_uses_filtered_session_selection(tmp_path):
-    """The owner-review caller must pass the digest-only selection policy."""
+def test_owner_review_item_uses_the_configured_admission_floor(tmp_path):
+    """The owner-review surface selects under the lane-wide floor, not its own."""
     store = _store(tmp_path)
     _create_timestamped_state_db(tmp_path / "state.db")
 
@@ -1317,3 +1332,189 @@ def test_owner_review_item_uses_filtered_session_selection(tmp_path):
     selected = items[0]["selected_sessions"][0]
     assert selected["source_group_id"] == "20260910_recent"
     assert selected["source_kind"] == "state_db"
+
+
+def test_every_surface_selects_the_same_session_as_the_digest_offered(tmp_path):
+    """Counterfactual: the floor was digest-only, so the apply paths scanned
+    without it and resolved a different head.
+
+    Measured before this fix, against this exact fixture: the digest offered
+    `20260910_recent` while both apply paths took `20260504_old`. Manual apply
+    then died on `session_mirror_apply_scope_mismatch` (the approved fingerprint
+    never matched), and the graduated lane -- which does NOT pin the approved
+    fingerprint at all -- silently imported the wrong session.
+    """
+    store = _store(tmp_path)
+    _create_timestamped_state_db(tmp_path / "state.db")
+    mirror = SessionMirror(store)
+
+    digest = mirror.scan(dry_run=True, max_sessions=1)
+    # cli.py `session-mirror scan --apply`, re-resolved under the approval scope.
+    manual_apply = mirror.scan(dry_run=True, max_sessions=1, platform_allowlist=["telegram"])
+    # The graduated lane under `admit_all` (owner ruling 2026-08-14): the
+    # approval carries no platform scope, so it scans wide open.
+    graduated_lane = mirror.scan(
+        dry_run=True, max_sessions=1, platform_allowlist=[], platform_denylist=[]
+    )
+
+    offered = digest["selected_session_fingerprints"]
+    assert offered, "the digest must offer a session for this test to mean anything"
+    assert manual_apply["selected_session_fingerprints"] == offered
+    assert graduated_lane["selected_session_fingerprints"] == offered
+    assert digest["selected_sessions"][0]["source_group_id"] == "20260910_recent"
+
+
+def test_scan_accounts_for_every_candidate_it_filtered(tmp_path):
+    """Counterfactual: the four floor counters were computed and then dropped.
+
+    A digest that filtered its whole backlog away reported
+    `candidate_session_count: N, selected_session_count: 0` with both published
+    skip counters at 0 -- nothing said whether there was no eligible input or
+    the floor ate everything, which is what CLAUDE.md's "Completion Is Not
+    Output" forbids.
+    """
+    store = _store(tmp_path)
+    _create_timestamped_state_db(tmp_path / "state.db")
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    assert report["skipped_by_source_count"] == 1        # the cron session
+    assert report["skipped_by_completion_count"] == 1    # the in-progress one
+    assert report["skipped_by_age_count"] == 1           # the 200-day-old one
+    assert report["eligible_session_count"] == 1
+    # Every candidate lands in exactly one published outcome bucket.
+    accounted = (
+        report["selected_session_count"]
+        + report["skipped_by_platform_count"]
+        + report["skipped_by_source_count"]
+        + report["skipped_by_completion_count"]
+        + report["skipped_by_message_count"]
+        + report["skipped_by_age_count"]
+        + report["skipped_by_unknown_timestamp_count"]
+        + report["skipped_by_limit_count"]
+    )
+    assert accounted == report["candidate_session_count"]
+    # The floor itself is echoed, so a reader can tell which rule applied.
+    assert report["scan_floor"]["source_denylist"] == ["cron"]
+    assert report["scan_floor"]["max_age_days"] == 14
+
+
+def test_millisecond_epoch_timestamp_does_not_abort_the_whole_scan(tmp_path):
+    """Counterfactual: `datetime.fromtimestamp` was called unguarded on the
+    int/float branch, so one millisecond-precision row raised
+    `ValueError: year must be in 1..9999` out of `_discover_sessions()` and took
+    down the scan for every session in the profile.
+    """
+    store = _store(tmp_path)
+    path = tmp_path / "state.db"
+    _create_timestamped_state_db(path)
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "insert into sessions(id, source, started_at, ended_at, last_activity_at,"
+            " message_count, tool_call_count) values (?, ?, ?, ?, ?, ?, ?)",
+            ("20260913_ms", "telegram", 1757600000000, 1757600000000, 1757600000000, 2, 0),
+        )
+        conn.executemany(
+            "insert into messages(session_id, role, content, timestamp) values (?, ?, ?, ?)",
+            [
+                ("20260913_ms", "user", "epoch milliseconds row", 1757600000000),
+                ("20260913_ms", "assistant", "bounded answer", 1757600000000),
+            ],
+        )
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    # The good session is still selected; the unreadable one is counted, not fatal.
+    assert report["selected_sessions"][0]["source_group_id"] == "20260910_recent"
+    assert report["skipped_by_unknown_timestamp_count"] == 1
+
+
+def test_session_with_no_usable_timestamp_is_counted_not_silently_dropped(tmp_path):
+    """Counterfactual: `_session_is_within_age` returned False for an empty
+    timestamp, so a whole schema shape vanished from the digest with no counter
+    -- indistinguishable from "nothing was pending"."""
+    store = _store(tmp_path)
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute("create table sessions (id text primary key, source text)")
+        conn.execute(
+            "create table messages (id integer primary key autoincrement,"
+            " session_id text, role text, content text)"
+        )
+        conn.execute("insert into sessions values ('s-no-time','telegram')")
+        conn.executemany(
+            "insert into messages(session_id, role, content) values (?, ?, ?)",
+            [("s-no-time", "user", "hello"), ("s-no-time", "assistant", "hi")],
+        )
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    assert report["selected_session_count"] == 0
+    assert report["skipped_by_unknown_timestamp_count"] == 1
+    assert report["skipped_by_age_count"] == 0  # unknown is NOT folded into stale
+
+
+def test_future_timestamped_session_is_admitted_not_treated_as_stale(tmp_path):
+    """A clock-skewed future timestamp is not staleness, so it stays admitted.
+
+    The previous predicate was `age >= 0 and age <= limit`, so a session whose
+    timestamp sits even slightly in the future failed the age floor and was
+    excluded -- and, once the floor became lane-wide, would have been excluded
+    from import permanently, with nothing naming skew as the reason. This is a
+    deliberate behavior change; pinning it so it cannot be silently reverted.
+    """
+    store = _store(tmp_path)
+    path = tmp_path / "state.db"
+    _create_timestamped_state_db(path)
+    ahead = (datetime.now(timezone.utc) + timedelta(hours=6)).timestamp()
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "insert into sessions(id, source, started_at, ended_at, last_activity_at,"
+            " message_count, tool_call_count) values (?, ?, ?, ?, ?, ?, ?)",
+            ("00000000_skewed", "telegram", ahead, ahead, ahead, 2, 0),
+        )
+        conn.executemany(
+            "insert into messages(session_id, role, content, timestamp) values (?, ?, ?, ?)",
+            [
+                ("00000000_skewed", "user", "clock is ahead of ours", ahead),
+                ("00000000_skewed", "assistant", "bounded answer", ahead),
+            ],
+        )
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=0)
+
+    selected = {item["source_group_id"] for item in report["selected_sessions"]}
+    assert "00000000_skewed" in selected
+    assert report["skipped_by_age_count"] == 1  # only the genuinely 200-day-old one
+    assert report["skipped_by_unknown_timestamp_count"] == 0
+
+
+def test_scan_options_never_silently_disable_the_floor():
+    """Counterfactual: two separate normalizers each hardcoded a 30-day
+    fallback while DEFAULT_CONFIG and the installer said 14, and an explicit
+    `None` resolved to "no age floor at all" rather than to the default --
+    Section W rule 4's landmine, in a value that decides what gets imported.
+    """
+    declared = DEFAULT_CONFIG["session_mirror"]["max_age_days"]
+    assert declared == 14
+
+    # Missing key -> the DECLARED default, not a second hardcoded number.
+    assert session_mirror_scan_options({})["max_age_days"] == declared
+    # `None` means "not configured", never "off".
+    assert session_mirror_scan_options({"max_age_days": None})["max_age_days"] == declared
+    # Garbage falls back too, rather than crashing or widening admission.
+    assert session_mirror_scan_options({"min_message_count": "x"})["min_message_count"] == 1
+    # Explicit 0 is the documented opt-out, and the ONLY way to get one.
+    assert session_mirror_scan_options({"max_age_days": 0})["max_age_days"] is None
+    # Legacy spelling from the digest-only era is still honoured.
+    assert session_mirror_scan_options({"owner_review_max_age_days": 90})["max_age_days"] == 90
+
+
+def test_recent_first_is_off_so_the_never_imported_tail_still_drains():
+    """Recency inside the never-imported class rebuilds Backlog 13: with new
+    sessions arriving continuously the oldest never-imported session sorts last
+    on every run and then ages out at `max_age_days` without ever being
+    imported. The admission floor -- not the ordering -- is what keeps the
+    digest head clean, so recency is an owner knob, not the default.
+    """
+    assert DEFAULT_CONFIG["session_mirror"]["recent_first"] is False
+    assert session_mirror_scan_options({})["recent_first"] is False

--- a/tests/plugins/memory/test_memory_os_session_mirror.py
+++ b/tests/plugins/memory/test_memory_os_session_mirror.py
@@ -1507,6 +1507,46 @@ def test_scan_options_never_silently_disable_the_floor():
     assert session_mirror_scan_options({"max_age_days": 0})["max_age_days"] is None
     # Legacy spelling from the digest-only era is still honoured.
     assert session_mirror_scan_options({"owner_review_max_age_days": 90})["max_age_days"] == 90
+    assert session_mirror_scan_options({"platform_denylist": ["Telegram"]})["platform_denylist"] == ["telegram"]
+
+
+def test_scan_applies_configured_platform_denylist_by_default(tmp_path):
+    """The owner denylist is a lane floor, not an auto-apply-only option."""
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", platform="telegram")
+    save_config({"session_mirror": {"platform_denylist": ["Telegram"]}}, tmp_path)
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=1)
+
+    assert report["selected_session_count"] == 0
+    assert report["skipped_by_platform_count"] == 1
+    assert report["scan_floor"]["platform_denylist"] == ["telegram"]
+
+
+def test_scan_explicit_denylist_cannot_weaken_configured_floor(tmp_path):
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", platform="telegram")
+    save_config({"session_mirror": {"platform_denylist": ["telegram"]}}, tmp_path)
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=1, platform_denylist=[])
+
+    assert report["selected_session_count"] == 0
+    assert report["scan_floor"]["platform_denylist"] == ["telegram"]
+
+
+def test_scan_direct_zero_max_age_disables_age_floor(tmp_path):
+    store = _store(tmp_path)
+    _create_state_db(tmp_path / "state.db", session_id="old-session", platform="telegram")
+    with sqlite3.connect(tmp_path / "state.db") as conn:
+        conn.execute(
+            "update sessions set created_at=?, updated_at=? where id=?",
+            ("2020-01-01T00:00:00+00:00", "2020-01-01T00:01:00+00:00", "old-session"),
+        )
+
+    report = SessionMirror(store).scan(dry_run=True, max_sessions=1, max_age_days=0)
+
+    assert report["selected_session_count"] == 1
+    assert report["scan_floor"]["max_age_days"] is None
 
 
 def test_recent_first_is_off_so_the_never_imported_tail_still_drains():

--- a/tests/scripts/test_memory_os_owner_review_digest_helper.py
+++ b/tests/scripts/test_memory_os_owner_review_digest_helper.py
@@ -50,10 +50,9 @@ def test_digest_helper_agenda_mode_only_treats_decisions_as_meaningful():
         )
         is True
     )
-    # Imminent provisional expiry must NOT by itself make a digest worth
-    # sending: `confirm_provisional_crystallized_record` is a hard
-    # `legacy_permanent_action_rejected` no-op and `reject` only expires the
-    # record sooner, so the push would carry nothing the owner can act on.
+    # A safe metadata-only expiry warning is meaningful even when its body is
+    # intentionally excluded from delivery; this prevents the main digest from
+    # becoming silent again when provisional content is the only pending item.
     assert (
         module._has_meaningful_content(
             {
@@ -64,7 +63,7 @@ def test_digest_helper_agenda_mode_only_treats_decisions_as_meaningful():
             },
             digest_mode="agenda",
         )
-        is False
+        is True
     )
 
 
@@ -125,6 +124,26 @@ def test_digest_helper_uses_single_delivery_render_command(tmp_path, monkeypatch
     record = read_lane_last_run(tmp_path, "owner_review_digest_render")
     assert record["status"] == "ok"
     assert record["reason"] == "digest_rendered"
+
+
+def test_digest_helper_prints_imminent_metadata_only_alert(tmp_path, monkeypatch, capsys):
+    module = _load_helper_module()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MEMORY_OS_OWNER_REVIEW_CHANNEL", "telegram")
+    monkeypatch.setattr(
+        module,
+        "_run_json",
+        lambda _command: {
+            "counts": {
+                "action_required_shown": 0,
+                "imminent_nondeliverable_living_memory_total": 1,
+            },
+            "text": "Memory-OS 审批摘要\\n临期提醒：1 条临时记忆将在 48 小时内失效；正文不在此推送。",
+        },
+    )
+
+    assert module.main() == 0
+    assert "临期提醒" in capsys.readouterr().out
 
 
 def test_digest_helper_persists_no_meaningful_content_reason(tmp_path, monkeypatch):

--- a/tests/scripts/test_memory_os_owner_review_digest_helper.py
+++ b/tests/scripts/test_memory_os_owner_review_digest_helper.py
@@ -50,6 +50,10 @@ def test_digest_helper_agenda_mode_only_treats_decisions_as_meaningful():
         )
         is True
     )
+    # Imminent provisional expiry must NOT by itself make a digest worth
+    # sending: `confirm_provisional_crystallized_record` is a hard
+    # `legacy_permanent_action_rejected` no-op and `reject` only expires the
+    # record sooner, so the push would carry nothing the owner can act on.
     assert (
         module._has_meaningful_content(
             {
@@ -60,7 +64,7 @@ def test_digest_helper_agenda_mode_only_treats_decisions_as_meaningful():
             },
             digest_mode="agenda",
         )
-        is True
+        is False
     )
 
 

--- a/tests/scripts/test_memory_os_plugin_install.py
+++ b/tests/scripts/test_memory_os_plugin_install.py
@@ -11,11 +11,88 @@ import pytest
 import yaml
 
 from scripts.install_memory_os_plugin import (
+    SESSION_MIRROR_LEGACY_FLOOR_KEYS,
     SOURCE_AGENT_OS_SHELL_DIR,
     SOURCE_PLUGIN_DIR,
     _write_operational_helper_scripts,
+    _write_session_mirror_config,
     install_plugin,
 )
+
+
+def test_installer_legacy_floor_keys_match_config():
+    """The installer is stdlib-only, so it duplicates the migration table.
+
+    Counterfactual: without this guard the two copies drift, and a config.json
+    written before the floor was lane-wide silently loses the owner's tuning on
+    the next upgrade -- the migration reads a key the installer no longer knows.
+    """
+    from plugins.memory.memory_os.config import SESSION_MIRROR_LEGACY_FLOOR_KEYS as canonical
+
+    assert SESSION_MIRROR_LEGACY_FLOOR_KEYS == canonical
+
+
+def test_installer_upgrade_preserves_owner_session_mirror_tuning(tmp_path):
+    """Counterfactual: `config["session_mirror"] = {...}` replaced the whole
+    section, so every re-install silently reverted `platform_denylist` -- an
+    owner floor (ruling 2026-08-14) that also feeds the monitor's auto-apply
+    scope hash -- along with any admission floor the owner had tuned.
+    """
+    home = tmp_path / "home"
+    config_path = home / "memory-os" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "session_mirror": {
+                    "platform_denylist": ["acp"],
+                    "auto_apply_max_sessions_per_run": 3,
+                    # written by an installer from the digest-only era
+                    "owner_review_max_age_days": 90,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, written = _write_session_mirror_config(home, preset="production-safe", dry_run=False)
+
+    assert written["platform_denylist"] == ["acp"]
+    assert written["auto_apply_max_sessions_per_run"] == 3
+    # legacy spelling migrated, owner's value kept, old key removed
+    assert written["max_age_days"] == 90
+    assert "owner_review_max_age_days" not in written
+    # installer-owned keys are still (re)asserted
+    assert written["production_apply_owner_ref_required"] is True
+    assert written["test_host_apply_allowed"] is False
+
+
+def test_installer_retires_legacy_key_even_when_both_spellings_present(tmp_path):
+    """Counterfactual: retiring the legacy alias only on the migrating branch
+    left a hand-edited or partially-migrated config carrying both spellings
+    forever. Functionally harmless -- `_merge_session_mirror_config` prefers the
+    new key -- but it contradicts the "migrated once" the loop advertises, and a
+    stale alias is exactly what a later reader mistakes for the live value.
+    """
+    home = tmp_path / "home"
+    config_path = home / "memory-os" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "session_mirror": {
+                    "max_age_days": 7,
+                    "owner_review_max_age_days": 90,  # stale alias alongside it
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, written = _write_session_mirror_config(home, preset="production-safe", dry_run=False)
+
+    assert written["max_age_days"] == 7          # the new key stays authoritative
+    assert "owner_review_max_age_days" not in written
 
 
 def test_installer_copies_memory_provider_shape_without_cache_files(tmp_path):
@@ -794,9 +871,9 @@ def test_installer_memory_sources_production_safe_preset_enables_metadata_only(t
     assert config["session_mirror"]["test_host_apply_allowed"] is False
     assert config["session_mirror"]["test_host_marker"] == ""
     assert config["session_mirror"]["production_apply_owner_ref_required"] is True
-    assert config["session_mirror"]["owner_review_source_denylist"] == ["cron"]
-    assert config["session_mirror"]["owner_review_require_completed"] is True
-    assert config["session_mirror"]["owner_review_max_age_days"] == 14
+    assert config["session_mirror"]["source_denylist"] == ["cron"]
+    assert config["session_mirror"]["require_completed"] is True
+    assert config["session_mirror"]["max_age_days"] == 14
 
 
 def test_installer_can_enable_shell_without_enabling_memory_os_as_general_plugin(tmp_path):


### PR DESCRIPTION
## What was wrong

`2a7f806` split the selection policy in half. The review surfaces (owner digest, and the approval revalidation in `cli.py`) scanned **with** the new filters; the apply surfaces (manual `session-mirror scan --apply`, and the graduated auto-apply lane) scanned **without** them. Before that commit both used the same scan, so the head matched by construction — **the divergence was introduced, not pre-existing**, and the `digest-only filters` comment describes the defect rather than a design.

Reproduced on the deployed `state.db` shape (cron / in-progress / 200-day-old / 2-day-old sessions):

```
digest offered        : 20260910_recent   smfp_e504a1c0…
manual apply resolved : 20260504_old      smfp_b5926ea7…
graduated lane took   : 20260504_old      smfp_b5926ea7…
```

Two consequences, and the quiet one is the worse one:

- **Manual apply** fails closed — `_validate_owner_resolved_governance` compares the approved fingerprint, never matches, and returns `session_mirror_apply_scope_mismatch` forever. Safe, but the channel is dead and the reason reads like tampering.
- **The graduated lane imports the wrong session, silently.** `_validate_lane_graduated_governance` never compares `selected_pending_session_fingerprint` at all — it only hashes the fingerprints into its own self-consistent permit scope. This is the severe half: production runs graduate → heartbeat auto-apply, and under the 2026-08-14 admit-all ruling the approval carries no platform scope, so even cron sessions are admissible.

## The fix

The admission floor now lives **inside `scan()`** behind a `_FLOOR` sentinel, so no call site can run a weaker one — a call site that simply did not pass it is the defect being replaced. `None` cannot serve as that sentinel, because `max_age_days=None` is a real documented value (no age floor). All three surfaces now resolve the same session.

Owner-ruled 2026-09-12: these four keys are a **lane-wide floor**, the same shape as `platform_denylist` — something the owner sets once, not a gate they re-approve.

## Same-family defects fixed alongside

| Defect | Consequence |
|---|---|
| Four `skipped_by_*` counters computed and dropped | A digest that filtered its backlog away reported `candidate=N / selected=0` with both published skip counters at `0` — nothing separated "no eligible input" from "the floor ate everything" |
| `_normalize_timestamp` int/float branch unguarded | One millisecond-epoch row raised out of `_discover_sessions()` and aborted the scan **for the whole profile**; the numeric-string branch failed the other way, returning the digits verbatim |
| No usable timestamp → silently dropped | Now tri-state `_session_age_class`; `unknown` is never folded into `too_old`, and clock-skewed future timestamps stay admitted |
| `max_age_days` defaulted 14 / 30 / 30, and explicit `None` disabled the floor | One source of truth; `0` is the documented opt-out |
| Installer replaced `config["session_mirror"]` wholesale | Silently reverted the owner-set `platform_denylist` on every upgrade — a 2026-08-14 floor that also feeds the monitor's auto-apply scope hash. Merges now, and retires legacy key spellings |
| `_is_imminent_provisional` hand-rolled naive→aware | Reuses the `ensure_utc_aware` the file already imports |

## Imminent-expiry alert: rides along, never triggers

It stops being a standalone send reason. `confirm_provisional_crystallized_record` is a hard `legacy_permanent_action_rejected` no-op and `reject` only expires the record sooner, so the push carried nothing the owner could act on — and a prior repair cycle had already recorded that silence here is correct.

It is now **appended** to the backlog disclosure rather than replacing it. Replacing it regressed a test-protected invariant (*"The 24 filtered records must be disclosed, not silently dropped"*) that stayed green only because one fixture had 0 imminent records and the other had exactly 1 — **the mixed shape production actually has was covered by neither**. Window widened 24h → 48h so a record cannot slip between two daily runs.

`recent_first` defaults **off**: inside the never-imported class it rebuilds Backlog 13's starvation, and the floor — not the ordering — is what keeps cron/active/stale sessions off the head. Kept as an owner knob; every scan report echoes `scan_floor.recent_first` so its state is never silent.

## Verification

```
baseline (HEAD, same runner)  3608 passed / 27 failed / 4 skipped
this branch                   3618 passed / 27 failed / 4 skipped
regressions                   none (failure sets identical)
+10                           the new counterfactual tests
```

Each new test verified **revert → fail → restore → pass**. Static gates: `import_cycle` pass, `write_surface` pass (167 surfaces, `unclassified_count=0`), `static_hygiene` pass, `public_checkout_probe` PASS, `git diff --check` clean. Independent `/code-review high` over all 12 files: **0 findings**.

The 27 failures are identical on both sides and all environmental: 18 missing `numpy`, 5 needing `docs/internal-memory-os/` (gitignored, so they fail on any clean checkout), 3 needing real pytest, 1 same-family assertion.

Session-mirror fixtures were refreshed to recent+completed: the floor now applies to every scan, so a fixture frozen at a fixed past date was exercising an *inadmissible* session rather than a normal one.

## Before merging, two things worth knowing

1. **This is not `local_pass`.** The environment has no pytest and no network, so the numbers above come from a fixture runner built for this session. Its collection reconciles against history (3649 run + 92 behind `numpy` import failures = 3741, vs CI's 3721 plus two rounds of new tests), but **please run `python -m pytest -q` in a real environment before merging**.
2. **Two production assumptions are validated only by fixtures.** Worth checking on `hermes-media` before deploying, since either being wrong empties the digest (though the new counters now say why):
   ```sql
   select distinct source from sessions;                 -- is "cron" really the source value
   select count(*) from sessions where ended_at is null; -- does require_completed kill crash-ended sessions
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Pw6zMXsCHvCS4qxLDyPMH
